### PR TITLE
isCertificateAboutToExpire fix

### DIFF
--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.android.kt
@@ -12,7 +12,6 @@ import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.spec.X509EncodedKeySpec
-import kotlin.time.Duration.Companion.days
 
 actual object CryptoManager {
 
@@ -35,7 +34,7 @@ actual object CryptoManager {
         val certificateFactory = CertificateFactory.getInstance(CERTIFICATE_TYPE)
         val certificate = certificateFactory.generateCertificate(base64Certificate.decodeBase64Bytes().inputStream()) as X509Certificate
         certificate.notAfter?.let {
-            Clock.System.now() >= it.toInstant().toKotlinInstant() - 30.days
+            Clock.System.now() >= it.toInstant().toKotlinInstant() - MIN_CERTIFICATE_LIFETIME_DAYS
         } ?: true
     } catch (exception: Exception) {
         true

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.kt
@@ -1,6 +1,7 @@
 package com.doordeck.multiplatform.sdk.crypto
 
 import com.doordeck.multiplatform.sdk.api.model.Crypto
+import kotlin.time.Duration.Companion.days
 
 internal const val SODIUM_PUBLIC_KEY_SIZE = 32
 internal const val SODIUM_PRIVATE_KEY_SIZE = 64
@@ -9,6 +10,7 @@ internal const val CRYPTO_KIT_PRIVATE_KEY_SIZE = 32
 internal const val JAVA_PKCS8_PUBLIC_KEY_SIZE = 44
 internal const val JAVA_PKCS8_PRIVATE_KEY_SIZE = 48
 internal const val RAW_KEY_SIZE = 32
+internal val MIN_CERTIFICATE_LIFETIME_DAYS = 7.days
 
 internal val PRIVATE_KEY_ASN1_HEADER = byteArrayOf(
     0x30, 0x2e,                     // ASN.1 SEQUENCE, length 46

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/util/CertificateUtils.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/util/CertificateUtils.kt
@@ -1,17 +1,17 @@
 package com.doordeck.multiplatform.sdk.util
 
+import com.doordeck.multiplatform.sdk.crypto.MIN_CERTIFICATE_LIFETIME_DAYS
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
-import kotlin.time.Duration.Companion.days
 
 internal fun String.isCertificateAboutToExpire(): Boolean = try {
     val notAfter = extractNotAfter(decodeBase64ToByteArray())
     val notAfterInstant = parseNotAfter(notAfter.decodeToString())
-    Clock.System.now() >= notAfterInstant - 30.days
+    Clock.System.now() >= notAfterInstant - MIN_CERTIFICATE_LIFETIME_DAYS
 } catch (exception: Exception) {
     true
 }

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.js.kt
@@ -12,7 +12,6 @@ import io.ktor.utils.io.core.toByteArray
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.js.Date
-import kotlin.time.Duration.Companion.days
 
 @JsExport
 actual object CryptoManager {
@@ -40,7 +39,7 @@ actual object CryptoManager {
         val certificate = PKI.Certificate()
         certificate.fromSchema(asn1.result)
         val notAfterDate = Date(certificate.notAfter.value.toString()).toISOString()
-        Clock.System.now() >= Instant.parse(notAfterDate) - 30.days
+        Clock.System.now() >= Instant.parse(notAfterDate) - MIN_CERTIFICATE_LIFETIME_DAYS
     } catch (exception: Throwable) {
         true
     }

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.jvm.kt
@@ -12,7 +12,6 @@ import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.spec.X509EncodedKeySpec
-import kotlin.time.Duration.Companion.days
 
 actual object CryptoManager {
 
@@ -35,7 +34,7 @@ actual object CryptoManager {
         val certificateFactory = CertificateFactory.getInstance(CERTIFICATE_TYPE)
         val certificate = certificateFactory.generateCertificate(base64Certificate.decodeBase64Bytes().inputStream()) as X509Certificate
         certificate.notAfter?.let {
-            Clock.System.now() >= it.toInstant().toKotlinInstant() - 30.days
+            Clock.System.now() >= it.toInstant().toKotlinInstant() - MIN_CERTIFICATE_LIFETIME_DAYS
         } ?: true
     } catch (exception: Exception) {
         true


### PR DESCRIPTION
@gunhansancar  pointed out that `isCertificateChainAboutToExpire` was always returning `true`, even for newly registered key pairs. The issue was that I was checking if the certificate expiration date was within the next 30-day threshold, which is too long. I’ve now updated it to follow the logic of the [JS SDK](https://github.com/doordeck/doordeck-sdk-javascript/blob/df9e510a3fb5ff94aceef68106768293b916e120/common/services/certificate.js#L27), using a 7-day threshold instead.