### PR TITLE
Context improvements

### DIFF
--- a/docs/07_API-ACCOUNTLESS.md
+++ b/docs/07_API-ACCOUNTLESS.md
@@ -2,6 +2,9 @@
 
 ## Login
 
+> [!NOTE]  
+> When used successfully, the user email, auth token and refresh token from the response are added to the [context manager](06_CONTEXT-MANAGER.md).
+
 ### JVM & Android
 <details>
 <summary>Show Details</summary>
@@ -44,7 +47,10 @@ var response = Utils.fromData<TokenResponse>(symbols->kotlin.root.com.doordeck.m
 
 ## Register a new user
 
-After registration, you will need to [verify the email](#verify-email).
+After registration, you will need to [verify the email](#verify-email)
+
+> [!NOTE]  
+> When used successfully, the user email, auth token and refresh token from the response are added to the [context manager](06_CONTEXT-MANAGER.md).
 
 ### JVM & Android
 <details>

--- a/docs/08_API-ACCOUNT.md
+++ b/docs/08_API-ACCOUNT.md
@@ -6,6 +6,9 @@
 > This function is only available to users with Doordeck issued auth tokens.
 
 > [!NOTE]  
+> When used successfully, the auth token and refresh token from the response are added to the [context manager](06_CONTEXT-MANAGER.md).
+
+> [!NOTE]  
 > This function can be used with the [refresh token](06_CONTEXT-MANAGER.md#set-refresh-token) value from the context. To use the value from the context, you should pass null as the function parameter
 
 ### JVM & Android
@@ -95,6 +98,9 @@ symbols->kotlin.root.com.doordeck.multiplatform.sdk.api.AccountResource.logout(r
 ## Register ephemeral key
 To register a new ephemeral key, you will need to [generate a new key pair](05_CRYPTO.md#generate-a-key-pair).
 
+> [!NOTE]  
+> When used successfully, the user ID, and user certificate chain from the response are added to the [context manager](06_CONTEXT-MANAGER.md).
+
 ### JVM & Android
 <details>
 <summary>Show Details</summary>
@@ -137,6 +143,9 @@ var response = Utils.fromData<RegisterEphemeralKeyResponse>(symbols->kotlin.root
 
 ## Register ephemeral key with secondary authentication
 To register a new ephemeral key with secondary authentication, you will need to [generate a new key pair](05_CRYPTO.md#generate-a-key-pair). After the registration, you will need to [verify the ephemeral key registration](#verify-ephemeral-key-registration).
+
+> [!NOTE]  
+> When used successfully, the user ID, and user certificate chain from the response are added to the [context manager](06_CONTEXT-MANAGER.md).
 
 ### JVM & Android
 <details>

--- a/docs/09_API-FUSION.md
+++ b/docs/09_API-FUSION.md
@@ -2,6 +2,9 @@
 
 ## Login
 
+> [!NOTE]  
+> When used successfully, the auth token from the response is added to the [context manager](06_CONTEXT-MANAGER.md).
+
 ### JVM & Android
 <details>
 <summary>Show Details</summary>

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/api/ContextManager.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/api/ContextManager.kt
@@ -23,8 +23,6 @@ interface ContextManager {
     fun isCertificateChainAboutToExpire(): Boolean
     fun setKeyPair(publicKey: ByteArray, privateKey: ByteArray)
     fun getKeyPair(): Crypto.KeyPair?
-    fun getPublicKey(): ByteArray?
-    fun getPrivateKey(): ByteArray?
     fun isKeyPairValid(): Boolean
     fun setOperationContext(userId: String, certificateChain: List<String>, publicKey: ByteArray, privateKey: ByteArray)
     fun setOperationContextJson(data: String)

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/api/ContextManager.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/api/ContextManager.kt
@@ -1,5 +1,6 @@
 package com.doordeck.multiplatform.sdk.api
 
+import com.doordeck.multiplatform.sdk.api.model.Crypto
 import com.doordeck.multiplatform.sdk.storage.SecureStorage
 import kotlin.js.JsExport
 
@@ -7,13 +8,24 @@ import kotlin.js.JsExport
 interface ContextManager {
 
     fun setAuthToken(token: String)
+    fun getAuthToken(): String?
     fun isAuthTokenAboutToExpire(): Boolean
     fun setRefreshToken(token: String)
+    fun getRefreshToken(): String?
     fun setFusionAuthToken(token: String)
+    fun getFusionAuthToken(): String?
     fun setUserId(userId: String)
+    fun getUserId(): String?
+    fun setUserEmail(email: String)
+    fun getUserEmail(): String?
     fun setCertificateChain(certificateChain: List<String>)
+    fun getCertificateChain(): List<String>?
     fun isCertificateChainAboutToExpire(): Boolean
     fun setKeyPair(publicKey: ByteArray, privateKey: ByteArray)
+    fun getKeyPair(): Crypto.KeyPair?
+    fun getPublicKey(): ByteArray?
+    fun getPrivateKey(): ByteArray?
+    fun isKeyPairValid(): Boolean
     fun setOperationContext(userId: String, certificateChain: List<String>, publicKey: ByteArray, privateKey: ByteArray)
     fun setOperationContextJson(data: String)
     fun setSecureStorageImpl(secureStorage: SecureStorage)

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/internal/ContextManagerImpl.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/internal/ContextManagerImpl.kt
@@ -101,11 +101,11 @@ internal class ContextManagerImpl(
         } else null
     }
 
-    override fun getPublicKey(): ByteArray? {
+    internal fun getPublicKey(): ByteArray? {
         return currentUserPublicKey
     }
 
-    override fun getPrivateKey(): ByteArray? {
+    internal fun getPrivateKey(): ByteArray? {
         return currentUserPrivateKey
     }
 

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/internal/ContextManagerImpl.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/internal/ContextManagerImpl.kt
@@ -116,7 +116,11 @@ internal class ContextManagerImpl(
             return false
         }
         val text = Uuid.random().toString()
-        val signature = text.signWithPrivateKey(actualUserPrivateKey)
+        val signature = try {
+            text.signWithPrivateKey(actualUserPrivateKey)
+        } catch (exception: Exception) {
+            return false
+        }
         return signature.verifySignature(actualUserPublicKey, text)
     }
 

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/internal/ContextManagerImpl.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/internal/ContextManagerImpl.kt
@@ -5,11 +5,14 @@ import com.doordeck.multiplatform.sdk.api.ContextManager
 import com.doordeck.multiplatform.sdk.api.model.Context
 import com.doordeck.multiplatform.sdk.api.model.Crypto
 import com.doordeck.multiplatform.sdk.crypto.CryptoManager
+import com.doordeck.multiplatform.sdk.crypto.CryptoManager.signWithPrivateKey
+import com.doordeck.multiplatform.sdk.crypto.CryptoManager.verifySignature
 import com.doordeck.multiplatform.sdk.storage.SecureStorage
 import com.doordeck.multiplatform.sdk.storage.createSecureStorage
 import com.doordeck.multiplatform.sdk.util.JwtUtils.isJwtTokenAboutToExpire
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
 import com.doordeck.multiplatform.sdk.util.fromJson
+import kotlin.uuid.Uuid
 
 internal class ContextManagerImpl(
     private val applicationContext: ApplicationContext? = null,
@@ -21,6 +24,7 @@ internal class ContextManagerImpl(
     private var currentRefreshToken: String? = refreshToken
     private var currentFusionToken: String? = null
     private var currentUserId: String? = null
+    private var currentEmail: String? = null
     private var currentUserCertificateChain: List<String>? = null
     private var currentUserPublicKey: ByteArray? = null
     private var currentUserPrivateKey: ByteArray? = null
@@ -28,6 +32,10 @@ internal class ContextManagerImpl(
 
     override fun setAuthToken(token: String) {
         currentToken = token
+    }
+
+    override fun getAuthToken(): String? {
+        return currentToken
     }
 
     override fun isAuthTokenAboutToExpire(): Boolean {
@@ -38,16 +46,40 @@ internal class ContextManagerImpl(
         currentRefreshToken = token
     }
 
+    override fun getRefreshToken(): String? {
+        return currentRefreshToken
+    }
+
     override fun setFusionAuthToken(token: String) {
         currentFusionToken = token
+    }
+
+    override fun getFusionAuthToken(): String? {
+        return currentFusionToken
     }
 
     override fun setUserId(userId: String) {
         currentUserId = userId
     }
 
+    override fun getUserId(): String? {
+        return currentUserId
+    }
+
+    override fun setUserEmail(email: String) {
+        currentEmail = email
+    }
+
+    override fun getUserEmail(): String? {
+        return currentEmail
+    }
+
     override fun setCertificateChain(certificateChain: List<String>) {
         currentUserCertificateChain = certificateChain
+    }
+
+    override fun getCertificateChain(): List<String>? {
+        return currentUserCertificateChain
     }
 
     override fun isCertificateChainAboutToExpire(): Boolean {
@@ -61,6 +93,33 @@ internal class ContextManagerImpl(
         currentUserPrivateKey = privateKey
     }
 
+    override fun getKeyPair(): Crypto.KeyPair? {
+        val actualUserPublicKey = currentUserPublicKey
+        val actualUserPrivateKey = currentUserPrivateKey
+        return if (actualUserPublicKey != null && actualUserPrivateKey != null) {
+            Crypto.KeyPair(actualUserPrivateKey, actualUserPublicKey)
+        } else null
+    }
+
+    override fun getPublicKey(): ByteArray? {
+        return currentUserPublicKey
+    }
+
+    override fun getPrivateKey(): ByteArray? {
+        return currentUserPrivateKey
+    }
+
+    override fun isKeyPairValid(): Boolean {
+        val actualUserPublicKey = currentUserPublicKey
+        val actualUserPrivateKey = currentUserPrivateKey
+        if (actualUserPublicKey == null || actualUserPrivateKey == null) {
+            return false
+        }
+        val text = Uuid.random().toString()
+        val signature = text.signWithPrivateKey(actualUserPrivateKey)
+        return signature.verifySignature(actualUserPublicKey, text)
+    }
+
     internal fun setTokens(token: String, refreshToken: String) {
         currentToken = token
         currentRefreshToken = refreshToken
@@ -69,6 +128,7 @@ internal class ContextManagerImpl(
     internal fun reset() {
         resetTokens()
         resetOperationContext()
+        currentEmail = null
     }
 
     private fun resetTokens() {
@@ -110,6 +170,7 @@ internal class ContextManagerImpl(
         currentRefreshToken = currentRefreshToken ?: secureStorage?.getCloudRefreshToken()
         currentFusionToken = currentFusionToken ?: secureStorage?.getFusionAuthToken()
         currentUserId = currentUserId ?: secureStorage?.getUserId()
+        currentEmail = currentEmail ?: secureStorage?.getUserEmail()
         currentUserCertificateChain = currentUserCertificateChain ?: secureStorage?.getCertificateChain()
         currentUserPublicKey = currentUserPublicKey ?: secureStorage?.getPublicKey()
         currentUserPrivateKey = currentUserPrivateKey ?: secureStorage?.getPrivateKey()
@@ -122,6 +183,7 @@ internal class ContextManagerImpl(
         currentRefreshToken?.let { secureStorage?.addCloudRefreshToken(it) }
         currentFusionToken?.let { secureStorage?.addFusionAuthToken(it) }
         currentUserId?.let { secureStorage?.addUserId(it) }
+        currentEmail?.let { secureStorage?.addUserEmail(it) }
         currentUserCertificateChain?.let { secureStorage?.addCertificateChain(it) }
         currentUserPublicKey?.let { secureStorage?.addPublicKey(it) }
         currentUserPrivateKey?.let { secureStorage?.addPrivateKey(it) }
@@ -131,42 +193,6 @@ internal class ContextManagerImpl(
         initializeSecureStorage()
 
         secureStorage?.clear()
-    }
-
-    internal fun getCertificateChain(): List<String>? {
-        return currentUserCertificateChain
-    }
-
-    internal fun getUserId(): String? {
-        return currentUserId
-    }
-
-    internal fun getAuthToken(): String? {
-        return currentToken
-    }
-
-    internal fun getRefreshToken(): String? {
-        return currentRefreshToken
-    }
-
-    internal fun getFusionAuthToken(): String? {
-        return currentFusionToken
-    }
-
-    internal fun getPublicKey(): ByteArray? {
-        return currentUserPublicKey
-    }
-
-    internal fun getPrivateKey(): ByteArray? {
-        return currentUserPrivateKey
-    }
-
-    internal fun getKeyPair(): Crypto.KeyPair? {
-        val actualUserPublicKey = currentUserPublicKey
-        val actualUserPrivateKey = currentUserPrivateKey
-        return if (actualUserPublicKey != null && actualUserPrivateKey != null) {
-            Crypto.KeyPair(actualUserPrivateKey, actualUserPublicKey)
-        } else null
     }
 
     private fun initializeSecureStorage() {

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountClient.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountClient.kt
@@ -61,7 +61,7 @@ internal open class AccountClient(
     suspend fun registerEphemeralKeyRequest(publicKey: ByteArray? = null): RegisterEphemeralKeyResponse {
         val publicKeyEncoded = publicKey?.encodeByteArrayToBase64()
             ?: contextManager.getPublicKey()?.encodeByteArrayToBase64()
-            ?: throw MissingContextFieldException("PublicKey is missing")
+            ?: throw MissingContextFieldException("Public key is missing")
         return httpClient.post<RegisterEphemeralKeyResponse>(Paths.getRegisterEphemeralKeyPath()) {
             addRequestHeaders()
             setBody(RegisterEphemeralKeyRequest(publicKeyEncoded))

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountlessClient.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountlessClient.kt
@@ -24,6 +24,7 @@ internal open class AccountlessClient(
             addRequestHeaders(apiVersion = ApiVersion.VERSION_2)
             setBody(LoginRequest(email, password))
         }.also {
+            contextManager.setUserEmail(email)
             contextManager.setAuthToken(it.authToken)
             contextManager.setRefreshToken(it.refreshToken)
         }
@@ -44,6 +45,7 @@ internal open class AccountlessClient(
             ))
             parameter(Params.FORCE, force)
         }.also {
+            contextManager.setUserEmail(email)
             contextManager.setAuthToken(it.authToken)
             contextManager.setRefreshToken(it.refreshToken)
         }

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsClient.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsClient.kt
@@ -411,7 +411,7 @@ internal open class LockOperationsClient(
     private fun LockOperations.BaseOperation.toBaseOperationRequestUsingContext(): BaseOperationRequest {
         val userId = userId
             ?: contextManager.getUserId()
-            ?: throw MissingContextFieldException("User id is missing")
+            ?: throw MissingContextFieldException("User ID is missing")
         val userCertificateChain = userCertificateChain
             ?: contextManager.getCertificateChain()
             ?: throw MissingContextFieldException("Certificate chain is missing")

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/DefaultSecureStorage.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/DefaultSecureStorage.kt
@@ -17,6 +17,7 @@ internal class DefaultSecureStorage(private val settings: Settings) : SecureStor
     private val PUBLIC_KEY_KEY = "PUBLIC_KEY_KEY"
     private val PRIVATE_KEY_KEY = "PRIVATE_KEY_KEY"
     private val USER_ID_KEY = "USER_ID_KEY"
+    private val USER_EMAIL_KEY = "USER_EMAIL_KEY"
     private val CERTIFICATE_CHAIN_KEY = "CERTIFICATE_CHAIN_KEY"
 
     override fun addCloudAuthToken(token: String) {
@@ -65,6 +66,14 @@ internal class DefaultSecureStorage(private val settings: Settings) : SecureStor
 
     override fun getUserId(): String? {
         return settings.getStringOrNull(USER_ID_KEY)
+    }
+
+    override fun addUserEmail(email: String) {
+        settings.putString(USER_EMAIL_KEY, email)
+    }
+
+    override fun getUserEmail(): String? {
+        return settings.getStringOrNull(USER_EMAIL_KEY)
     }
 
     override fun addCertificateChain(certificateChain: List<String>) {

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.kt
@@ -23,6 +23,9 @@ interface SecureStorage {
     fun addUserId(userId: String)
     fun getUserId(): String?
 
+    fun addUserEmail(email: String)
+    fun getUserEmail(): String?
+
     fun addCertificateChain(certificateChain: List<String>)
     fun getCertificateChain(): List<String>?
 

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsClientTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsClientTest.kt
@@ -709,14 +709,14 @@ internal class LockOperationsClientTest : IntegrationTest() {
 
         // Then
         assertTrue { revokeAccessToLockUsingContextException is MissingContextFieldException }
-        assertEquals("User id is missing", revokeAccessToLockUsingContextException.message)
+        assertEquals("User ID is missing", revokeAccessToLockUsingContextException.message)
         assertTrue { shareLockUsingContextException is MissingContextFieldException }
-        assertEquals("User id is missing", shareLockUsingContextException.message)
+        assertEquals("User ID is missing", shareLockUsingContextException.message)
         assertTrue { unlockUsingContextException is MissingContextFieldException }
-        assertEquals("User id is missing", unlockUsingContextException.message)
+        assertEquals("User ID is missing", unlockUsingContextException.message)
         assertTrue { updateSecureSettingUnlockDurationUsingContextException is MissingContextFieldException }
-        assertEquals("User id is missing", updateSecureSettingUnlockDurationUsingContextException.message)
+        assertEquals("User ID is missing", updateSecureSettingUnlockDurationUsingContextException.message)
         assertTrue { updateSecureSettingUnlockBetweenUsingContextException is MissingContextFieldException }
-        assertEquals("User id is missing", updateSecureSettingUnlockBetweenUsingContextException.message)
+        assertEquals("User ID is missing", updateSecureSettingUnlockBetweenUsingContextException.message)
     }
 }

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/internal/ContextManagerTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/internal/ContextManagerTest.kt
@@ -103,6 +103,7 @@ class ContextManagerTest {
         val publicKey = Uuid.random().toString().encodeToByteArray()
         val privateKey = Uuid.random().toString().encodeToByteArray()
         val contextManager = ContextManagerImpl()
+        contextManager.setSecureStorageImpl(DefaultSecureStorage(MapSettings()))
         contextManager.setOperationContext(userId, certificateChain, publicKey, privateKey)
 
         // When
@@ -127,6 +128,7 @@ class ContextManagerTest {
         val publicKey = Uuid.random().toString().encodeToByteArray()
         val privateKey = Uuid.random().toString().encodeToByteArray()
         val contextManager = ContextManagerImpl()
+        contextManager.setSecureStorageImpl(DefaultSecureStorage(MapSettings()))
         val operationContextData = Context.OperationContextData(userId, certificateChain, publicKey.encodeByteArrayToBase64(), privateKey.encodeByteArrayToBase64())
         contextManager.setOperationContextJson(operationContextData.toJson())
 
@@ -148,6 +150,7 @@ class ContextManagerTest {
     fun shouldCheckAuthTokenNullValidity() = runTest {
         // Given
         val contextManager = ContextManagerImpl()
+        contextManager.setSecureStorageImpl(DefaultSecureStorage(MapSettings()))
 
         // When
         val result = contextManager.isAuthTokenAboutToExpire()
@@ -160,6 +163,7 @@ class ContextManagerTest {
     fun shouldCheckCertificateChainNullValidity() = runTest {
         // Given
         val contextManager = ContextManagerImpl()
+        contextManager.setSecureStorageImpl(DefaultSecureStorage(MapSettings()))
 
         // When
         val result = contextManager.isCertificateChainAboutToExpire()
@@ -172,6 +176,7 @@ class ContextManagerTest {
     fun shouldCheckKeyPairNullValidity() = runTest {
         // Given
         val contextManager = ContextManagerImpl()
+        contextManager.setSecureStorageImpl(DefaultSecureStorage(MapSettings()))
 
         // When
         val result = contextManager.isKeyPairValid()
@@ -184,6 +189,7 @@ class ContextManagerTest {
     fun shouldCheckKeyPairInvalidValidity() = runTest {
         // Given
         val contextManager = ContextManagerImpl()
+        contextManager.setSecureStorageImpl(DefaultSecureStorage(MapSettings()))
         val publicKey = Uuid.random().toString().encodeToByteArray()
         val privateKey = Uuid.random().toString().encodeToByteArray()
         contextManager.setKeyPair(publicKey, privateKey)
@@ -199,6 +205,7 @@ class ContextManagerTest {
     fun shouldCheckKeyPairValidity() = runTest {
         // Given
         val contextManager = ContextManagerImpl()
+        contextManager.setSecureStorageImpl(DefaultSecureStorage(MapSettings()))
         val keyPair = CryptoManager.generateKeyPair()
         contextManager.setKeyPair(keyPair.public, keyPair.private)
 

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/internal/ContextManagerTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/internal/ContextManagerTest.kt
@@ -1,6 +1,7 @@
 package com.doordeck.multiplatform.sdk.internal
 
 import com.doordeck.multiplatform.sdk.api.model.Context
+import com.doordeck.multiplatform.sdk.crypto.CryptoManager
 import com.doordeck.multiplatform.sdk.storage.DefaultSecureStorage
 import com.doordeck.multiplatform.sdk.util.Utils.encodeByteArrayToBase64
 import com.doordeck.multiplatform.sdk.util.toJson
@@ -9,7 +10,9 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
 class ContextManagerTest {
@@ -139,5 +142,70 @@ class ContextManagerTest {
         assertContentEquals(privateKey, contextManager.getPrivateKey())
         assertContentEquals(publicKey, contextManager.getKeyPair()?.public)
         assertContentEquals(privateKey, contextManager.getKeyPair()?.private)
+    }
+
+    @Test
+    fun shouldCheckAuthTokenNullValidity() = runTest {
+        // Given
+        val contextManager = ContextManagerImpl()
+
+        // When
+        val result = contextManager.isAuthTokenAboutToExpire()
+
+        // Then
+        assertTrue { result }
+    }
+
+    @Test
+    fun shouldCheckCertificateChainNullValidity() = runTest {
+        // Given
+        val contextManager = ContextManagerImpl()
+
+        // When
+        val result = contextManager.isCertificateChainAboutToExpire()
+
+        // Then
+        assertTrue { result }
+    }
+
+    @Test
+    fun shouldCheckKeyPairNullValidity() = runTest {
+        // Given
+        val contextManager = ContextManagerImpl()
+
+        // When
+        val result = contextManager.isKeyPairValid()
+
+        // Then
+        assertFalse { result }
+    }
+
+    @Test
+    fun shouldCheckKeyPairInvalidValidity() = runTest {
+        // Given
+        val contextManager = ContextManagerImpl()
+        val publicKey = Uuid.random().toString().encodeToByteArray()
+        val privateKey = Uuid.random().toString().encodeToByteArray()
+        contextManager.setKeyPair(publicKey, privateKey)
+
+        // When
+        val result = contextManager.isKeyPairValid()
+
+        // Then
+        assertFalse { result }
+    }
+
+    @Test
+    fun shouldCheckKeyPairValidity() = runTest {
+        // Given
+        val contextManager = ContextManagerImpl()
+        val keyPair = CryptoManager.generateKeyPair()
+        contextManager.setKeyPair(keyPair.public, keyPair.private)
+
+        // When
+        val result = contextManager.isKeyPairValid()
+
+        // Then
+        assertTrue { result }
     }
 }


### PR DESCRIPTION
This PR includes several improvements to the context manager:

* Added `isKeyPairValid` // Verifies the validity of the context key pair by validating the signature of a dummy text
* Added `userEmail` // The email address of the logged-in or registered user (not from JWT)
* Added 'public' getters for all the context fields (previously internal)