### PR TITLE
SPM publish

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -71,23 +71,23 @@ jobs:
           git config --global user.name "Doordeck Development"
           git config --global user.email "development@doordeck.com"
 
-#      - name: Setup Node
-#        uses: actions/setup-node@v4
-#        with:
-#          node-version: 'latest'
-#          registry-url: 'https://registry.npmjs.org'
-#          scope: '@doordeck'
-#        env:
-#          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISHING_TOKEN }}
-#
-#      - name: Setup Ruby
-#        uses: ruby/setup-ruby@v1
-#        with:
-#          ruby-version: '3.3'
-#
-#      - name: Install CocoaPods
-#        run: |
-#          sudo gem install cocoapods
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'latest'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@doordeck'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISHING_TOKEN }}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install CocoaPods
+        run: |
+          sudo gem install cocoapods
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -105,12 +105,6 @@ jobs:
           role-to-assume: arn:aws:iam::135184807345:role/GitHubAction-HeadlessSDKRelease
           aws-region: eu-west-1
 
-      - name: Publish to SPM
-        #if: github.ref == 'refs/heads/main'
-        run: |
-          ./gradlew assembleDoordeckSDKReleaseXCFramework
-          aws s3 cp doordeck-sdk/DoordeckSDK.xcframework.zip s3://cdn.doordeck.com/xcframework/v1.1.1/
-
 #      - name: Tag for release (if on main)
 #        if: github.ref == 'refs/heads/main'
 #        run: ./gradlew -Prelease.version=1.0.0 final -x test
@@ -118,24 +112,33 @@ jobs:
 #      - name: Parse release version
 #        id: version_info
 #        run: echo version=$(./gradlew properties -q -Prelease.useLastTag=true | grep "version:" | awk '{print $2}') >> "$GITHUB_OUTPUT"
-#
-#      - name: Publish to SPM
-#        run: |
-#          ./gradlew assembleDoordeckSDKReleaseXCFramework
-#          CHECKSUM=$(swift package compute-checksum doordeck-sdk/DoordeckSDK.xcframework.zip)
-#          echo "checksum=$CHECKSUM" >> $GITHUB_ENV
+
+      - name: Publish to SPM
+        #if: github.ref == 'refs/heads/main'
+        run: |
+          ./gradlew assembleDoordeckSDKReleaseXCFramework
+          CHECKSUM=$(swift package compute-checksum doordeck-sdk/DoordeckSDK.xcframework.zip)
+          echo "checksum=$CHECKSUM" >> $GITHUB_ENV
+          aws s3 cp doordeck-sdk/DoordeckSDK.xcframework.zip s3://cdn.doordeck.com/xcframework/v1.0.0/
 #          ./gradlew updatePackageSwift -PpackageVersion=${{ steps.version_info.outputs.version }} -PpackageChecksum=$CHECKSUM
 #          git add Package.swift
 #          git commit -m "Update Package.swift for v${{ steps.version_info.outputs.version }} [skip actions]"
 #          git push
-#
+
 #      - name: Update tag to point to latest commit
 #        run: |
 #          TAG=$(git describe --tags --abbrev=0)
 #          git tag -d "$TAG"
 #          git tag "$TAG"
 #          git push origin "$TAG" --force
-#
+
+      - name: Publish to CocoaPods
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: |
+          ./gradlew podSpecRelease
+          pod trunk push doordeck-sdk/build/cocoapods/publish/release/DoordeckSDK.podspec --allow-warnings
+
 #      - name: Publish to Maven Central
 #        run: ./gradlew -Prelease.useLastTag=true kotlinUpgradeYarnLock doordeck-sdk:publishToSonatype closeAndReleaseSonatypeStagingRepository -x test
 #        env:
@@ -143,13 +146,6 @@ jobs:
 #          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
 #          MAVEN_SIGN_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
 #          MAVEN_SIGN_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-#
-#      - name: Publish to CocoaPods
-#        env:
-#          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-#        run: |
-#          cd doordeck-sdk/build/cocoapods/publish/release
-#          pod trunk push DoordeckSDK.podspec --allow-warnings
 #
 #      - name: Publish to NPM
 #        env:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,51 +9,50 @@ on:
   pull_request:
     branches:
       - 'main'
-      - 'spm-publish'
 
 jobs:
-#  build:
-#    env:
-#      TEST_MAIN_USER_PASSWORD: ${{ secrets.TEST_MAIN_USER_PASSWORD }}
-#      TEST_MAIN_USER_PRIVATE_KEY: ${{ secrets.TEST_MAIN_USER_PRIVATE_KEY }}
-#      TEST_ENV_VAR: 9f8e96ae-bed8-43a4-ac5e-2f55dc6a85cb
-#    strategy:
-#      max-parallel: 1
-#      matrix:
-#        include:
-#          - name: JVM
-#            test: jvmTest
-#            os: ubuntu-latest
-#          - name: Android
-#            test: testReleaseUnitTest
-#            os: ubuntu-latest
-#          - name: JS
-#            test: kotlinUpgradeYarnLock jsTest
-#            os: ubuntu-latest
-#          - name: Apple
-#            test: iosX64Test macosArm64Test
-#            os: macos-latest
-#          - name: Windows
-#            test: mingwX64Test
-#            os: windows-latest
-#    runs-on: ${{ matrix.os }}
-#    name: ${{ matrix.name }}
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: Set up Java
-#        uses: actions/setup-java@v4
-#        with:
-#          distribution: corretto
-#          java-version: 21
-#      - name: Setup Gradle
-#        uses: gradle/actions/setup-gradle@v4
-#      - name: Tests
-#        run: ./gradlew ${{ matrix.test }} --rerun-tasks
+  build:
+    env:
+      TEST_MAIN_USER_PASSWORD: ${{ secrets.TEST_MAIN_USER_PASSWORD }}
+      TEST_MAIN_USER_PRIVATE_KEY: ${{ secrets.TEST_MAIN_USER_PRIVATE_KEY }}
+      TEST_ENV_VAR: 9f8e96ae-bed8-43a4-ac5e-2f55dc6a85cb
+    strategy:
+      max-parallel: 1
+      matrix:
+        include:
+          - name: JVM
+            test: jvmTest
+            os: ubuntu-latest
+          - name: Android
+            test: testReleaseUnitTest
+            os: ubuntu-latest
+          - name: JS
+            test: kotlinUpgradeYarnLock jsTest
+            os: ubuntu-latest
+          - name: Apple
+            test: iosX64Test macosArm64Test
+            os: macos-latest
+          - name: Windows
+            test: mingwX64Test
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.name }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Tests
+        run: ./gradlew ${{ matrix.test }} --rerun-tasks
 
   release:
     name: Releases
-    #needs: build
-    #if: (success() && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    if: (success() && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
 
     permissions:
@@ -99,38 +98,38 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Configure AWS Credentials
-        #if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::135184807345:role/GitHubAction-HeadlessSDKRelease
           aws-region: eu-west-1
 
-#      - name: Tag for release (if on main)
-#        if: github.ref == 'refs/heads/main'
-#        run: ./gradlew -Prelease.version=1.0.0 final -x test
-#
-#      - name: Parse release version
-#        id: version_info
-#        run: echo version=$(./gradlew properties -q -Prelease.useLastTag=true | grep "version:" | awk '{print $2}') >> "$GITHUB_OUTPUT"
+      - name: Tag for release (if on main)
+        if: github.ref == 'refs/heads/main'
+        run: ./gradlew -Prelease.version=1.0.0 final -x test
+
+      - name: Parse release version
+        id: version_info
+        run: echo version=$(./gradlew properties -q -Prelease.useLastTag=true | grep "version:" | awk '{print $2}') >> "$GITHUB_OUTPUT"
 
       - name: Publish to SPM
-        #if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           ./gradlew assembleDoordeckSDKReleaseXCFramework
           CHECKSUM=$(swift package compute-checksum doordeck-sdk/DoordeckSDK.xcframework.zip)
           echo "checksum=$CHECKSUM" >> $GITHUB_ENV
-          aws s3 cp doordeck-sdk/DoordeckSDK.xcframework.zip s3://cdn.doordeck.com/xcframework/v1.0.0/
-#          ./gradlew updatePackageSwift -PpackageVersion=${{ steps.version_info.outputs.version }} -PpackageChecksum=$CHECKSUM
-#          git add Package.swift
-#          git commit -m "Update Package.swift for v${{ steps.version_info.outputs.version }} [skip actions]"
-#          git push
+          aws s3 cp doordeck-sdk/DoordeckSDK.xcframework.zip s3://cdn.doordeck.com/xcframework/v${{ steps.version_info.outputs.version }}/
+          ./gradlew updatePackageSwift -PpackageVersion=${{ steps.version_info.outputs.version }} -PpackageChecksum=$CHECKSUM
+          git add Package.swift
+          git commit -m "Update Package.swift for v${{ steps.version_info.outputs.version }} [skip actions]"
+          git push
 
-#      - name: Update tag to point to latest commit
-#        run: |
-#          TAG=$(git describe --tags --abbrev=0)
-#          git tag -d "$TAG"
-#          git tag "$TAG"
-#          git push origin "$TAG" --force
+      - name: Update tag to point to latest commit
+        run: |
+          TAG=$(git describe --tags --abbrev=0)
+          git tag -d "$TAG"
+          git tag "$TAG"
+          git push origin "$TAG" --force
 
       - name: Publish to CocoaPods
         env:
@@ -139,23 +138,23 @@ jobs:
           ./gradlew podSpecRelease
           pod trunk push doordeck-sdk/build/cocoapods/publish/release/DoordeckSDK.podspec --allow-warnings
 
-#      - name: Publish to Maven Central
-#        run: ./gradlew -Prelease.useLastTag=true kotlinUpgradeYarnLock doordeck-sdk:publishToSonatype closeAndReleaseSonatypeStagingRepository -x test
-#        env:
-#          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-#          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
-#          MAVEN_SIGN_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-#          MAVEN_SIGN_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-#
-#      - name: Publish to NPM
-#        env:
-#          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISHING_TOKEN }}
-#        run: |
-#          cd build/js/packages/doordeck-sdk
-#          npm publish --access public
-#
-#      - name: Create GitHub Release
-#        env:
-#          GH_TOKEN: ${{ github.token }}
-#        run: |
-#          gh release create v${{ steps.version_info.outputs.version }} --title "Release v${{ steps.version_info.outputs.version }}" --verify-tag --generate-notes
+      - name: Publish to Maven Central
+        run: ./gradlew -Prelease.useLastTag=true kotlinUpgradeYarnLock doordeck-sdk:publishToSonatype closeAndReleaseSonatypeStagingRepository -x test
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+          MAVEN_SIGN_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          MAVEN_SIGN_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Publish to NPM
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISHING_TOKEN }}
+        run: |
+          cd build/js/packages/doordeck-sdk
+          npm publish --access public
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create v${{ steps.version_info.outputs.version }} --title "Release v${{ steps.version_info.outputs.version }}" --verify-tag --generate-notes

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -57,6 +57,7 @@ jobs:
     runs-on: macos-latest
 
     permissions:
+      id-token: write
       contents: write
       packages: write
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Tag for release (if on main)
         if: github.ref == 'refs/heads/main'
-        run: ./gradlew final -x test
+        run: ./gradlew -Prelease.version=1.0.0 final -x test
 
       - name: Parse release version
         id: version_info

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -109,7 +109,7 @@ jobs:
         #if: github.ref == 'refs/heads/main'
         run: |
           ./gradlew assembleDoordeckSDKReleaseXCFramework
-          aws s3 cp doordeck-sdk/DoordeckSDK.xcframework.zip s3://cdn.doordeck.com/xcframework/
+          aws s3 cp doordeck-sdk/DoordeckSDK.xcframework.zip s3://cdn.doordeck.com/xcframework/v1.1.1/
 
 #      - name: Tag for release (if on main)
 #        if: github.ref == 'refs/heads/main'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -109,7 +109,7 @@ jobs:
         #if: github.ref == 'refs/heads/main'
         run: |
           ./gradlew assembleDoordeckSDKReleaseXCFramework
-          aws s3 cp doordeck-sdk/DoordeckSDK.xcframework.zip s3://cdn.doordeck.com/xcframework/v1.1.1/
+          aws s3 cp doordeck-sdk/DoordeckSDK.xcframework.zip s3://cdn.doordeck.com/xcframework/
 
 #      - name: Tag for release (if on main)
 #        if: github.ref == 'refs/heads/main'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -104,14 +104,6 @@ jobs:
         id: version_info
         run: echo version=$(./gradlew properties -q -Prelease.useLastTag=true | grep "version:" | awk '{print $2}') >> "$GITHUB_OUTPUT"
 
-      - name: Publish to Maven Central
-        run: ./gradlew -Prelease.useLastTag=true kotlinUpgradeYarnLock doordeck-sdk:publishToSonatype closeAndReleaseSonatypeStagingRepository -x test
-        env:
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
-          MAVEN_SIGN_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          MAVEN_SIGN_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-
       - name: Publish to SPM
         run: |
           ./gradlew assembleDoordeckSDKReleaseXCFramework
@@ -121,6 +113,21 @@ jobs:
           git add Package.swift
           git commit -m "Update Package.swift for v${{ steps.version_info.outputs.version }} [skip actions]"
           git push
+
+      - name: Update tag to point to latest commit
+        run: |
+          TAG=$(git describe --tags --abbrev=0)
+          git tag -d "$TAG"
+          git tag "$TAG"
+          git push origin "$TAG" --force
+
+      - name: Publish to Maven Central
+        run: ./gradlew -Prelease.useLastTag=true kotlinUpgradeYarnLock doordeck-sdk:publishToSonatype closeAndReleaseSonatypeStagingRepository -x test
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+          MAVEN_SIGN_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          MAVEN_SIGN_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Publish to CocoaPods
         env:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,50 +9,51 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'spm-publish'
 
 jobs:
-  build:
-    env:
-      TEST_MAIN_USER_PASSWORD: ${{ secrets.TEST_MAIN_USER_PASSWORD }}
-      TEST_MAIN_USER_PRIVATE_KEY: ${{ secrets.TEST_MAIN_USER_PRIVATE_KEY }}
-      TEST_ENV_VAR: 9f8e96ae-bed8-43a4-ac5e-2f55dc6a85cb
-    strategy:
-      max-parallel: 1
-      matrix:
-        include:
-          - name: JVM
-            test: jvmTest
-            os: ubuntu-latest
-          - name: Android
-            test: testReleaseUnitTest
-            os: ubuntu-latest
-          - name: JS
-            test: kotlinUpgradeYarnLock jsTest
-            os: ubuntu-latest
-          - name: Apple
-            test: iosX64Test macosArm64Test
-            os: macos-latest
-          - name: Windows
-            test: mingwX64Test
-            os: windows-latest
-    runs-on: ${{ matrix.os }}
-    name: ${{ matrix.name }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          java-version: 21
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-      - name: Tests
-        run: ./gradlew ${{ matrix.test }} --rerun-tasks
+#  build:
+#    env:
+#      TEST_MAIN_USER_PASSWORD: ${{ secrets.TEST_MAIN_USER_PASSWORD }}
+#      TEST_MAIN_USER_PRIVATE_KEY: ${{ secrets.TEST_MAIN_USER_PRIVATE_KEY }}
+#      TEST_ENV_VAR: 9f8e96ae-bed8-43a4-ac5e-2f55dc6a85cb
+#    strategy:
+#      max-parallel: 1
+#      matrix:
+#        include:
+#          - name: JVM
+#            test: jvmTest
+#            os: ubuntu-latest
+#          - name: Android
+#            test: testReleaseUnitTest
+#            os: ubuntu-latest
+#          - name: JS
+#            test: kotlinUpgradeYarnLock jsTest
+#            os: ubuntu-latest
+#          - name: Apple
+#            test: iosX64Test macosArm64Test
+#            os: macos-latest
+#          - name: Windows
+#            test: mingwX64Test
+#            os: windows-latest
+#    runs-on: ${{ matrix.os }}
+#    name: ${{ matrix.name }}
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Set up Java
+#        uses: actions/setup-java@v4
+#        with:
+#          distribution: corretto
+#          java-version: 21
+#      - name: Setup Gradle
+#        uses: gradle/actions/setup-gradle@v4
+#      - name: Tests
+#        run: ./gradlew ${{ matrix.test }} --rerun-tasks
 
   release:
     name: Releases
-    needs: build
-    if: (success() && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v')
+    #needs: build
+    #if: (success() && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
 
     permissions:
@@ -69,23 +70,23 @@ jobs:
           git config --global user.name "Doordeck Development"
           git config --global user.email "development@doordeck.com"
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 'latest'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@doordeck'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISHING_TOKEN }}
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3'
-
-      - name: Install CocoaPods
-        run: |
-          sudo gem install cocoapods
+#      - name: Setup Node
+#        uses: actions/setup-node@v4
+#        with:
+#          node-version: 'latest'
+#          registry-url: 'https://registry.npmjs.org'
+#          scope: '@doordeck'
+#        env:
+#          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISHING_TOKEN }}
+#
+#      - name: Setup Ruby
+#        uses: ruby/setup-ruby@v1
+#        with:
+#          ruby-version: '3.3'
+#
+#      - name: Install CocoaPods
+#        run: |
+#          sudo gem install cocoapods
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -96,55 +97,68 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Tag for release (if on main)
-        if: github.ref == 'refs/heads/main'
-        run: ./gradlew -Prelease.version=1.0.0 final -x test
-
-      - name: Parse release version
-        id: version_info
-        run: echo version=$(./gradlew properties -q -Prelease.useLastTag=true | grep "version:" | awk '{print $2}') >> "$GITHUB_OUTPUT"
+      - name: Configure AWS Credentials
+        #if: github.ref == 'refs/heads/main'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::135184807345:role/GitHubAction-HeadlessSDKRelease
+          aws-region: eu-west-1
 
       - name: Publish to SPM
+        #if: github.ref == 'refs/heads/main'
         run: |
           ./gradlew assembleDoordeckSDKReleaseXCFramework
-          CHECKSUM=$(swift package compute-checksum doordeck-sdk/DoordeckSDK.xcframework.zip)
-          echo "checksum=$CHECKSUM" >> $GITHUB_ENV
-          ./gradlew updatePackageSwift -PpackageVersion=${{ steps.version_info.outputs.version }} -PpackageChecksum=$CHECKSUM
-          git add Package.swift
-          git commit -m "Update Package.swift for v${{ steps.version_info.outputs.version }} [skip actions]"
-          git push
+          aws s3 cp doordeck-sdk/DoordeckSDK.xcframework.zip s3://cdn.doordeck.com/xcframework/v1.1.1/
 
-      - name: Update tag to point to latest commit
-        run: |
-          TAG=$(git describe --tags --abbrev=0)
-          git tag -d "$TAG"
-          git tag "$TAG"
-          git push origin "$TAG" --force
-
-      - name: Publish to Maven Central
-        run: ./gradlew -Prelease.useLastTag=true kotlinUpgradeYarnLock doordeck-sdk:publishToSonatype closeAndReleaseSonatypeStagingRepository -x test
-        env:
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
-          MAVEN_SIGN_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          MAVEN_SIGN_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Publish to CocoaPods
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: |
-          cd doordeck-sdk/build/cocoapods/publish/release
-          pod trunk push DoordeckSDK.podspec --allow-warnings
-
-      - name: Publish to NPM
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISHING_TOKEN }}
-        run: |
-          cd build/js/packages/doordeck-sdk
-          npm publish --access public
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create v${{ steps.version_info.outputs.version }} --title "Release v${{ steps.version_info.outputs.version }}" --verify-tag --generate-notes
+#      - name: Tag for release (if on main)
+#        if: github.ref == 'refs/heads/main'
+#        run: ./gradlew -Prelease.version=1.0.0 final -x test
+#
+#      - name: Parse release version
+#        id: version_info
+#        run: echo version=$(./gradlew properties -q -Prelease.useLastTag=true | grep "version:" | awk '{print $2}') >> "$GITHUB_OUTPUT"
+#
+#      - name: Publish to SPM
+#        run: |
+#          ./gradlew assembleDoordeckSDKReleaseXCFramework
+#          CHECKSUM=$(swift package compute-checksum doordeck-sdk/DoordeckSDK.xcframework.zip)
+#          echo "checksum=$CHECKSUM" >> $GITHUB_ENV
+#          ./gradlew updatePackageSwift -PpackageVersion=${{ steps.version_info.outputs.version }} -PpackageChecksum=$CHECKSUM
+#          git add Package.swift
+#          git commit -m "Update Package.swift for v${{ steps.version_info.outputs.version }} [skip actions]"
+#          git push
+#
+#      - name: Update tag to point to latest commit
+#        run: |
+#          TAG=$(git describe --tags --abbrev=0)
+#          git tag -d "$TAG"
+#          git tag "$TAG"
+#          git push origin "$TAG" --force
+#
+#      - name: Publish to Maven Central
+#        run: ./gradlew -Prelease.useLastTag=true kotlinUpgradeYarnLock doordeck-sdk:publishToSonatype closeAndReleaseSonatypeStagingRepository -x test
+#        env:
+#          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+#          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+#          MAVEN_SIGN_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+#          MAVEN_SIGN_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+#
+#      - name: Publish to CocoaPods
+#        env:
+#          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+#        run: |
+#          cd doordeck-sdk/build/cocoapods/publish/release
+#          pod trunk push DoordeckSDK.podspec --allow-warnings
+#
+#      - name: Publish to NPM
+#        env:
+#          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISHING_TOKEN }}
+#        run: |
+#          cd build/js/packages/doordeck-sdk
+#          npm publish --access public
+#
+#      - name: Create GitHub Release
+#        env:
+#          GH_TOKEN: ${{ github.token }}
+#        run: |
+#          gh release create v${{ steps.version_info.outputs.version }} --title "Release v${{ steps.version_info.outputs.version }}" --verify-tag --generate-notes

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -100,6 +100,10 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: ./gradlew final -x test
 
+      - name: Parse release version
+        id: version_info
+        run: echo version=$(./gradlew properties -q -Prelease.useLastTag=true | grep "version:" | awk '{print $2}') >> "$GITHUB_OUTPUT"
+
       - name: Publish to Maven Central
         run: ./gradlew -Prelease.useLastTag=true kotlinUpgradeYarnLock doordeck-sdk:publishToSonatype closeAndReleaseSonatypeStagingRepository -x test
         env:
@@ -107,6 +111,16 @@ jobs:
           MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
           MAVEN_SIGN_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           MAVEN_SIGN_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Publish to SPM
+        run: |
+          ./gradlew assembleDoordeckSDKReleaseXCFramework
+          CHECKSUM=$(swift package compute-checksum doordeck-sdk/DoordeckSDK.xcframework.zip)
+          echo "checksum=$CHECKSUM" >> $GITHUB_ENV
+          ./gradlew updatePackageSwift -PpackageVersion=${{ steps.version_info.outputs.version }} -PpackageChecksum=$CHECKSUM
+          git add Package.swift
+          git commit -m "Update Package.swift for v${{ steps.version_info.outputs.version }} [skip actions]"
+          git push
 
       - name: Publish to CocoaPods
         env:
@@ -121,10 +135,6 @@ jobs:
         run: |
           cd build/js/packages/doordeck-sdk
           npm publish --access public
-
-      - name: Parse release version
-        id: version_info
-        run: echo version=$(./gradlew properties -q -Prelease.useLastTag=true | grep "version:" | awk '{print $2}') >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         env:

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+   name: "DoordeckSDK",
+   platforms: [
+     .iOS(.v14),
+     .macOS(.v11),
+   ],
+   products: [
+      .library(name: "DoordeckSDK", targets: ["DoordeckSDK"])
+   ],
+   targets: [
+      .binaryTarget(
+         name: "DoordeckSDK",
+         url: "",
+         checksum: ""
+      )
+   ]
+)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ tasks.register("updatePackageSwift") {
             val packageFile = file("Package.swift")
             val content = packageFile.readText()
             val updatedContent = content
-                .replace(Regex("""url: ".*""""), """url: "https://github.com/doordeck/doordeck-headless-sdk/releases/download/v$packageVersion/DoordeckSDK.xcframework.zip"""")
+                .replace(Regex("""url: ".*""""), """url: "https://cdn.doordeck.com/xcframework/v$packageVersion/DoordeckSDK.xcframework.zip"""")
                 .replace(Regex("""checksum: ".*""""), """checksum: "$packageChecksum"""")
             packageFile.writeText(updatedContent)
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,3 +20,19 @@ nexusPublishing {
         }
     }
 }
+
+tasks.register("updatePackageSwift") {
+    val packageVersion: String? by project
+    val packageChecksum: String? by project
+
+    doLast {
+        if (!packageVersion.isNullOrEmpty() && !packageChecksum.isNullOrEmpty()) {
+            val packageFile = file("Package.swift")
+            val content = packageFile.readText()
+            val updatedContent = content
+                .replace(Regex("""url: ".*""""), """url: "https://github.com/doordeck/doordeck-headless-sdk/releases/download/v$packageVersion/DoordeckSDK.xcframework.zip"""")
+                .replace(Regex("""checksum: ".*""""), """checksum: "$packageChecksum"""")
+            packageFile.writeText(updatedContent)
+        }
+    }
+}

--- a/doordeck-sdk/build.gradle.kts
+++ b/doordeck-sdk/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
     iosTargets.forEach {
         it.binaries.framework {
             baseName = "DoordeckSDK"
+            binaryOption("bundleId", "com.doordeck.DoordeckSDK")
             xcf.add(this)
         }
 
@@ -280,4 +281,15 @@ swiftklib {
         minMacos = libs.versions.ios.minSdk.get().toInt()
         minIos = libs.versions.ios.minSdk.get().toInt()
     }
+}
+
+tasks.register<Zip>("zipXCFramework") {
+    from("build/XCFrameworks/release/DoordeckSDK.xcframework")
+    archiveFileName.set("DoordeckSDK.xcframework.zip")
+    destinationDirectory.set(file("."))
+    include("**/*")
+}
+
+tasks.named("assembleDoordeckSDKReleaseXCFramework").configure {
+    finalizedBy("zipXCFramework")
 }

--- a/doordeck-sdk/build.gradle.kts
+++ b/doordeck-sdk/build.gradle.kts
@@ -92,8 +92,8 @@ kotlin {
         homepage = "https://www.doordeck.com/"
         license = "{ :type => 'Apache-2.0' }"
         authors = "Doordeck Limited"
-        version = "${project.version}"
-        source = "{ :http => 'https://cdn.doordeck.com/xcframework/v${project.version}/DoordeckSDK.xcframework.zip' }"
+        version = "1.0.0"//"${project.version}"
+        source = "{ :http => 'https://cdn.doordeck.com/xcframework/v1.0.0/DoordeckSDK.xcframework.zip' }"
         ios.deploymentTarget = libs.versions.ios.minSdk.get()
         name = "DoordeckSDK"
         framework {
@@ -250,7 +250,7 @@ signing {
 }
 
 tasks.named("publishToSonatype").configure {
-    finalizedBy("jsBrowserProductionLibraryDistribution", "podSpecRelease")
+    finalizedBy("jsBrowserProductionLibraryDistribution")
 }
 
 tasks.named("jsBrowserProductionLibraryDistribution").configure {

--- a/doordeck-sdk/build.gradle.kts
+++ b/doordeck-sdk/build.gradle.kts
@@ -92,8 +92,8 @@ kotlin {
         homepage = "https://www.doordeck.com/"
         license = "{ :type => 'Apache-2.0' }"
         authors = "Doordeck Limited"
-        version = "1.0.0"//"${project.version}"
-        source = "{ :http => 'https://cdn.doordeck.com/xcframework/v1.0.0/DoordeckSDK.xcframework.zip' }"
+        version = "${project.version}"
+        source = "{ :http => 'https://cdn.doordeck.com/xcframework/v${project.version}/DoordeckSDK.xcframework.zip' }"
         ios.deploymentTarget = libs.versions.ios.minSdk.get()
         name = "DoordeckSDK"
         framework {

--- a/doordeck-sdk/build.gradle.kts
+++ b/doordeck-sdk/build.gradle.kts
@@ -93,14 +93,13 @@ kotlin {
         license = "{ :type => 'Apache-2.0' }"
         authors = "Doordeck Limited"
         version = "${project.version}"
-        source = "{ :git => 'https://github.com/doordeck/doordeck-headless-sdk.git', :tag => 'v${project.version}' }"
+        source = "{ :http => 'https://cdn.doordeck.com/xcframework/v${project.version}/DoordeckSDK.xcframework.zip' }"
         ios.deploymentTarget = libs.versions.ios.minSdk.get()
         name = "DoordeckSDK"
         framework {
             baseName = "DoordeckSDK"
         }
-        extraSpecAttributes["vendored_frameworks"] = "'doordeck-sdk/build/cocoapods/publish/release/DoordeckSDK.xcframework'"
-        extraSpecAttributes["prepare_command"] = "'./gradlew --no-daemon -Pversion=${project.version} podPublishReleaseXCFramework'"
+        extraSpecAttributes["vendored_frameworks"] = "'DoordeckSDK.xcframework'"
     }
 
     sourceSets {

--- a/doordeck-sdk/build.gradle.kts
+++ b/doordeck-sdk/build.gradle.kts
@@ -284,7 +284,7 @@ swiftklib {
 }
 
 tasks.register<Zip>("zipXCFramework") {
-    from("build/XCFrameworks/release/DoordeckSDK.xcframework")
+    from("build/XCFrameworks/release")
     archiveFileName.set("DoordeckSDK.xcframework.zip")
     destinationDirectory.set(file("."))
     include("**/*")


### PR DESCRIPTION
SPM requires the project to have a [Package.swift](https://kotlinlang.org/docs/native-spm.html#prepare-the-xcframework-and-the-swift-package-manifest) file. Inside that file, we need to update the URL and checksum fields for each release (this update is handled by github actions). This means I should update the tag to include this commit, as I haven’t found any other way to handle it.

The URL refers to the framework's ZIP file that we upload to S3, and the checksum is generated from that file.

SPM doesn't seem to like versions starting with 0, or at least I had problems with them. So, I added `-Prelease.version=1.0.0` to bump the release version to `1.0.0`. This should be removed at the next merge.