### PR TITLE
Removing UUID library

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,11 @@
 [versions]
 agp = "8.2.0"
-kotlin = "2.0.0"
+kotlin = "2.0.20"
 nexus-publish = "2.0.0-rc-1"
 android-minSdk = "24"
 android-compileSdk = "33"
 ktor-client = "3.0.0-beta-2"
 libsodium = "0.9.2"
-uuid-generator = "0.8.4"
 kotlinx-datetime = "0.6.0"
 kotlin-coroutines-test = "1.9.0-RC.2"
 koin = "4.0.0-RC1"
@@ -35,7 +34,6 @@ ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negoti
 libsodium-bindings = { module = "com.ionspin.kotlin:multiplatform-crypto-libsodium-bindings", version.ref = "libsodium" }
 
 # Utils
-uuid-generator = { module = "com.benasher44:uuid", version.ref = "uuid-generator" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 [plugins]

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -72,6 +72,7 @@ kotlin {
                 optIn("kotlin.ExperimentalUnsignedTypes")
                 optIn("kotlinx.coroutines.DelicateCoroutinesApi")
                 optIn("kotlinx.serialization.ExperimentalSerializationApi")
+                optIn("kotlin.uuid.ExperimentalUuidApi")
             }
         }
 
@@ -84,7 +85,6 @@ kotlin {
                 implementation(libs.ktor.client.content.negotiation)
                 implementation(libs.ktor.client.encoding)
                 implementation(libs.libsodium.bindings)
-                implementation(libs.uuid.generator)
                 implementation(libs.kotlinx.datetime)
                 implementation(libs.koin)
             }

--- a/library/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/api/model/LockOperations.kt
+++ b/library/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/api/model/LockOperations.kt
@@ -1,10 +1,10 @@
 package com.doordeck.multiplatform.sdk.api.model
 
-import com.benasher44.uuid.uuid4
 import kotlinx.datetime.Clock
 import kotlin.js.JsExport
 import kotlin.jvm.JvmOverloads
 import kotlin.time.Duration.Companion.minutes
+import kotlin.uuid.Uuid
 
 @JsExport
 object LockOperations {
@@ -73,7 +73,7 @@ object LockOperations {
         val notBefore: Int = Clock.System.now().epochSeconds.toInt(),
         val issuedAt: Int = Clock.System.now().epochSeconds.toInt(),
         val expiresAt: Int = (Clock.System.now() + 1.minutes).epochSeconds.toInt(),
-        val jti: String = uuid4().toString()
+        val jti: String = Uuid.random().toString()
     )
 
     abstract class Operation(

--- a/library/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountClientTest.kt
+++ b/library/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountClientTest.kt
@@ -1,6 +1,5 @@
 package com.doordeck.multiplatform.sdk.api
 
-import com.benasher44.uuid.uuid4
 import com.doordeck.multiplatform.sdk.IntegrationTest
 import com.doordeck.multiplatform.sdk.PlatformType
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_EMAIL
@@ -15,6 +14,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
 
 class AccountClientTest : IntegrationTest() {
 
@@ -42,7 +42,7 @@ class AccountClientTest : IntegrationTest() {
         // Given
         val login = ACCOUNTLESS_CLIENT.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
         CONTEXT_MANAGER.setAuthToken(login.authToken)
-        val updatedUserDisplayName = uuid4().toString()
+        val updatedUserDisplayName = Uuid.random().toString()
 
         // When
         ACCOUNT_CLIENT.updateUserDetailsRequest(updatedUserDisplayName)

--- a/library/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountlessClientTest.kt
+++ b/library/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountlessClientTest.kt
@@ -1,6 +1,5 @@
 package com.doordeck.multiplatform.sdk.api
 
-import com.benasher44.uuid.uuid4
 import com.doordeck.multiplatform.sdk.IntegrationTest
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_ENVIRONMENT
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_EMAIL
@@ -13,6 +12,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFails
 import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
 
 class AccountlessClientTest : IntegrationTest() {
 
@@ -29,7 +29,7 @@ class AccountlessClientTest : IntegrationTest() {
     @Test
     fun shouldRegisterAndDelete() = runTest {
         // Given - shouldRegister
-         val newUserEmail = TEST_MAIN_USER_EMAIL.replace("@", "+${getPlatform()}-${uuid4()}@")
+         val newUserEmail = TEST_MAIN_USER_EMAIL.replace("@", "+${getPlatform()}-${Uuid.random()}@")
 
         // When
         val response = ACCOUNTLESS_CLIENT.registrationRequest(newUserEmail, TEST_MAIN_USER_PASSWORD, null, false)

--- a/library/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/api/FusionClientTest.kt
+++ b/library/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/api/FusionClientTest.kt
@@ -1,6 +1,5 @@
 package com.doordeck.multiplatform.sdk.api
 
-import com.benasher44.uuid.uuid4
 import com.doordeck.multiplatform.sdk.IntegrationTest
 import com.doordeck.multiplatform.sdk.TestConstants.FUSION_INTEGRATIONS
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_SITE_ID
@@ -17,6 +16,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
 
 class FusionClientTest : IntegrationTest() {
 
@@ -38,7 +38,7 @@ class FusionClientTest : IntegrationTest() {
             fusionContextManager.setFusionAuthToken(login.authToken)
 
             // Given - shouldEnableDoor
-            val name = "Test Fusion Door ${uuid4()}"
+            val name = "Test Fusion Door ${Uuid.random()}"
 
             // When
             fusionClient.enableDoorRequest(name, TEST_MAIN_SITE_ID, testController.controller)

--- a/library/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsClientTest.kt
+++ b/library/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsClientTest.kt
@@ -1,6 +1,5 @@
 package com.doordeck.multiplatform.sdk.api
 
-import com.benasher44.uuid.uuid4
 import com.doordeck.multiplatform.sdk.IntegrationTest
 import com.doordeck.multiplatform.sdk.MissingOperationContextException
 import com.doordeck.multiplatform.sdk.PlatformType
@@ -34,6 +33,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
+import kotlin.uuid.Uuid
 
 class LockOperationsClientTest : IntegrationTest() {
 
@@ -61,7 +61,7 @@ class LockOperationsClientTest : IntegrationTest() {
         // Given
         val login = ACCOUNTLESS_CLIENT.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
         CONTEXT_MANAGER.setAuthToken(login.authToken)
-        val updatedLockName = "Demo ${uuid4()} Lock"
+        val updatedLockName = "Demo ${Uuid.random()} Lock"
 
         // When
         LOCK_OPERATIONS_CLIENT.updateLockNameRequest(TEST_MAIN_LOCK_ID, updatedLockName)
@@ -106,7 +106,7 @@ class LockOperationsClientTest : IntegrationTest() {
         // Given
         val login = ACCOUNTLESS_CLIENT.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
         CONTEXT_MANAGER.setAuthToken(login.authToken)
-        val updatedLockDefaultName = "Demo ${uuid4()} Lock"
+        val updatedLockDefaultName = "Demo ${Uuid.random()} Lock"
 
         // When
         LOCK_OPERATIONS_CLIENT.updateLockSettingDefaultNameRequest(TEST_MAIN_LOCK_ID, updatedLockDefaultName)

--- a/library/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/api/PlatformClientTest.kt
+++ b/library/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/api/PlatformClientTest.kt
@@ -1,6 +1,5 @@
 package com.doordeck.multiplatform.sdk.api
 
-import com.benasher44.uuid.uuid4
 import com.doordeck.multiplatform.sdk.IntegrationTest
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_EMAIL
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_ID
@@ -17,6 +16,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
 
 class PlatformClientTest : IntegrationTest() {
 
@@ -26,8 +26,8 @@ class PlatformClientTest : IntegrationTest() {
         val login = ACCOUNTLESS_CLIENT.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
         CONTEXT_MANAGER.setAuthToken(login.authToken)
         val newApplication = Platform.CreateApplication(
-            name = "Test Application ${getPlatform()} ${uuid4()}",
-            companyName = uuid4().toString(),
+            name = "Test Application ${getPlatform()} ${Uuid.random()}",
+            companyName = Uuid.random().toString(),
             mailingAddress = "test@doordeck.com",
             privacyPolicy = "https://www.doordeck.com/privacy",
             supportContact = "https://www.doordeck.com"
@@ -43,7 +43,7 @@ class PlatformClientTest : IntegrationTest() {
         assertNotNull(application)
 
         // Given - shouldUpdateApplicationName
-        val updatedApplicationName = "Test Application ${uuid4()}"
+        val updatedApplicationName = "Test Application ${Uuid.random()}"
 
         // When
         PLATFORM_CLIENT.updateApplicationNameRequest(application.applicationId, updatedApplicationName)
@@ -53,7 +53,7 @@ class PlatformClientTest : IntegrationTest() {
         assertEquals(updatedApplicationName, application.name)
 
         // Given - shouldUpdateApplicationCompanyName
-        val updatedApplicationCompanyName = uuid4().toString()
+        val updatedApplicationCompanyName = Uuid.random().toString()
 
         // When
         PLATFORM_CLIENT.updateApplicationCompanyNameRequest(application.applicationId, updatedApplicationCompanyName)
@@ -186,7 +186,7 @@ class PlatformClientTest : IntegrationTest() {
 
         // Given - shouldAddEd25519AuthKey
         val ed25519Key = Platform.Ed25519Key(
-            kid = uuid4().toString(),
+            kid = Uuid.random().toString(),
             use = "sig",
             alg = "EdDSA",
             d = "NUTwZGmCu7zQ5tNRXqBGBnZCTYqDci3GMlLCg8qw0J4",
@@ -211,7 +211,7 @@ class PlatformClientTest : IntegrationTest() {
 
         // Given - shouldAddRsaAuthKey
         val rsaKey = Platform.RsaKey(
-            kid = uuid4().toString(),
+            kid = Uuid.random().toString(),
             use = "sig",
             alg = "RS256",
             p = "_86RLMHT_HrvYGzRLA8K2gEzUh3UADy5xMatYY7nh6KLBWY2USMn5nD93adcT0u6FKE6cEBjNRhWpq_11ai4UuJmLI88Cpf3HoN-eVBqpf0aULsLMNPJK88MWNRvLR5_54-NrAqZOUDLGi32te-CWd4Uq4ly6D_MS_p7G1z7zdk",
@@ -241,7 +241,7 @@ class PlatformClientTest : IntegrationTest() {
 
         // Given - shouldAddEcAuthKey
         val ecKey = Platform.EcKey(
-            kid = uuid4().toString(),
+            kid = Uuid.random().toString(),
             use = "sig",
             alg = "ES256",
             d = "6BCNLf3Qdkle4DRLzqocD_58yIQLkaCT-EiWVThFf1s",


### PR DESCRIPTION
[UUID support](https://kotlinlang.org/docs/whatsnew2020.html#support-for-uuids-in-the-common-kotlin-standard-library) was added in Kotlin 2.0.20, so we no longer need to use an external dependency.