### PR TITLE
Force the tests tasks to be executed ignoring the caches

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Tests
-        run: ./gradlew ${{ matrix.test }}
+        run: ./gradlew ${{ matrix.test }} --rerun-tasks
 
   release:
     name: Releases


### PR DESCRIPTION
Check the [issue](https://github.com/doordeck/doordeck-headless-sdk/issues/45) for more details!