### PR TITLE
Async simplification

### DIFF
--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/api/FusionResource.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/api/FusionResource.android.kt
@@ -56,7 +56,7 @@ actual interface FusionResource {
     suspend fun stopDoor(deviceId: String)
 
     @DoordeckOnly
-    suspend fun stopDoorAsync(deviceId: String): CompletableFuture<Unit>
+    fun stopDoorAsync(deviceId: String): CompletableFuture<Unit>
 }
 
 actual fun fusion(): FusionResource = FusionResourceImpl

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountResourceImpl.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountResourceImpl.android.kt
@@ -6,9 +6,7 @@ import com.doordeck.multiplatform.sdk.api.responses.RegisterEphemeralKeyResponse
 import com.doordeck.multiplatform.sdk.api.responses.RegisterEphemeralKeyWithSecondaryAuthenticationResponse
 import com.doordeck.multiplatform.sdk.api.responses.TokenResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserDetailsResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object AccountResourceImpl : AccountResource {
@@ -18,7 +16,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun refreshTokenAsync(refreshToken: String?): CompletableFuture<TokenResponse> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.refreshTokenRequest(refreshToken) }
+        return completableFuture { refreshToken(refreshToken) }
     }
 
     override suspend fun logout() {
@@ -26,7 +24,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun logoutAsync(): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.logoutRequest() }
+        return completableFuture { logout() }
     }
 
     override suspend fun registerEphemeralKey(publicKey: ByteArray?): RegisterEphemeralKeyResponse {
@@ -34,7 +32,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun registerEphemeralKeyAsync(publicKey: ByteArray?): CompletableFuture<RegisterEphemeralKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.registerEphemeralKeyRequest(publicKey) }
+        return completableFuture { registerEphemeralKey(publicKey) }
     }
 
     override suspend fun registerEphemeralKeyWithSecondaryAuthentication(publicKey: ByteArray?, method: TwoFactorMethod?): RegisterEphemeralKeyWithSecondaryAuthenticationResponse {
@@ -42,7 +40,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun registerEphemeralKeyWithSecondaryAuthenticationAsync(publicKey: ByteArray?, method: TwoFactorMethod?): CompletableFuture<RegisterEphemeralKeyWithSecondaryAuthenticationResponse> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.registerEphemeralKeyWithSecondaryAuthenticationRequest(publicKey, method) }
+        return completableFuture { registerEphemeralKeyWithSecondaryAuthentication(publicKey, method) }
     }
 
     override suspend fun verifyEphemeralKeyRegistration(code: String, privateKey: ByteArray?): RegisterEphemeralKeyResponse {
@@ -50,7 +48,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun verifyEphemeralKeyRegistrationAsync(code: String, privateKey: ByteArray?): CompletableFuture<RegisterEphemeralKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.verifyEphemeralKeyRegistrationRequest(code, privateKey) }
+        return completableFuture { verifyEphemeralKeyRegistration(code, privateKey) }
     }
 
     override suspend fun reverifyEmail() {
@@ -58,7 +56,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun reverifyEmailAsync(): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.reverifyEmailRequest() }
+        return completableFuture { reverifyEmail() }
     }
 
     override suspend fun changePassword(oldPassword: String, newPassword: String) {
@@ -66,7 +64,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun changePasswordAsync(oldPassword: String, newPassword: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.changePasswordRequest(oldPassword, newPassword) }
+        return completableFuture { changePassword(oldPassword, newPassword) }
     }
 
     override suspend fun getUserDetails(): UserDetailsResponse {
@@ -74,7 +72,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun getUserDetailsAsync(): CompletableFuture<UserDetailsResponse> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.getUserDetailsRequest() }
+        return completableFuture { getUserDetails() }
     }
 
     override suspend fun updateUserDetails(displayName: String) {
@@ -82,7 +80,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun updateUserDetailsAsync(displayName: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.updateUserDetailsRequest(displayName) }
+        return completableFuture { updateUserDetails(displayName) }
     }
 
     override suspend fun deleteAccount() {
@@ -90,6 +88,6 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun deleteAccountAsync(): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.deleteAccountRequest() }
+        return completableFuture { deleteAccount() }
     }
 }

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountlessResourceImpl.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountlessResourceImpl.android.kt
@@ -2,9 +2,7 @@ package com.doordeck.multiplatform.sdk.internal.api
 
 import com.doordeck.multiplatform.sdk.api.AccountlessResource
 import com.doordeck.multiplatform.sdk.api.responses.TokenResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object AccountlessResourceImpl : AccountlessResource {
@@ -14,7 +12,7 @@ internal object AccountlessResourceImpl : AccountlessResource {
     }
 
     override fun loginAsync(email: String, password: String): CompletableFuture<TokenResponse> {
-        return GlobalScope.future(Dispatchers.IO) { AccountlessClient.loginRequest(email, password) }
+        return completableFuture { login(email, password) }
     }
 
     override suspend fun registration(email: String, password: String, displayName: String?, force: Boolean, publicKey: ByteArray?): TokenResponse {
@@ -22,7 +20,7 @@ internal object AccountlessResourceImpl : AccountlessResource {
     }
 
     override fun registrationAsync(email: String, password: String, displayName: String?, force: Boolean, publicKey: ByteArray?): CompletableFuture<TokenResponse> {
-        return GlobalScope.future(Dispatchers.IO) { AccountlessClient.registrationRequest(email, password, displayName, force, publicKey) }
+        return completableFuture { registration(email, password, displayName, force, publicKey) }
     }
 
     override suspend fun verifyEmail(code: String) {
@@ -30,7 +28,7 @@ internal object AccountlessResourceImpl : AccountlessResource {
     }
 
     override fun verifyEmailAsync(code: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountlessClient.verifyEmailRequest(code) }
+        return completableFuture { verifyEmail(code) }
     }
 
     override suspend fun passwordReset(email: String) {
@@ -38,14 +36,14 @@ internal object AccountlessResourceImpl : AccountlessResource {
     }
 
     override fun passwordResetAsync(email: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountlessClient.passwordResetRequest(email) }
+        return completableFuture { passwordReset(email) }
     }
 
     override suspend fun passwordResetVerify(userId: String, token: String, password: String) {
-        AccountlessClient.passwordResetVerifyRequest(userId, token, password)
+        return AccountlessClient.passwordResetVerifyRequest(userId, token, password)
     }
 
     override fun passwordResetVerifyAsync(userId: String, token: String, password: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountlessClient.passwordResetVerifyRequest(userId, token, password) }
+        return completableFuture { passwordResetVerify(userId, token, password) }
     }
 }

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/FusionResourceImpl.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/FusionResourceImpl.android.kt
@@ -6,9 +6,7 @@ import com.doordeck.multiplatform.sdk.api.responses.DoorStateResponse
 import com.doordeck.multiplatform.sdk.api.responses.FusionLoginResponse
 import com.doordeck.multiplatform.sdk.api.responses.IntegrationConfigurationResponse
 import com.doordeck.multiplatform.sdk.api.responses.IntegrationTypeResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object FusionResourceImpl : FusionResource {
@@ -18,7 +16,7 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun loginAsync(email: String, password: String): CompletableFuture<FusionLoginResponse> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.loginRequest(email, password) }
+        return completableFuture { login(email, password) }
     }
 
     override suspend fun getIntegrationType(): IntegrationTypeResponse {
@@ -26,7 +24,7 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun getIntegrationTypeAsync(): CompletableFuture<IntegrationTypeResponse> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.getIntegrationTypeRequest() }
+        return completableFuture { getIntegrationType() }
     }
 
     override suspend fun getIntegrationConfiguration(type: String): List<IntegrationConfigurationResponse> {
@@ -34,7 +32,7 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun getIntegrationConfigurationAsync(type: String): CompletableFuture<List<IntegrationConfigurationResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.getIntegrationConfigurationRequest(type) }
+        return completableFuture { getIntegrationConfiguration(type) }
     }
 
     override suspend fun enableDoor(name: String, siteId: String, controller: Fusion.LockController) {
@@ -42,7 +40,7 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun enableDoorAsync(name: String, siteId: String, controller: Fusion.LockController): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.enableDoorRequest(name, siteId, controller) }
+        return completableFuture { enableDoor(name, siteId, controller) }
     }
 
     override suspend fun deleteDoor(deviceId: String) {
@@ -50,7 +48,7 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun deleteDoorAsync(deviceId: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.deleteDoorRequest(deviceId) }
+        return completableFuture { deleteDoor(deviceId) }
     }
 
     override suspend fun getDoorStatus(deviceId: String): DoorStateResponse {
@@ -58,7 +56,7 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun getDoorStatusAsync(deviceId: String): CompletableFuture<DoorStateResponse> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.getDoorStatusRequest(deviceId) }
+        return completableFuture { getDoorStatus(deviceId) }
     }
 
     override suspend fun startDoor(deviceId: String) {
@@ -66,14 +64,14 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun startDoorAsync(deviceId: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.startDoorRequest(deviceId) }
+        return completableFuture { startDoor(deviceId) }
     }
 
     override suspend fun stopDoor(deviceId: String) {
         return FusionClient.stopDoorRequest(deviceId)
     }
 
-    override suspend fun stopDoorAsync(deviceId: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.stopDoorRequest(deviceId) }
+    override fun stopDoorAsync(deviceId: String): CompletableFuture<Unit> {
+        return completableFuture { stopDoor(deviceId) }
     }
 }

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/HelperResourceImpl.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/HelperResourceImpl.android.kt
@@ -3,9 +3,7 @@ package com.doordeck.multiplatform.sdk.internal.api
 import com.doordeck.multiplatform.sdk.api.HelperResource
 import com.doordeck.multiplatform.sdk.api.responses.AssistedLoginResponse
 import com.doordeck.multiplatform.sdk.api.responses.AssistedRegisterEphemeralKeyResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object HelperResourceImpl : HelperResource {
@@ -15,7 +13,7 @@ internal object HelperResourceImpl : HelperResource {
     }
 
     override fun uploadPlatformLogoAsync(applicationId: String, contentType: String, image: ByteArray): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { HelperClient.uploadPlatformLogoRequest(applicationId, contentType, image) }
+        return completableFuture { uploadPlatformLogo(applicationId, contentType, image) }
     }
 
     override suspend fun assistedLogin(email: String, password: String): AssistedLoginResponse {
@@ -23,7 +21,7 @@ internal object HelperResourceImpl : HelperResource {
     }
 
     override fun assistedLoginAsync(email: String, password: String): CompletableFuture<AssistedLoginResponse> {
-        return GlobalScope.future(Dispatchers.IO) { HelperClient.assistedLoginRequest(email, password) }
+        return completableFuture { assistedLogin(email, password) }
     }
 
     override suspend fun assistedRegisterEphemeralKey(publicKey: ByteArray?): AssistedRegisterEphemeralKeyResponse {
@@ -31,7 +29,7 @@ internal object HelperResourceImpl : HelperResource {
     }
 
     override fun assistedRegisterEphemeralKeyAsync(publicKey: ByteArray?): CompletableFuture<AssistedRegisterEphemeralKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { HelperClient.assistedRegisterEphemeralKeyRequest(publicKey) }
+        return completableFuture { assistedRegisterEphemeralKey(publicKey) }
     }
 
     override suspend fun assistedRegister(email: String, password: String, displayName: String?, force: Boolean) {
@@ -39,6 +37,6 @@ internal object HelperResourceImpl : HelperResource {
     }
 
     override fun assistedRegisterAsync(email: String, password: String, displayName: String?, force: Boolean): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { HelperClient.assistedRegisterRequest(email, password, displayName, force) }
+        return completableFuture { assistedRegister(email, password, displayName, force) }
     }
 }

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.android.kt
@@ -219,7 +219,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun batchShareLockAsync(batchShareLockOperation: LockOperations.BatchShareLockOperation): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.batchShareLockRequest(batchShareLockOperation) }
+        return completableFuture { LockOperationsClient.batchShareLockRequest(batchShareLockOperation) }
     }
 
     override suspend fun revokeAccessToLock(revokeAccessToLockOperation: LockOperations.RevokeAccessToLockOperation) {

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.android.kt
@@ -9,19 +9,17 @@ import com.doordeck.multiplatform.sdk.api.responses.LockUserResponse
 import com.doordeck.multiplatform.sdk.api.responses.ShareableLockResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserLockResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserPublicKeyResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object LockOperationsResourceImpl : LockOperationsResource {
-    
+
     override suspend fun getSingleLock(lockId: String): LockResponse {
         return LockOperationsClient.getSingleLockRequest(lockId)
     }
 
     override fun getSingleLockAsync(lockId: String): CompletableFuture<LockResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getSingleLockRequest(lockId) }
+        return completableFuture { getSingleLock(lockId) }
     }
 
     override suspend fun getLockAuditTrail(lockId: String, start: Int, end: Int): List<AuditResponse> {
@@ -29,7 +27,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getLockAuditTrailAsync(lockId: String, start: Int, end: Int): CompletableFuture<List<AuditResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getLockAuditTrailRequest(lockId, start, end) }
+        return completableFuture { getLockAuditTrail(lockId, start, end) }
     }
 
     override suspend fun getAuditForUser(userId: String, start: Int, end: Int): List<AuditResponse> {
@@ -37,7 +35,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getAuditForUserAsync(userId: String, start: Int, end: Int): CompletableFuture<List<AuditResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getAuditForUserRequest(userId, start, end) }
+        return completableFuture { getAuditForUser(userId, start, end) }
     }
 
     override suspend fun getUsersForLock(lockId: String): List<UserLockResponse> {
@@ -45,7 +43,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUsersForLockAsync(lockId: String): CompletableFuture<List<UserLockResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUsersForLockRequest(lockId) }
+        return completableFuture { getUsersForLock(lockId) }
     }
 
     override suspend fun getLocksForUser(userId: String): LockUserResponse {
@@ -53,7 +51,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getLocksForUserAsync(userId: String): CompletableFuture<LockUserResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getLocksForUserRequest(userId) }
+        return completableFuture { getLocksForUser(userId) }
     }
 
     override suspend fun updateLockName(lockId: String, name: String?) {
@@ -61,7 +59,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateLockNameAsync(lockId: String, name: String?): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateLockNameRequest(lockId, name) }
+        return completableFuture { updateLockName(lockId, name) }
     }
 
     override suspend fun updateLockFavourite(lockId: String, favourite: Boolean?) {
@@ -69,7 +67,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateLockFavouriteAsync(lockId: String, favourite: Boolean?): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateLockFavouriteRequest(lockId, favourite) }
+        return completableFuture { updateLockFavourite(lockId, favourite) }
     }
 
     override suspend fun updateLockColour(lockId: String, colour: String?) {
@@ -77,7 +75,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateLockColourAsync(lockId: String, colour: String?): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateLockColourRequest(lockId, colour) }
+        return completableFuture { updateLockColour(lockId, colour) }
     }
 
     override suspend fun updateLockSettingDefaultName(lockId: String, name: String?) {
@@ -85,7 +83,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateLockSettingDefaultNameAsync(lockId: String, name: String?): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateLockSettingDefaultNameRequest(lockId, name) }
+        return completableFuture { updateLockSettingDefaultName(lockId, name) }
     }
 
     override suspend fun setLockSettingPermittedAddresses(lockId: String, permittedAddresses: List<String>) {
@@ -93,7 +91,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun setLockSettingPermittedAddressesAsync(lockId: String, permittedAddresses: List<String>): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.setLockSettingPermittedAddressesRequest(lockId, permittedAddresses) }
+        return completableFuture { setLockSettingPermittedAddresses(lockId, permittedAddresses) }
     }
 
     override suspend fun updateLockSettingHidden(lockId: String, hidden: Boolean) {
@@ -101,7 +99,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateLockSettingHiddenAsync(lockId: String, hidden: Boolean): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateLockSettingHiddenRequest(lockId, hidden) }
+        return completableFuture { updateLockSettingHidden(lockId, hidden) }
     }
 
     override suspend fun setLockSettingTimeRestrictions(lockId: String, times: List<LockOperations.TimeRequirement>) {
@@ -109,7 +107,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun setLockSettingTimeRestrictionsAsync(lockId: String, times: List<LockOperations.TimeRequirement>): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.setLockSettingTimeRestrictionsRequest(lockId, times) }
+        return completableFuture { setLockSettingTimeRestrictions(lockId, times) }
     }
 
     override suspend fun updateLockSettingLocationRestrictions(lockId: String, location: LockOperations.LocationRequirement?) {
@@ -117,7 +115,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateLockSettingLocationRestrictionsAsync(lockId: String, location: LockOperations.LocationRequirement?): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateLockSettingLocationRestrictionsRequest(lockId, location) }
+        return completableFuture { updateLockSettingLocationRestrictions(lockId, location) }
     }
 
     override suspend fun getUserPublicKey(userEmail: String, visitor: Boolean): UserPublicKeyResponse {
@@ -125,7 +123,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override suspend fun getUserPublicKeyAsync(userEmail: String, visitor: Boolean): CompletableFuture<UserPublicKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyRequest(userEmail, visitor) }
+        return completableFuture { getUserPublicKey(userEmail, visitor) }
     }
 
     override suspend fun getUserPublicKeyByEmail(email: String): UserPublicKeyResponse {
@@ -133,7 +131,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByEmailAsync(email: String): CompletableFuture<UserPublicKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByEmailRequest(email) }
+        return completableFuture { getUserPublicKeyByEmail(email) }
     }
 
     override suspend fun getUserPublicKeyByTelephone(telephone: String): UserPublicKeyResponse {
@@ -141,7 +139,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByTelephoneAsync(telephone: String): CompletableFuture<UserPublicKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByTelephoneRequest(telephone) }
+        return completableFuture { getUserPublicKeyByTelephone(telephone) }
     }
 
     override suspend fun getUserPublicKeyByLocalKey(localKey: String): UserPublicKeyResponse {
@@ -149,7 +147,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByLocalKeyAsync(localKey: String): CompletableFuture<UserPublicKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByLocalKeyRequest(localKey) }
+        return completableFuture { getUserPublicKeyByLocalKey(localKey) }
     }
 
     override suspend fun getUserPublicKeyByForeignKey(foreignKey: String): UserPublicKeyResponse {
@@ -157,7 +155,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByForeignKeyAsync(foreignKey: String): CompletableFuture<UserPublicKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByForeignKeyRequest(foreignKey) }
+        return completableFuture { getUserPublicKeyByForeignKey(foreignKey) }
     }
 
     override suspend fun getUserPublicKeyByIdentity(identity: String): UserPublicKeyResponse {
@@ -165,7 +163,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByIdentityAsync(identity: String): CompletableFuture<UserPublicKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByIdentityRequest(identity) }
+        return completableFuture { getUserPublicKeyByIdentity(identity) }
     }
 
     override suspend fun getUserPublicKeyByEmails(emails: List<String>): List<BatchUserPublicKeyResponse> {
@@ -173,7 +171,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByEmailsAsync(emails: List<String>): CompletableFuture<List<BatchUserPublicKeyResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByEmailsRequest(emails) }
+        return completableFuture { getUserPublicKeyByEmails(emails) }
     }
 
     override suspend fun getUserPublicKeyByTelephones(telephones: List<String>): List<BatchUserPublicKeyResponse> {
@@ -181,7 +179,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByTelephonesAsync(telephones: List<String>): CompletableFuture<List<BatchUserPublicKeyResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByTelephonesRequest(telephones) }
+        return completableFuture { getUserPublicKeyByTelephones(telephones) }
     }
 
     override suspend fun getUserPublicKeyByLocalKeys(localKeys: List<String>): List<BatchUserPublicKeyResponse> {
@@ -189,7 +187,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByLocalKeysAsync(localKeys: List<String>): CompletableFuture<List<BatchUserPublicKeyResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByLocalKeysRequest(localKeys) }
+        return completableFuture { getUserPublicKeyByLocalKeys(localKeys) }
     }
 
     override suspend fun getUserPublicKeyByForeignKeys(foreignKeys: List<String>): List<BatchUserPublicKeyResponse> {
@@ -197,7 +195,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByForeignKeysAsync(foreignKeys: List<String>): CompletableFuture<List<BatchUserPublicKeyResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByForeignKeysRequest(foreignKeys) }
+        return completableFuture { getUserPublicKeyByForeignKeys(foreignKeys) }
     }
 
     override suspend fun unlock(unlockOperation: LockOperations.UnlockOperation) {
@@ -205,7 +203,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun unlockAsync(unlockOperation: LockOperations.UnlockOperation): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.unlockRequest(unlockOperation) }
+        return completableFuture { unlock(unlockOperation) }
     }
 
     override suspend fun shareLock(shareLockOperation: LockOperations.ShareLockOperation) {
@@ -213,7 +211,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun shareLockAsync(shareLockOperation: LockOperations.ShareLockOperation): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.shareLockRequest(shareLockOperation) }
+        return completableFuture { shareLock(shareLockOperation) }
     }
 
     override suspend fun revokeAccessToLock(revokeAccessToLockOperation: LockOperations.RevokeAccessToLockOperation) {
@@ -221,7 +219,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun revokeAccessToLockAsync(revokeAccessToLockOperation: LockOperations.RevokeAccessToLockOperation): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.revokeAccessToLockRequest(revokeAccessToLockOperation) }
+        return completableFuture { revokeAccessToLock(revokeAccessToLockOperation) }
     }
 
     override suspend fun updateSecureSettingUnlockDuration(updateSecureSettingUnlockDuration: LockOperations.UpdateSecureSettingUnlockDuration) {
@@ -229,7 +227,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateSecureSettingUnlockDurationAsync(updateSecureSettingUnlockDuration: LockOperations.UpdateSecureSettingUnlockDuration): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateSecureSettingUnlockDurationRequest(updateSecureSettingUnlockDuration) }
+        return completableFuture { updateSecureSettingUnlockDuration(updateSecureSettingUnlockDuration) }
     }
 
     override suspend fun updateSecureSettingUnlockBetween(updateSecureSettingUnlockBetween: LockOperations.UpdateSecureSettingUnlockBetween) {
@@ -237,7 +235,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateSecureSettingUnlockBetweenAsync(updateSecureSettingUnlockBetween: LockOperations.UpdateSecureSettingUnlockBetween): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateSecureSettingUnlockBetweenRequest(updateSecureSettingUnlockBetween) }
+        return completableFuture { updateSecureSettingUnlockBetween(updateSecureSettingUnlockBetween) }
     }
 
     override suspend fun getPinnedLocks(): List<LockResponse> {
@@ -245,7 +243,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getPinnedLocksAsync(): CompletableFuture<List<LockResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getPinnedLocksRequest() }
+        return completableFuture { getPinnedLocks() }
     }
 
     override suspend fun getShareableLocks(): List<ShareableLockResponse> {
@@ -253,6 +251,6 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getShareableLocksAsync(): CompletableFuture<List<ShareableLockResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getShareableLocksRequest() }
+        return completableFuture { getShareableLocks() }
     }
 }

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/PlatformResourceImpl.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/PlatformResourceImpl.android.kt
@@ -5,9 +5,7 @@ import com.doordeck.multiplatform.sdk.api.model.Platform
 import com.doordeck.multiplatform.sdk.api.responses.ApplicationOwnerDetailsResponse
 import com.doordeck.multiplatform.sdk.api.responses.ApplicationResponse
 import com.doordeck.multiplatform.sdk.api.responses.GetLogoUploadUrlResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object PlatformResourceImpl : PlatformResource {
@@ -17,7 +15,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun createApplicationAsync(application: Platform.CreateApplication): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.createApplicationRequest(application) }
+        return completableFuture { createApplication(application) }
     }
 
     override suspend fun listApplications(): List<ApplicationResponse> {
@@ -25,7 +23,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun listApplicationsAsync(): CompletableFuture<List<ApplicationResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.listApplicationsRequest() }
+        return completableFuture { listApplications() }
     }
 
     override suspend fun getApplication(applicationId: String): ApplicationResponse {
@@ -33,7 +31,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun getApplicationAsync(applicationId: String): CompletableFuture<ApplicationResponse> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.getApplicationRequest(applicationId) }
+        return completableFuture { getApplication(applicationId) }
     }
 
     override suspend fun updateApplicationName(applicationId: String, name: String) {
@@ -41,7 +39,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationNameAsync(applicationId: String, name: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationNameRequest(applicationId, name) }
+        return completableFuture { updateApplicationName(applicationId, name) }
     }
 
     override suspend fun updateApplicationCompanyName(applicationId: String, companyName: String) {
@@ -49,7 +47,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationCompanyNameAsync(applicationId: String, companyName: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationCompanyNameRequest(applicationId, companyName) }
+        return completableFuture { updateApplicationCompanyName(applicationId, companyName) }
     }
 
     override suspend fun updateApplicationMailingAddress(applicationId: String, mailingAddress: String) {
@@ -57,7 +55,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationMailingAddressAsync(applicationId: String, mailingAddress: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationMailingAddressRequest(applicationId, mailingAddress) }
+        return completableFuture { updateApplicationMailingAddress(applicationId, mailingAddress) }
     }
 
     override suspend fun updateApplicationPrivacyPolicy(applicationId: String, privacyPolicy: String) {
@@ -65,7 +63,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationPrivacyPolicyAsync(applicationId: String, privacyPolicy: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationPrivacyPolicyRequest(applicationId, privacyPolicy) }
+        return completableFuture { updateApplicationPrivacyPolicy(applicationId, privacyPolicy) }
     }
 
     override suspend fun updateApplicationSupportContact(applicationId: String, supportContact: String) {
@@ -73,7 +71,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationSupportContactAsync(applicationId: String, supportContact: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationSupportContactRequest(applicationId, supportContact) }
+        return completableFuture { updateApplicationSupportContact(applicationId, supportContact) }
     }
 
     override suspend fun updateApplicationAppLink(applicationId: String, appLink: String) {
@@ -81,7 +79,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationAppLinkAsync(applicationId: String, appLink: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationAppLinkRequest(applicationId, appLink) }
+        return completableFuture { updateApplicationAppLink(applicationId, appLink) }
     }
 
     override suspend fun updateApplicationEmailPreferences(applicationId: String, emailPreferences: Platform.EmailPreferences) {
@@ -89,7 +87,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationEmailPreferencesAsync(applicationId: String, emailPreferences: Platform.EmailPreferences): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationEmailPreferencesRequest(applicationId, emailPreferences) }
+        return completableFuture { updateApplicationEmailPreferences(applicationId, emailPreferences) }
     }
 
     override suspend fun updateApplicationLogoUrl(applicationId: String, logoUrl: String) {
@@ -97,7 +95,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationLogoUrlAsync(applicationId: String, logoUrl: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationLogoUrlRequest(applicationId, logoUrl) }
+        return completableFuture { updateApplicationLogoUrl(applicationId, logoUrl) }
     }
 
     override suspend fun deleteApplication(applicationId: String) {
@@ -105,7 +103,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun deleteApplicationAsync(applicationId: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.deleteApplicationRequest(applicationId) }
+        return completableFuture { deleteApplication(applicationId) }
     }
 
     override suspend fun getLogoUploadUrl(applicationId: String, contentType: String): GetLogoUploadUrlResponse {
@@ -113,7 +111,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun getLogoUploadUrlAsync(applicationId: String, contentType: String): CompletableFuture<GetLogoUploadUrlResponse> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.getLogoUploadUrlRequest(applicationId, contentType) }
+        return completableFuture { getLogoUploadUrl(applicationId, contentType) }
     }
 
     override suspend fun addAuthKey(applicationId: String, key: Platform.AuthKey) {
@@ -121,7 +119,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun addAuthKeyAsync(applicationId: String, key: Platform.AuthKey): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.addAuthKeyRequest(applicationId, key) }
+        return completableFuture { addAuthKey(applicationId, key) }
     }
 
     override suspend fun addAuthIssuer(applicationId: String, url: String) {
@@ -129,7 +127,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun addAuthIssuerAsync(applicationId: String, url: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.addAuthIssuerRequest(applicationId, url) }
+        return completableFuture { addAuthIssuer(applicationId, url) }
     }
 
     override suspend fun deleteAuthIssuer(applicationId: String, url: String) {
@@ -137,7 +135,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun deleteAuthIssuerAsync(applicationId: String, url: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.deleteAuthIssuerRequest(applicationId, url) }
+        return completableFuture { deleteAuthIssuer(applicationId, url) }
     }
 
     override suspend fun addCorsDomain(applicationId: String, url: String) {
@@ -145,7 +143,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun addCorsDomainAsync(applicationId: String, url: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.addCorsDomainRequest(applicationId, url) }
+        return completableFuture { addCorsDomain(applicationId, url) }
     }
 
     override suspend fun removeCorsDomain(applicationId: String, url: String) {
@@ -153,7 +151,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun removeCorsDomainAsync(applicationId: String, url: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.removeCorsDomainRequest(applicationId, url) }
+        return completableFuture { removeCorsDomain(applicationId, url) }
     }
 
     override suspend fun addApplicationOwner(applicationId: String, userId: String) {
@@ -161,7 +159,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun addApplicationOwnerAsync(applicationId: String, userId: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.addApplicationOwnerRequest(applicationId, userId) }
+        return completableFuture { addApplicationOwner(applicationId, userId) }
     }
 
     override suspend fun removeApplicationOwner(applicationId: String, userId: String) {
@@ -169,7 +167,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun removeApplicationOwnerAsync(applicationId: String, userId: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.removeApplicationOwnerRequest(applicationId, userId) }
+        return completableFuture { removeApplicationOwner(applicationId, userId) }
     }
 
     override suspend fun getApplicationOwnersDetails(applicationId: String): List<ApplicationOwnerDetailsResponse> {
@@ -177,6 +175,6 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun getApplicationOwnersDetailsAsync(applicationId: String): CompletableFuture<List<ApplicationOwnerDetailsResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.getApplicationOwnersDetailsRequest(applicationId) }
+        return completableFuture { getApplicationOwnersDetails(applicationId) }
     }
 }

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/SitesResourceImpl.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/SitesResourceImpl.android.kt
@@ -4,9 +4,7 @@ import com.doordeck.multiplatform.sdk.api.SitesResource
 import com.doordeck.multiplatform.sdk.api.responses.SiteLocksResponse
 import com.doordeck.multiplatform.sdk.api.responses.SiteResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserForSiteResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object SitesResourceImpl : SitesResource {
@@ -16,7 +14,7 @@ internal object SitesResourceImpl : SitesResource {
     }
 
     override fun listSitesAsync(): CompletableFuture<List<SiteResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { SitesClient.listSitesRequest() }
+        return completableFuture { listSites() }
     }
 
     override suspend fun getLocksForSite(siteId: String): List<SiteLocksResponse> {
@@ -24,7 +22,7 @@ internal object SitesResourceImpl : SitesResource {
     }
 
     override fun getLocksForSiteAsync(siteId: String): CompletableFuture<List<SiteLocksResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { SitesClient.getLocksForSiteRequest(siteId) }
+        return completableFuture { getLocksForSite(siteId) }
     }
 
     override suspend fun getUsersForSite(siteId: String): List<UserForSiteResponse> {
@@ -32,6 +30,6 @@ internal object SitesResourceImpl : SitesResource {
     }
 
     override fun getUsersForSiteAsync(siteId: String): CompletableFuture<List<UserForSiteResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { SitesClient.getUsersForSiteRequest(siteId) }
+        return completableFuture { getUsersForSite(siteId) }
     }
 }

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/TilesResourceImpl.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/TilesResourceImpl.android.kt
@@ -2,9 +2,7 @@ package com.doordeck.multiplatform.sdk.internal.api
 
 import com.doordeck.multiplatform.sdk.api.TilesResource
 import com.doordeck.multiplatform.sdk.api.responses.TileLocksResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object TilesResourceImpl : TilesResource {
@@ -14,7 +12,7 @@ internal object TilesResourceImpl : TilesResource {
     }
 
     override fun getLocksBelongingToTileAsync(tileId: String): CompletableFuture<TileLocksResponse> {
-        return GlobalScope.future(Dispatchers.IO) { TilesClient.getLocksBelongingToTileRequest(tileId) }
+        return completableFuture { getLocksBelongingToTile(tileId) }
     }
 
     override suspend fun associateMultipleLocks(tileId: String, siteId: String, lockIds: List<String>) {
@@ -22,6 +20,6 @@ internal object TilesResourceImpl : TilesResource {
     }
 
     override fun associateMultipleLocksAsync(tileId: String, siteId: String, lockIds: List<String>): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { TilesClient.associateMultipleLocksRequest(tileId, siteId, lockIds) }
+        return completableFuture { associateMultipleLocks(tileId, siteId, lockIds) }
     }
 }

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.android.kt
@@ -4,8 +4,12 @@ import com.doordeck.multiplatform.sdk.Constants.CERTIFICATE_PINNER_DOMAIN_PATTER
 import com.doordeck.multiplatform.sdk.Constants.TRUSTED_CERTIFICATES
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.okhttp.OkHttpConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.future
 import okhttp3.CertificatePinner
 import okhttp3.OkHttpClient
+import java.util.concurrent.CompletableFuture
 
 internal actual fun HttpClientConfig<*>.installCertificatePinner() {
     engine {
@@ -17,5 +21,23 @@ internal actual fun HttpClientConfig<*>.installCertificatePinner() {
                 .certificatePinner(certificatePinner)
                 .build()
         }
+    }
+}
+
+/**
+ * Creates a `CompletableFuture` from a suspendable function.
+ *
+ * This function executes the given suspend function within a coroutine context
+ * and returns a `CompletableFuture` that completes once the suspend function
+ * finishes. The coroutine is launched in the `IO` dispatcher.
+ *
+ * @param T The type of the result produced by the suspend function.
+ * @param block The suspend function that will be executed asynchronously.
+ *
+ * @return A `CompletableFuture` that completes with the result of the suspend function.
+ */
+internal inline fun <reified T>completableFuture(crossinline block: suspend () -> T): CompletableFuture<T> {
+    return GlobalScope.future(Dispatchers.IO) {
+        block()
     }
 }

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountResourceImpl.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountResourceImpl.js.kt
@@ -6,49 +6,48 @@ import com.doordeck.multiplatform.sdk.api.responses.RegisterEphemeralKeyResponse
 import com.doordeck.multiplatform.sdk.api.responses.RegisterEphemeralKeyWithSecondaryAuthenticationResponse
 import com.doordeck.multiplatform.sdk.api.responses.TokenResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserDetailsResponse
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.promise
+import com.doordeck.multiplatform.sdk.util.promise
 import kotlin.js.Promise
 
 internal object AccountResourceImpl : AccountResource {
 
     override fun refreshToken(refreshToken: String?): Promise<TokenResponse> {
-        return GlobalScope.promise { AccountClient.refreshTokenRequest(refreshToken) }
+        return promise { AccountClient.refreshTokenRequest(refreshToken) }
     }
 
     override fun logout(): Promise<Unit> {
-        return GlobalScope.promise { AccountClient.logoutRequest() }
+        return promise { AccountClient.logoutRequest() }
     }
 
     override fun registerEphemeralKey(publicKey: ByteArray?): Promise<RegisterEphemeralKeyResponse> {
-        return GlobalScope.promise { AccountClient.registerEphemeralKeyRequest(publicKey) }
+        return promise { AccountClient.registerEphemeralKeyRequest(publicKey) }
     }
 
     override fun registerEphemeralKeyWithSecondaryAuthentication(publicKey: ByteArray?, method: TwoFactorMethod?): Promise<RegisterEphemeralKeyWithSecondaryAuthenticationResponse> {
-        return GlobalScope.promise { AccountClient.registerEphemeralKeyWithSecondaryAuthenticationRequest(publicKey, method) }
+        return promise { AccountClient.registerEphemeralKeyWithSecondaryAuthenticationRequest(publicKey, method) }
     }
 
     override fun verifyEphemeralKeyRegistration(code: String, privateKey: ByteArray?): Promise<RegisterEphemeralKeyResponse> {
-        return GlobalScope.promise { AccountClient.verifyEphemeralKeyRegistrationRequest(code, privateKey) }
+        return promise { AccountClient.verifyEphemeralKeyRegistrationRequest(code, privateKey) }
     }
 
     override fun reverifyEmail(): Promise<Unit> {
-        return GlobalScope.promise { AccountClient.reverifyEmailRequest() }
+        return promise { AccountClient.reverifyEmailRequest() }
     }
 
     override fun changePassword(oldPassword: String, newPassword: String): Promise<Unit> {
-        return GlobalScope.promise { AccountClient.changePasswordRequest(oldPassword, newPassword) }
+        return promise { AccountClient.changePasswordRequest(oldPassword, newPassword) }
     }
 
     override fun getUserDetails(): Promise<UserDetailsResponse> {
-        return GlobalScope.promise { AccountClient.getUserDetailsRequest() }
+        return promise { AccountClient.getUserDetailsRequest() }
     }
 
     override fun updateUserDetails(displayName: String): Promise<Unit> {
-        return GlobalScope.promise { AccountClient.updateUserDetailsRequest(displayName) }
+        return promise { AccountClient.updateUserDetailsRequest(displayName) }
     }
 
     override fun deleteAccount(): Promise<Unit> {
-        return GlobalScope.promise { AccountClient.deleteAccountRequest() }
+        return promise { AccountClient.deleteAccountRequest() }
     }
 }

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountlessResourceImpl.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountlessResourceImpl.js.kt
@@ -2,29 +2,28 @@ package com.doordeck.multiplatform.sdk.internal.api
 
 import com.doordeck.multiplatform.sdk.api.AccountlessResource
 import com.doordeck.multiplatform.sdk.api.responses.TokenResponse
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.promise
+import com.doordeck.multiplatform.sdk.util.promise
 import kotlin.js.Promise
 
 internal object AccountlessResourceImpl : AccountlessResource {
 
     override fun login(email: String, password: String): Promise<TokenResponse> {
-        return GlobalScope.promise { AccountlessClient.loginRequest(email, password) }
+        return promise { AccountlessClient.loginRequest(email, password) }
     }
 
     override fun registration(email: String, password: String, displayName: String?, force: Boolean, publicKey: ByteArray?): Promise<TokenResponse> {
-        return GlobalScope.promise { AccountlessClient.registrationRequest(email, password, displayName, force, publicKey) }
+        return promise { AccountlessClient.registrationRequest(email, password, displayName, force, publicKey) }
     }
 
     override fun verifyEmail(code: String): Promise<Unit> {
-        return GlobalScope.promise { AccountlessClient.verifyEmailRequest(code) }
+        return promise { AccountlessClient.verifyEmailRequest(code) }
     }
 
     override fun passwordReset(email: String): Promise<dynamic> {
-        return GlobalScope.promise { AccountlessClient.passwordResetRequest(email) }
+        return promise { AccountlessClient.passwordResetRequest(email) }
     }
 
     override fun passwordResetVerify(userId: String, token: String, password: String): Promise<dynamic> {
-        return GlobalScope.promise { AccountlessClient.passwordResetVerifyRequest(userId, token, password) }
+        return promise { AccountlessClient.passwordResetVerifyRequest(userId, token, password) }
     }
 }

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/FusionResourceImpl.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/FusionResourceImpl.js.kt
@@ -6,41 +6,40 @@ import com.doordeck.multiplatform.sdk.api.responses.DoorStateResponse
 import com.doordeck.multiplatform.sdk.api.responses.FusionLoginResponse
 import com.doordeck.multiplatform.sdk.api.responses.IntegrationConfigurationResponse
 import com.doordeck.multiplatform.sdk.api.responses.IntegrationTypeResponse
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.promise
+import com.doordeck.multiplatform.sdk.util.promise
 import kotlin.js.Promise
 
 internal object FusionResourceImpl : FusionResource {
 
     override fun login(email: String, password: String): Promise<FusionLoginResponse> {
-        return GlobalScope.promise { FusionClient.loginRequest(email, password) }
+        return promise { FusionClient.loginRequest(email, password) }
     }
 
     override fun getIntegrationType(): Promise<IntegrationTypeResponse> {
-        return GlobalScope.promise { FusionClient.getIntegrationTypeRequest() }
+        return promise { FusionClient.getIntegrationTypeRequest() }
     }
 
     override fun getIntegrationConfiguration(type: String): Promise<List<IntegrationConfigurationResponse>> {
-        return GlobalScope.promise { FusionClient.getIntegrationConfigurationRequest(type) }
+        return promise { FusionClient.getIntegrationConfigurationRequest(type) }
     }
 
     override fun enableDoor(name: String, siteId: String, controller: Fusion.LockController): Promise<Unit> {
-        return GlobalScope.promise { FusionClient.enableDoorRequest(name, siteId, controller) }
+        return promise { FusionClient.enableDoorRequest(name, siteId, controller) }
     }
 
     override fun deleteDoor(deviceId: String): Promise<Unit> {
-        return GlobalScope.promise { FusionClient.deleteDoorRequest(deviceId) }
+        return promise { FusionClient.deleteDoorRequest(deviceId) }
     }
 
     override fun getDoorStatus(deviceId: String): Promise<DoorStateResponse> {
-        return GlobalScope.promise { FusionClient.getDoorStatusRequest(deviceId) }
+        return promise { FusionClient.getDoorStatusRequest(deviceId) }
     }
 
     override fun startDoor(deviceId: String): Promise<Unit> {
-        return GlobalScope.promise { FusionClient.startDoorRequest(deviceId) }
+        return promise { FusionClient.startDoorRequest(deviceId) }
     }
 
     override fun stopDoor(deviceId: String): Promise<Unit> {
-        return GlobalScope.promise { FusionClient.stopDoorRequest(deviceId) }
+        return promise { FusionClient.stopDoorRequest(deviceId) }
     }
 }

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/HelperResourceImpl.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/HelperResourceImpl.js.kt
@@ -3,25 +3,24 @@ package com.doordeck.multiplatform.sdk.internal.api
 import com.doordeck.multiplatform.sdk.api.HelperResource
 import com.doordeck.multiplatform.sdk.api.responses.AssistedLoginResponse
 import com.doordeck.multiplatform.sdk.api.responses.AssistedRegisterEphemeralKeyResponse
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.promise
+import com.doordeck.multiplatform.sdk.util.promise
 import kotlin.js.Promise
 
 internal object HelperResourceImpl : HelperResource {
 
     override fun uploadPlatformLogo(applicationId: String, contentType: String, image: ByteArray): Promise<Unit> {
-        return GlobalScope.promise { HelperClient.uploadPlatformLogoRequest(applicationId, contentType, image) }
+        return promise { HelperClient.uploadPlatformLogoRequest(applicationId, contentType, image) }
     }
 
     override fun assistedLogin(email: String, password: String): Promise<AssistedLoginResponse> {
-        return GlobalScope.promise { HelperClient.assistedLoginRequest(email, password) }
+        return promise { HelperClient.assistedLoginRequest(email, password) }
     }
 
     override fun assistedRegisterEphemeralKey(publicKey: ByteArray?): Promise<AssistedRegisterEphemeralKeyResponse> {
-        return GlobalScope.promise { HelperClient.assistedRegisterEphemeralKeyRequest(publicKey) }
+        return promise { HelperClient.assistedRegisterEphemeralKeyRequest(publicKey) }
     }
 
     override fun assistedRegister(email: String, password: String, displayName: String?, force: Boolean): Promise<dynamic> {
-        return GlobalScope.promise { HelperClient.assistedRegisterRequest(email, password, displayName, force) }
+        return promise { HelperClient.assistedRegisterRequest(email, password, displayName, force) }
     }
 }

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.js.kt
@@ -115,7 +115,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun batchShareLock(batchShareLockOperation: LockOperations.BatchShareLockOperation): Promise<dynamic> {
-        return GlobalScope.promise { LockOperationsClient.batchShareLockRequest(batchShareLockOperation) }
+        return promise { LockOperationsClient.batchShareLockRequest(batchShareLockOperation) }
     }
 
     override fun revokeAccessToLock(revokeAccessToLockOperation: LockOperations.RevokeAccessToLockOperation): Promise<Unit> {

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.js.kt
@@ -9,129 +9,128 @@ import com.doordeck.multiplatform.sdk.api.responses.LockUserResponse
 import com.doordeck.multiplatform.sdk.api.responses.ShareableLockResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserLockResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserPublicKeyResponse
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.promise
+import com.doordeck.multiplatform.sdk.util.promise
 import kotlin.js.Promise
 
 internal object LockOperationsResourceImpl : LockOperationsResource {
     
     override fun getSingleLock(lockId: String): Promise<LockResponse> {
-        return GlobalScope.promise { LockOperationsClient.getSingleLockRequest(lockId) }
+        return promise { LockOperationsClient.getSingleLockRequest(lockId) }
     }
 
     override fun getLockAuditTrail(lockId: String, start: Int, end: Int): Promise<List<AuditResponse>> {
-        return GlobalScope.promise { LockOperationsClient.getLockAuditTrailRequest(lockId, start, end) }
+        return promise { LockOperationsClient.getLockAuditTrailRequest(lockId, start, end) }
     }
 
     override fun getAuditForUser(userId: String, start: Int, end: Int): Promise<List<AuditResponse>> {
-        return GlobalScope.promise { LockOperationsClient.getAuditForUserRequest(userId, start, end) }
+        return promise { LockOperationsClient.getAuditForUserRequest(userId, start, end) }
     }
 
     override fun getUsersForLock(lockId: String): Promise<List<UserLockResponse>> {
-        return GlobalScope.promise { LockOperationsClient.getUsersForLockRequest(lockId) }
+        return promise { LockOperationsClient.getUsersForLockRequest(lockId) }
     }
 
     override fun getLocksForUser(userId: String): Promise<LockUserResponse> {
-        return GlobalScope.promise { LockOperationsClient.getLocksForUserRequest(userId) }
+        return promise { LockOperationsClient.getLocksForUserRequest(userId) }
     }
 
     override fun updateLockName(lockId: String, name: String?): Promise<Unit> {
-        return GlobalScope.promise { LockOperationsClient.updateLockNameRequest(lockId, name) }
+        return promise { LockOperationsClient.updateLockNameRequest(lockId, name) }
     }
 
     override fun updateLockFavourite(lockId: String, favourite: Boolean?): Promise<Unit> {
-        return GlobalScope.promise { LockOperationsClient.updateLockFavouriteRequest(lockId, favourite) }
+        return promise { LockOperationsClient.updateLockFavouriteRequest(lockId, favourite) }
     }
 
     override fun updateLockColour(lockId: String, colour: String?): Promise<Unit> {
-        return GlobalScope.promise { LockOperationsClient.updateLockColourRequest(lockId, colour) }
+        return promise { LockOperationsClient.updateLockColourRequest(lockId, colour) }
     }
 
     override fun updateLockSettingDefaultName(lockId: String, name: String?): Promise<Unit> {
-        return GlobalScope.promise { LockOperationsClient.updateLockSettingDefaultNameRequest(lockId, name) }
+        return promise { LockOperationsClient.updateLockSettingDefaultNameRequest(lockId, name) }
     }
 
     override fun setLockSettingPermittedAddresses(lockId: String, permittedAddresses: List<String>): Promise<Unit> {
-        return GlobalScope.promise { LockOperationsClient.setLockSettingPermittedAddressesRequest(lockId, permittedAddresses) }
+        return promise { LockOperationsClient.setLockSettingPermittedAddressesRequest(lockId, permittedAddresses) }
     }
 
     override fun updateLockSettingHidden(lockId: String, hidden: Boolean): Promise<Unit> {
-        return GlobalScope.promise { LockOperationsClient.updateLockSettingHiddenRequest(lockId, hidden) }
+        return promise { LockOperationsClient.updateLockSettingHiddenRequest(lockId, hidden) }
     }
 
     override fun setLockSettingTimeRestrictions(lockId: String, times: List<LockOperations.TimeRequirement>): Promise<Unit> {
-        return GlobalScope.promise { LockOperationsClient.setLockSettingTimeRestrictionsRequest(lockId, times) }
+        return promise { LockOperationsClient.setLockSettingTimeRestrictionsRequest(lockId, times) }
     }
 
     override fun updateLockSettingLocationRestrictions(lockId: String, location: LockOperations.LocationRequirement?): Promise<Unit> {
-        return GlobalScope.promise { LockOperationsClient.updateLockSettingLocationRestrictionsRequest(lockId, location) }
+        return promise { LockOperationsClient.updateLockSettingLocationRestrictionsRequest(lockId, location) }
     }
 
     override fun getUserPublicKey(userEmail: String, visitor: Boolean): Promise<UserPublicKeyResponse> {
-        return GlobalScope.promise { LockOperationsClient.getUserPublicKeyRequest(userEmail, visitor) }
+        return promise { LockOperationsClient.getUserPublicKeyRequest(userEmail, visitor) }
     }
 
     override fun getUserPublicKeyByEmail(email: String): Promise<UserPublicKeyResponse> {
-        return GlobalScope.promise { LockOperationsClient.getUserPublicKeyByEmailRequest(email) }
+        return promise { LockOperationsClient.getUserPublicKeyByEmailRequest(email) }
     }
 
     override fun getUserPublicKeyByTelephone(telephone: String): Promise<UserPublicKeyResponse> {
-        return GlobalScope.promise { LockOperationsClient.getUserPublicKeyByTelephoneRequest(telephone) }
+        return promise { LockOperationsClient.getUserPublicKeyByTelephoneRequest(telephone) }
     }
 
     override fun getUserPublicKeyByLocalKey(localKey: String): Promise<UserPublicKeyResponse> {
-        return GlobalScope.promise { LockOperationsClient.getUserPublicKeyByLocalKeyRequest(localKey) }
+        return promise { LockOperationsClient.getUserPublicKeyByLocalKeyRequest(localKey) }
     }
 
     override fun getUserPublicKeyByForeignKey(foreignKey: String): Promise<UserPublicKeyResponse> {
-        return GlobalScope.promise { LockOperationsClient.getUserPublicKeyByForeignKeyRequest(foreignKey) }
+        return promise { LockOperationsClient.getUserPublicKeyByForeignKeyRequest(foreignKey) }
     }
 
     override fun getUserPublicKeyByIdentity(identity: String): Promise<UserPublicKeyResponse> {
-        return GlobalScope.promise { LockOperationsClient.getUserPublicKeyByIdentityRequest(identity) }
+        return promise { LockOperationsClient.getUserPublicKeyByIdentityRequest(identity) }
     }
 
     override fun getUserPublicKeyByEmails(emails: List<String>): Promise<List<BatchUserPublicKeyResponse>> {
-        return GlobalScope.promise { LockOperationsClient.getUserPublicKeyByEmailsRequest(emails) }
+        return promise { LockOperationsClient.getUserPublicKeyByEmailsRequest(emails) }
     }
 
     override fun getUserPublicKeyByTelephones(telephones: List<String>): Promise<List<BatchUserPublicKeyResponse>> {
-        return GlobalScope.promise { LockOperationsClient.getUserPublicKeyByTelephonesRequest(telephones) }
+        return promise { LockOperationsClient.getUserPublicKeyByTelephonesRequest(telephones) }
     }
 
     override fun getUserPublicKeyByLocalKeys(localKeys: List<String>): Promise<List<BatchUserPublicKeyResponse>> {
-        return GlobalScope.promise { LockOperationsClient.getUserPublicKeyByLocalKeysRequest(localKeys) }
+        return promise { LockOperationsClient.getUserPublicKeyByLocalKeysRequest(localKeys) }
     }
 
     override fun getUserPublicKeyByForeignKeys(foreignKeys: List<String>): Promise<List<BatchUserPublicKeyResponse>> {
-        return GlobalScope.promise { LockOperationsClient.getUserPublicKeyByForeignKeysRequest(foreignKeys) }
+        return promise { LockOperationsClient.getUserPublicKeyByForeignKeysRequest(foreignKeys) }
     }
 
     override fun unlock(unlockOperation: LockOperations.UnlockOperation): Promise<Unit> {
-        return GlobalScope.promise { LockOperationsClient.unlockRequest(unlockOperation) }
+        return promise { LockOperationsClient.unlockRequest(unlockOperation) }
     }
 
     override fun shareLock(shareLockOperation: LockOperations.ShareLockOperation): Promise<Unit> {
-        return GlobalScope.promise { LockOperationsClient.shareLockRequest(shareLockOperation) }
+        return promise { LockOperationsClient.shareLockRequest(shareLockOperation) }
     }
 
     override fun revokeAccessToLock(revokeAccessToLockOperation: LockOperations.RevokeAccessToLockOperation): Promise<Unit> {
-        return GlobalScope.promise { LockOperationsClient.revokeAccessToLockRequest(revokeAccessToLockOperation) }
+        return promise { LockOperationsClient.revokeAccessToLockRequest(revokeAccessToLockOperation) }
     }
 
     override fun updateSecureSettingUnlockDuration(updateSecureSettingUnlockDuration: LockOperations.UpdateSecureSettingUnlockDuration): Promise<Unit> {
-        return GlobalScope.promise { LockOperationsClient.updateSecureSettingUnlockDurationRequest(updateSecureSettingUnlockDuration) }
+        return promise { LockOperationsClient.updateSecureSettingUnlockDurationRequest(updateSecureSettingUnlockDuration) }
     }
 
     override fun updateSecureSettingUnlockBetween(updateSecureSettingUnlockBetween: LockOperations.UpdateSecureSettingUnlockBetween): Promise<Unit> {
-        return GlobalScope.promise { LockOperationsClient.updateSecureSettingUnlockBetweenRequest(updateSecureSettingUnlockBetween) }
+        return promise { LockOperationsClient.updateSecureSettingUnlockBetweenRequest(updateSecureSettingUnlockBetween) }
     }
 
     override fun getPinnedLocks(): Promise<List<LockResponse>> {
-        return GlobalScope.promise { LockOperationsClient.getPinnedLocksRequest() }
+        return promise { LockOperationsClient.getPinnedLocksRequest() }
     }
 
     override fun getShareableLocks(): Promise<List<ShareableLockResponse>> {
-        return GlobalScope.promise { LockOperationsClient.getShareableLocksRequest() }
+        return promise { LockOperationsClient.getShareableLocksRequest() }
     }
 }

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/PlatformResourceImpl.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/PlatformResourceImpl.js.kt
@@ -5,93 +5,92 @@ import com.doordeck.multiplatform.sdk.api.model.Platform
 import com.doordeck.multiplatform.sdk.api.responses.ApplicationOwnerDetailsResponse
 import com.doordeck.multiplatform.sdk.api.responses.ApplicationResponse
 import com.doordeck.multiplatform.sdk.api.responses.GetLogoUploadUrlResponse
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.promise
+import com.doordeck.multiplatform.sdk.util.promise
 import kotlin.js.Promise
 
 internal object PlatformResourceImpl : PlatformResource {
 
     override fun createApplication(application: Platform.CreateApplication): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.createApplicationRequest(application) }
+        return promise { PlatformClient.createApplicationRequest(application) }
     }
 
     override fun listApplications(): Promise<List<ApplicationResponse>> {
-        return GlobalScope.promise { PlatformClient.listApplicationsRequest() }
+        return promise { PlatformClient.listApplicationsRequest() }
     }
 
     override fun getApplication(applicationId: String): Promise<ApplicationResponse> {
-        return GlobalScope.promise { PlatformClient.getApplicationRequest(applicationId) }
+        return promise { PlatformClient.getApplicationRequest(applicationId) }
     }
 
     override fun updateApplicationName(applicationId: String, name: String): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.updateApplicationNameRequest(applicationId, name) }
+        return promise { PlatformClient.updateApplicationNameRequest(applicationId, name) }
     }
 
     override fun updateApplicationCompanyName(applicationId: String, companyName: String): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.updateApplicationCompanyNameRequest(applicationId, companyName) }
+        return promise { PlatformClient.updateApplicationCompanyNameRequest(applicationId, companyName) }
     }
 
     override fun updateApplicationMailingAddress(applicationId: String, mailingAddress: String): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.updateApplicationMailingAddressRequest(applicationId, mailingAddress) }
+        return promise { PlatformClient.updateApplicationMailingAddressRequest(applicationId, mailingAddress) }
     }
 
     override fun updateApplicationPrivacyPolicy(applicationId: String, privacyPolicy: String): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.updateApplicationPrivacyPolicyRequest(applicationId, privacyPolicy) }
+        return promise { PlatformClient.updateApplicationPrivacyPolicyRequest(applicationId, privacyPolicy) }
     }
 
     override fun updateApplicationSupportContact(applicationId: String, supportContact: String): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.updateApplicationSupportContactRequest(applicationId, supportContact)}
+        return promise { PlatformClient.updateApplicationSupportContactRequest(applicationId, supportContact)}
     }
 
     override fun updateApplicationAppLink(applicationId: String, appLink: String): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.updateApplicationAppLinkRequest(applicationId, appLink) }
+        return promise { PlatformClient.updateApplicationAppLinkRequest(applicationId, appLink) }
     }
 
     override fun updateApplicationEmailPreferences(applicationId: String, emailPreferences: Platform.EmailPreferences): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.updateApplicationEmailPreferencesRequest(applicationId, emailPreferences) }
+        return promise { PlatformClient.updateApplicationEmailPreferencesRequest(applicationId, emailPreferences) }
     }
 
     override fun updateApplicationLogoUrl(applicationId: String, logoUrl: String): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.updateApplicationLogoUrlRequest(applicationId, logoUrl) }
+        return promise { PlatformClient.updateApplicationLogoUrlRequest(applicationId, logoUrl) }
     }
 
     override fun deleteApplication(applicationId: String): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.deleteApplicationRequest(applicationId) }
+        return promise { PlatformClient.deleteApplicationRequest(applicationId) }
     }
 
     override fun getLogoUploadUrl(applicationId: String, contentType: String): Promise<GetLogoUploadUrlResponse> {
-        return GlobalScope.promise { PlatformClient.getLogoUploadUrlRequest(applicationId, contentType) }
+        return promise { PlatformClient.getLogoUploadUrlRequest(applicationId, contentType) }
     }
 
     override fun addAuthKey(applicationId: String, key: Platform.AuthKey): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.addAuthKeyRequest(applicationId, key) }
+        return promise { PlatformClient.addAuthKeyRequest(applicationId, key) }
     }
 
     override fun addAuthIssuer(applicationId: String, url: String): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.addAuthIssuerRequest(applicationId, url) }
+        return promise { PlatformClient.addAuthIssuerRequest(applicationId, url) }
     }
 
     override fun deleteAuthIssuer(applicationId: String, url: String): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.deleteAuthIssuerRequest(applicationId, url) }
+        return promise { PlatformClient.deleteAuthIssuerRequest(applicationId, url) }
     }
 
     override fun addCorsDomain(applicationId: String, url: String): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.addCorsDomainRequest(applicationId, url) }
+        return promise { PlatformClient.addCorsDomainRequest(applicationId, url) }
     }
 
     override fun removeCorsDomain(applicationId: String, url: String): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.removeCorsDomainRequest(applicationId, url) }
+        return promise { PlatformClient.removeCorsDomainRequest(applicationId, url) }
     }
 
     override fun addApplicationOwner(applicationId: String, userId: String): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.addApplicationOwnerRequest(applicationId, userId) }
+        return promise { PlatformClient.addApplicationOwnerRequest(applicationId, userId) }
     }
 
     override fun removeApplicationOwner(applicationId: String, userId: String): Promise<Unit> {
-        return GlobalScope.promise { PlatformClient.removeApplicationOwnerRequest(applicationId, userId) }
+        return promise { PlatformClient.removeApplicationOwnerRequest(applicationId, userId) }
     }
 
     override fun getApplicationOwnersDetails(applicationId: String): Promise<List<ApplicationOwnerDetailsResponse>> {
-        return GlobalScope.promise { PlatformClient.getApplicationOwnersDetailsRequest(applicationId) }
+        return promise { PlatformClient.getApplicationOwnersDetailsRequest(applicationId) }
     }
 }

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/SitesResourceImpl.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/SitesResourceImpl.js.kt
@@ -4,21 +4,20 @@ import com.doordeck.multiplatform.sdk.api.SitesResource
 import com.doordeck.multiplatform.sdk.api.responses.SiteLocksResponse
 import com.doordeck.multiplatform.sdk.api.responses.SiteResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserForSiteResponse
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.promise
+import com.doordeck.multiplatform.sdk.util.promise
 import kotlin.js.Promise
 
 internal object SitesResourceImpl : SitesResource {
 
     override fun listSites(): Promise<List<SiteResponse>> {
-        return GlobalScope.promise { SitesClient.listSitesRequest() }
+        return promise { SitesClient.listSitesRequest() }
     }
 
     override fun getLocksForSite(siteId: String): Promise<List<SiteLocksResponse>> {
-        return GlobalScope.promise { SitesClient.getLocksForSiteRequest(siteId) }
+        return promise { SitesClient.getLocksForSiteRequest(siteId) }
     }
 
     override fun getUsersForSite(siteId: String): Promise<List<UserForSiteResponse>> {
-        return GlobalScope.promise { SitesClient.getUsersForSiteRequest(siteId) }
+        return promise { SitesClient.getUsersForSiteRequest(siteId) }
     }
 }

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/TilesResourceImpl.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/TilesResourceImpl.js.kt
@@ -2,17 +2,16 @@ package com.doordeck.multiplatform.sdk.internal.api
 
 import com.doordeck.multiplatform.sdk.api.TilesResource
 import com.doordeck.multiplatform.sdk.api.responses.TileLocksResponse
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.promise
+import com.doordeck.multiplatform.sdk.util.promise
 import kotlin.js.Promise
 
 internal object TilesResourceImpl : TilesResource {
 
     override fun getLocksBelongingToTile(tileId: String): Promise<TileLocksResponse> {
-        return GlobalScope.promise { TilesClient.getLocksBelongingToTileRequest(tileId) }
+        return promise { TilesClient.getLocksBelongingToTileRequest(tileId) }
     }
 
     override fun associateMultipleLocks(tileId: String, siteId: String, lockIds: List<String>): Promise<Unit> {
-        return GlobalScope.promise { TilesClient.associateMultipleLocksRequest(tileId, siteId, lockIds) }
+        return promise { TilesClient.associateMultipleLocksRequest(tileId, siteId, lockIds) }
     }
 }

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.js.kt
@@ -1,7 +1,28 @@
 package com.doordeck.multiplatform.sdk.util
 
 import io.ktor.client.HttpClientConfig
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.promise
+import kotlin.js.Promise
 
 internal actual fun HttpClientConfig<*>.installCertificatePinner() {
     // Certificate pinner is not supported on the JS engine
+}
+
+/**
+ * Creates a `Promise` from a suspendable function.
+ *
+ * This function executes the given suspend function asynchronously within a
+ * coroutine and returns a `Promise` that completes when the suspend function
+ * finishes execution. The coroutine is launched in the default dispatcher.
+ *
+ * @param T The type of the result produced by the suspend function.
+ * @param block The suspend function that will be executed asynchronously.
+ *
+ * @return A `Promise` that completes with the result of the suspend function.
+ */
+internal inline fun <reified T>promise(crossinline block: suspend () -> T): Promise<T> {
+    return GlobalScope.promise {
+        block()
+    }
 }

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountResourceImpl.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountResourceImpl.jvm.kt
@@ -6,9 +6,7 @@ import com.doordeck.multiplatform.sdk.api.responses.RegisterEphemeralKeyResponse
 import com.doordeck.multiplatform.sdk.api.responses.RegisterEphemeralKeyWithSecondaryAuthenticationResponse
 import com.doordeck.multiplatform.sdk.api.responses.TokenResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserDetailsResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object AccountResourceImpl : AccountResource {
@@ -18,7 +16,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun refreshTokenAsync(refreshToken: String?): CompletableFuture<TokenResponse> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.refreshTokenRequest(refreshToken) }
+        return completableFuture { refreshToken(refreshToken) }
     }
 
     override suspend fun logout() {
@@ -26,7 +24,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun logoutAsync(): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.logoutRequest() }
+        return completableFuture { logout() }
     }
 
     override suspend fun registerEphemeralKey(publicKey: ByteArray?): RegisterEphemeralKeyResponse {
@@ -34,7 +32,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun registerEphemeralKeyAsync(publicKey: ByteArray?): CompletableFuture<RegisterEphemeralKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.registerEphemeralKeyRequest(publicKey) }
+        return completableFuture { registerEphemeralKey(publicKey) }
     }
 
     override suspend fun registerEphemeralKeyWithSecondaryAuthentication(publicKey: ByteArray?, method: TwoFactorMethod?): RegisterEphemeralKeyWithSecondaryAuthenticationResponse {
@@ -42,7 +40,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun registerEphemeralKeyWithSecondaryAuthenticationAsync(publicKey: ByteArray?, method: TwoFactorMethod?): CompletableFuture<RegisterEphemeralKeyWithSecondaryAuthenticationResponse> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.registerEphemeralKeyWithSecondaryAuthenticationRequest(publicKey, method) }
+        return completableFuture { registerEphemeralKeyWithSecondaryAuthentication(publicKey, method) }
     }
 
     override suspend fun verifyEphemeralKeyRegistration(code: String, privateKey: ByteArray?): RegisterEphemeralKeyResponse {
@@ -50,7 +48,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun verifyEphemeralKeyRegistrationAsync(code: String, privateKey: ByteArray?): CompletableFuture<RegisterEphemeralKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.verifyEphemeralKeyRegistrationRequest(code, privateKey) }
+        return completableFuture { verifyEphemeralKeyRegistration(code, privateKey) }
     }
 
     override suspend fun reverifyEmail() {
@@ -58,7 +56,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun reverifyEmailAsync(): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.reverifyEmailRequest() }
+        return completableFuture { reverifyEmail() }
     }
 
     override suspend fun changePassword(oldPassword: String, newPassword: String) {
@@ -66,7 +64,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun changePasswordAsync(oldPassword: String, newPassword: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.changePasswordRequest(oldPassword, newPassword) }
+        return completableFuture { changePassword(oldPassword, newPassword) }
     }
 
     override suspend fun getUserDetails(): UserDetailsResponse {
@@ -74,7 +72,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun getUserDetailsAsync(): CompletableFuture<UserDetailsResponse> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.getUserDetailsRequest() }
+        return completableFuture { getUserDetails() }
     }
 
     override suspend fun updateUserDetails(displayName: String) {
@@ -82,7 +80,7 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun updateUserDetailsAsync(displayName: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.updateUserDetailsRequest(displayName) }
+        return completableFuture { updateUserDetails(displayName) }
     }
 
     override suspend fun deleteAccount() {
@@ -90,6 +88,6 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun deleteAccountAsync(): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountClient.deleteAccountRequest() }
+        return completableFuture { deleteAccount() }
     }
 }

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountlessResourceImpl.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountlessResourceImpl.jvm.kt
@@ -2,9 +2,7 @@ package com.doordeck.multiplatform.sdk.internal.api
 
 import com.doordeck.multiplatform.sdk.api.AccountlessResource
 import com.doordeck.multiplatform.sdk.api.responses.TokenResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object AccountlessResourceImpl : AccountlessResource {
@@ -14,7 +12,7 @@ internal object AccountlessResourceImpl : AccountlessResource {
     }
 
     override fun loginAsync(email: String, password: String): CompletableFuture<TokenResponse> {
-        return GlobalScope.future(Dispatchers.IO) { AccountlessClient.loginRequest(email, password) }
+        return completableFuture { login(email, password) }
     }
 
     override suspend fun registration(email: String, password: String, displayName: String?, force: Boolean, publicKey: ByteArray?): TokenResponse {
@@ -22,7 +20,7 @@ internal object AccountlessResourceImpl : AccountlessResource {
     }
 
     override fun registrationAsync(email: String, password: String, displayName: String?, force: Boolean, publicKey: ByteArray?): CompletableFuture<TokenResponse> {
-        return GlobalScope.future(Dispatchers.IO) { AccountlessClient.registrationRequest(email, password, displayName, force, publicKey) }
+        return completableFuture { registration(email, password, displayName, force, publicKey) }
     }
 
     override suspend fun verifyEmail(code: String) {
@@ -30,7 +28,7 @@ internal object AccountlessResourceImpl : AccountlessResource {
     }
 
     override fun verifyEmailAsync(code: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountlessClient.verifyEmailRequest(code) }
+        return completableFuture { verifyEmail(code) }
     }
 
     override suspend fun passwordReset(email: String) {
@@ -38,14 +36,14 @@ internal object AccountlessResourceImpl : AccountlessResource {
     }
 
     override fun passwordResetAsync(email: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountlessClient.passwordResetRequest(email) }
+        return completableFuture { passwordReset(email) }
     }
 
     override suspend fun passwordResetVerify(userId: String, token: String, password: String) {
-        AccountlessClient.passwordResetVerifyRequest(userId, token, password)
+        return AccountlessClient.passwordResetVerifyRequest(userId, token, password)
     }
 
     override fun passwordResetVerifyAsync(userId: String, token: String, password: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { AccountlessClient.passwordResetVerifyRequest(userId, token, password) }
+        return completableFuture { passwordResetVerify(userId, token, password) }
     }
 }

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/FusionResourceImpl.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/FusionResourceImpl.jvm.kt
@@ -6,9 +6,7 @@ import com.doordeck.multiplatform.sdk.api.responses.DoorStateResponse
 import com.doordeck.multiplatform.sdk.api.responses.FusionLoginResponse
 import com.doordeck.multiplatform.sdk.api.responses.IntegrationConfigurationResponse
 import com.doordeck.multiplatform.sdk.api.responses.IntegrationTypeResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object FusionResourceImpl : FusionResource {
@@ -18,7 +16,7 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun loginAsync(email: String, password: String): CompletableFuture<FusionLoginResponse> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.loginRequest(email, password) }
+        return completableFuture { login(email, password) }
     }
 
     override suspend fun getIntegrationType(): IntegrationTypeResponse {
@@ -26,7 +24,7 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun getIntegrationTypeAsync(): CompletableFuture<IntegrationTypeResponse> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.getIntegrationTypeRequest() }
+        return completableFuture { getIntegrationType() }
     }
 
     override suspend fun getIntegrationConfiguration(type: String): List<IntegrationConfigurationResponse> {
@@ -34,7 +32,7 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun getIntegrationConfigurationAsync(type: String): CompletableFuture<List<IntegrationConfigurationResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.getIntegrationConfigurationRequest(type) }
+        return completableFuture { getIntegrationConfiguration(type) }
     }
 
     override suspend fun enableDoor(name: String, siteId: String, controller: Fusion.LockController) {
@@ -42,7 +40,7 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun enableDoorAsync(name: String, siteId: String, controller: Fusion.LockController): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.enableDoorRequest(name, siteId, controller) }
+        return completableFuture { enableDoor(name, siteId, controller) }
     }
 
     override suspend fun deleteDoor(deviceId: String) {
@@ -50,7 +48,7 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun deleteDoorAsync(deviceId: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.deleteDoorRequest(deviceId) }
+        return completableFuture { deleteDoor(deviceId) }
     }
 
     override suspend fun getDoorStatus(deviceId: String): DoorStateResponse {
@@ -58,7 +56,7 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun getDoorStatusAsync(deviceId: String): CompletableFuture<DoorStateResponse> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.getDoorStatusRequest(deviceId) }
+        return completableFuture { getDoorStatus(deviceId) }
     }
 
     override suspend fun startDoor(deviceId: String) {
@@ -66,7 +64,7 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun startDoorAsync(deviceId: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.startDoorRequest(deviceId) }
+        return completableFuture { startDoor(deviceId) }
     }
 
     override suspend fun stopDoor(deviceId: String) {
@@ -74,6 +72,6 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun stopDoorAsync(deviceId: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { FusionClient.stopDoorRequest(deviceId) }
+        return completableFuture { stopDoor(deviceId) }
     }
 }

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/HelperResourceImpl.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/HelperResourceImpl.jvm.kt
@@ -3,9 +3,7 @@ package com.doordeck.multiplatform.sdk.internal.api
 import com.doordeck.multiplatform.sdk.api.HelperResource
 import com.doordeck.multiplatform.sdk.api.responses.AssistedLoginResponse
 import com.doordeck.multiplatform.sdk.api.responses.AssistedRegisterEphemeralKeyResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object HelperResourceImpl : HelperResource {
@@ -15,7 +13,7 @@ internal object HelperResourceImpl : HelperResource {
     }
 
     override fun uploadPlatformLogoAsync(applicationId: String, contentType: String, image: ByteArray): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { HelperClient.uploadPlatformLogoRequest(applicationId, contentType, image) }
+        return completableFuture { uploadPlatformLogo(applicationId, contentType, image) }
     }
 
     override suspend fun assistedLogin(email: String, password: String): AssistedLoginResponse {
@@ -23,7 +21,7 @@ internal object HelperResourceImpl : HelperResource {
     }
 
     override fun assistedLoginAsync(email: String, password: String): CompletableFuture<AssistedLoginResponse> {
-        return GlobalScope.future(Dispatchers.IO) { HelperClient.assistedLoginRequest(email, password) }
+        return completableFuture { assistedLogin(email, password) }
     }
 
     override suspend fun assistedRegisterEphemeralKey(publicKey: ByteArray?): AssistedRegisterEphemeralKeyResponse {
@@ -31,7 +29,7 @@ internal object HelperResourceImpl : HelperResource {
     }
 
     override fun assistedRegisterEphemeralKeyAsync(publicKey: ByteArray?): CompletableFuture<AssistedRegisterEphemeralKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { HelperClient.assistedRegisterEphemeralKeyRequest(publicKey) }
+        return completableFuture { assistedRegisterEphemeralKey(publicKey) }
     }
 
     override suspend fun assistedRegister(email: String, password: String, displayName: String?, force: Boolean) {
@@ -39,6 +37,6 @@ internal object HelperResourceImpl : HelperResource {
     }
 
     override fun assistedRegisterAsync(email: String, password: String, displayName: String?, force: Boolean): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { HelperClient.assistedRegisterRequest(email, password, displayName, force) }
+        return completableFuture { assistedRegister(email, password, displayName, force) }
     }
 }

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.jvm.kt
@@ -219,7 +219,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun batchShareLockAsync(batchShareLockOperation: LockOperations.BatchShareLockOperation): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.batchShareLockRequest(batchShareLockOperation) }
+        return completableFuture { LockOperationsClient.batchShareLockRequest(batchShareLockOperation) }
     }
 
     override suspend fun revokeAccessToLock(revokeAccessToLockOperation: LockOperations.RevokeAccessToLockOperation) {

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.jvm.kt
@@ -9,9 +9,7 @@ import com.doordeck.multiplatform.sdk.api.responses.LockUserResponse
 import com.doordeck.multiplatform.sdk.api.responses.ShareableLockResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserLockResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserPublicKeyResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object LockOperationsResourceImpl : LockOperationsResource {
@@ -21,7 +19,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getSingleLockAsync(lockId: String): CompletableFuture<LockResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getSingleLockRequest(lockId) }
+        return completableFuture { getSingleLock(lockId) }
     }
 
     override suspend fun getLockAuditTrail(lockId: String, start: Int, end: Int): List<AuditResponse> {
@@ -29,7 +27,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getLockAuditTrailAsync(lockId: String, start: Int, end: Int): CompletableFuture<List<AuditResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getLockAuditTrailRequest(lockId, start, end) }
+        return completableFuture { getLockAuditTrail(lockId, start, end) }
     }
 
     override suspend fun getAuditForUser(userId: String, start: Int, end: Int): List<AuditResponse> {
@@ -37,7 +35,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getAuditForUserAsync(userId: String, start: Int, end: Int): CompletableFuture<List<AuditResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getAuditForUserRequest(userId, start, end) }
+        return completableFuture { getAuditForUser(userId, start, end) }
     }
 
     override suspend fun getUsersForLock(lockId: String): List<UserLockResponse> {
@@ -45,7 +43,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUsersForLockAsync(lockId: String): CompletableFuture<List<UserLockResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUsersForLockRequest(lockId) }
+        return completableFuture { getUsersForLock(lockId) }
     }
 
     override suspend fun getLocksForUser(userId: String): LockUserResponse {
@@ -53,7 +51,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getLocksForUserAsync(userId: String): CompletableFuture<LockUserResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getLocksForUserRequest(userId) }
+        return completableFuture { getLocksForUser(userId) }
     }
 
     override suspend fun updateLockName(lockId: String, name: String?) {
@@ -61,7 +59,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateLockNameAsync(lockId: String, name: String?): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateLockNameRequest(lockId, name) }
+        return completableFuture { updateLockName(lockId, name) }
     }
 
     override suspend fun updateLockFavourite(lockId: String, favourite: Boolean?) {
@@ -69,7 +67,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateLockFavouriteAsync(lockId: String, favourite: Boolean?): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateLockFavouriteRequest(lockId, favourite) }
+        return completableFuture { updateLockFavourite(lockId, favourite) }
     }
 
     override suspend fun updateLockColour(lockId: String, colour: String?) {
@@ -77,7 +75,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateLockColourAsync(lockId: String, colour: String?): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateLockColourRequest(lockId, colour) }
+        return completableFuture { updateLockColour(lockId, colour) }
     }
 
     override suspend fun updateLockSettingDefaultName(lockId: String, name: String?) {
@@ -85,7 +83,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateLockSettingDefaultNameAsync(lockId: String, name: String?): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateLockSettingDefaultNameRequest(lockId, name) }
+        return completableFuture { updateLockSettingDefaultName(lockId, name) }
     }
 
     override suspend fun setLockSettingPermittedAddresses(lockId: String, permittedAddresses: List<String>) {
@@ -93,7 +91,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun setLockSettingPermittedAddressesAsync(lockId: String, permittedAddresses: List<String>): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.setLockSettingPermittedAddressesRequest(lockId, permittedAddresses) }
+        return completableFuture { setLockSettingPermittedAddresses(lockId, permittedAddresses) }
     }
 
     override suspend fun updateLockSettingHidden(lockId: String, hidden: Boolean) {
@@ -101,7 +99,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateLockSettingHiddenAsync(lockId: String, hidden: Boolean): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateLockSettingHiddenRequest(lockId, hidden) }
+        return completableFuture { updateLockSettingHidden(lockId, hidden) }
     }
 
     override suspend fun setLockSettingTimeRestrictions(lockId: String, times: List<LockOperations.TimeRequirement>) {
@@ -109,7 +107,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun setLockSettingTimeRestrictionsAsync(lockId: String, times: List<LockOperations.TimeRequirement>): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.setLockSettingTimeRestrictionsRequest(lockId, times) }
+        return completableFuture { setLockSettingTimeRestrictions(lockId, times) }
     }
 
     override suspend fun updateLockSettingLocationRestrictions(lockId: String, location: LockOperations.LocationRequirement?) {
@@ -117,7 +115,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateLockSettingLocationRestrictionsAsync(lockId: String, location: LockOperations.LocationRequirement?): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateLockSettingLocationRestrictionsRequest(lockId, location) }
+        return completableFuture { updateLockSettingLocationRestrictions(lockId, location) }
     }
 
     override suspend fun getUserPublicKey(userEmail: String, visitor: Boolean): UserPublicKeyResponse {
@@ -125,7 +123,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override suspend fun getUserPublicKeyAsync(userEmail: String, visitor: Boolean): CompletableFuture<UserPublicKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyRequest(userEmail, visitor) }
+        return completableFuture { getUserPublicKey(userEmail, visitor) }
     }
 
     override suspend fun getUserPublicKeyByEmail(email: String): UserPublicKeyResponse {
@@ -133,7 +131,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByEmailAsync(email: String): CompletableFuture<UserPublicKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByEmailRequest(email) }
+        return completableFuture { getUserPublicKeyByEmail(email) }
     }
 
     override suspend fun getUserPublicKeyByTelephone(telephone: String): UserPublicKeyResponse {
@@ -141,7 +139,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByTelephoneAsync(telephone: String): CompletableFuture<UserPublicKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByTelephoneRequest(telephone) }
+        return completableFuture { getUserPublicKeyByTelephone(telephone) }
     }
 
     override suspend fun getUserPublicKeyByLocalKey(localKey: String): UserPublicKeyResponse {
@@ -149,7 +147,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByLocalKeyAsync(localKey: String): CompletableFuture<UserPublicKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByLocalKeyRequest(localKey) }
+        return completableFuture { getUserPublicKeyByLocalKey(localKey) }
     }
 
     override suspend fun getUserPublicKeyByForeignKey(foreignKey: String): UserPublicKeyResponse {
@@ -157,7 +155,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByForeignKeyAsync(foreignKey: String): CompletableFuture<UserPublicKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByForeignKeyRequest(foreignKey) }
+        return completableFuture { getUserPublicKeyByForeignKey(foreignKey) }
     }
 
     override suspend fun getUserPublicKeyByIdentity(identity: String): UserPublicKeyResponse {
@@ -165,7 +163,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByIdentityAsync(identity: String): CompletableFuture<UserPublicKeyResponse> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByIdentityRequest(identity) }
+        return completableFuture { getUserPublicKeyByIdentity(identity) }
     }
 
     override suspend fun getUserPublicKeyByEmails(emails: List<String>): List<BatchUserPublicKeyResponse> {
@@ -173,7 +171,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByEmailsAsync(emails: List<String>): CompletableFuture<List<BatchUserPublicKeyResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByEmailsRequest(emails) }
+        return completableFuture { getUserPublicKeyByEmails(emails) }
     }
 
     override suspend fun getUserPublicKeyByTelephones(telephones: List<String>): List<BatchUserPublicKeyResponse> {
@@ -181,7 +179,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByTelephonesAsync(telephones: List<String>): CompletableFuture<List<BatchUserPublicKeyResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByTelephonesRequest(telephones) }
+        return completableFuture { getUserPublicKeyByTelephones(telephones) }
     }
 
     override suspend fun getUserPublicKeyByLocalKeys(localKeys: List<String>): List<BatchUserPublicKeyResponse> {
@@ -189,7 +187,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByLocalKeysAsync(localKeys: List<String>): CompletableFuture<List<BatchUserPublicKeyResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByLocalKeysRequest(localKeys) }
+        return completableFuture { getUserPublicKeyByLocalKeys(localKeys) }
     }
 
     override suspend fun getUserPublicKeyByForeignKeys(foreignKeys: List<String>): List<BatchUserPublicKeyResponse> {
@@ -197,7 +195,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByForeignKeysAsync(foreignKeys: List<String>): CompletableFuture<List<BatchUserPublicKeyResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getUserPublicKeyByForeignKeysRequest(foreignKeys) }
+        return completableFuture { getUserPublicKeyByForeignKeys(foreignKeys) }
     }
 
     override suspend fun unlock(unlockOperation: LockOperations.UnlockOperation) {
@@ -205,7 +203,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun unlockAsync(unlockOperation: LockOperations.UnlockOperation): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.unlockRequest(unlockOperation) }
+        return completableFuture { unlock(unlockOperation) }
     }
 
     override suspend fun shareLock(shareLockOperation: LockOperations.ShareLockOperation) {
@@ -213,7 +211,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun shareLockAsync(shareLockOperation: LockOperations.ShareLockOperation): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.shareLockRequest(shareLockOperation) }
+        return completableFuture { shareLock(shareLockOperation) }
     }
 
     override suspend fun revokeAccessToLock(revokeAccessToLockOperation: LockOperations.RevokeAccessToLockOperation) {
@@ -221,7 +219,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun revokeAccessToLockAsync(revokeAccessToLockOperation: LockOperations.RevokeAccessToLockOperation): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.revokeAccessToLockRequest(revokeAccessToLockOperation) }
+        return completableFuture { revokeAccessToLock(revokeAccessToLockOperation) }
     }
 
     override suspend fun updateSecureSettingUnlockDuration(updateSecureSettingUnlockDuration: LockOperations.UpdateSecureSettingUnlockDuration) {
@@ -229,7 +227,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateSecureSettingUnlockDurationAsync(updateSecureSettingUnlockDuration: LockOperations.UpdateSecureSettingUnlockDuration): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateSecureSettingUnlockDurationRequest(updateSecureSettingUnlockDuration) }
+        return completableFuture { updateSecureSettingUnlockDuration(updateSecureSettingUnlockDuration) }
     }
 
     override suspend fun updateSecureSettingUnlockBetween(updateSecureSettingUnlockBetween: LockOperations.UpdateSecureSettingUnlockBetween) {
@@ -237,7 +235,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun updateSecureSettingUnlockBetweenAsync(updateSecureSettingUnlockBetween: LockOperations.UpdateSecureSettingUnlockBetween): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.updateSecureSettingUnlockBetweenRequest(updateSecureSettingUnlockBetween) }
+        return completableFuture { updateSecureSettingUnlockBetween(updateSecureSettingUnlockBetween) }
     }
 
     override suspend fun getPinnedLocks(): List<LockResponse> {
@@ -245,7 +243,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getPinnedLocksAsync(): CompletableFuture<List<LockResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getPinnedLocksRequest() }
+        return completableFuture { getPinnedLocks() }
     }
 
     override suspend fun getShareableLocks(): List<ShareableLockResponse> {
@@ -253,6 +251,6 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getShareableLocksAsync(): CompletableFuture<List<ShareableLockResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { LockOperationsClient.getShareableLocksRequest() }
+        return completableFuture { getShareableLocks() }
     }
 }

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/PlatformResourceImpl.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/PlatformResourceImpl.jvm.kt
@@ -5,9 +5,7 @@ import com.doordeck.multiplatform.sdk.api.model.Platform
 import com.doordeck.multiplatform.sdk.api.responses.ApplicationOwnerDetailsResponse
 import com.doordeck.multiplatform.sdk.api.responses.ApplicationResponse
 import com.doordeck.multiplatform.sdk.api.responses.GetLogoUploadUrlResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object PlatformResourceImpl : PlatformResource {
@@ -17,7 +15,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun createApplicationAsync(application: Platform.CreateApplication): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.createApplicationRequest(application) }
+        return completableFuture { createApplication(application) }
     }
 
     override suspend fun listApplications(): List<ApplicationResponse> {
@@ -25,7 +23,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun listApplicationsAsync(): CompletableFuture<List<ApplicationResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.listApplicationsRequest() }
+        return completableFuture { listApplications() }
     }
 
     override suspend fun getApplication(applicationId: String): ApplicationResponse {
@@ -33,7 +31,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun getApplicationAsync(applicationId: String): CompletableFuture<ApplicationResponse> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.getApplicationRequest(applicationId) }
+        return completableFuture { getApplication(applicationId) }
     }
 
     override suspend fun updateApplicationName(applicationId: String, name: String) {
@@ -41,7 +39,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationNameAsync(applicationId: String, name: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationNameRequest(applicationId, name) }
+        return completableFuture { updateApplicationName(applicationId, name) }
     }
 
     override suspend fun updateApplicationCompanyName(applicationId: String, companyName: String) {
@@ -49,7 +47,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationCompanyNameAsync(applicationId: String, companyName: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationCompanyNameRequest(applicationId, companyName) }
+        return completableFuture { updateApplicationCompanyName(applicationId, companyName) }
     }
 
     override suspend fun updateApplicationMailingAddress(applicationId: String, mailingAddress: String) {
@@ -57,7 +55,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationMailingAddressAsync(applicationId: String, mailingAddress: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationMailingAddressRequest(applicationId, mailingAddress) }
+        return completableFuture { updateApplicationMailingAddress(applicationId, mailingAddress) }
     }
 
     override suspend fun updateApplicationPrivacyPolicy(applicationId: String, privacyPolicy: String) {
@@ -65,7 +63,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationPrivacyPolicyAsync(applicationId: String, privacyPolicy: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationPrivacyPolicyRequest(applicationId, privacyPolicy) }
+        return completableFuture { updateApplicationPrivacyPolicy(applicationId, privacyPolicy) }
     }
 
     override suspend fun updateApplicationSupportContact(applicationId: String, supportContact: String) {
@@ -73,7 +71,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationSupportContactAsync(applicationId: String, supportContact: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationSupportContactRequest(applicationId, supportContact) }
+        return completableFuture { updateApplicationSupportContact(applicationId, supportContact) }
     }
 
     override suspend fun updateApplicationAppLink(applicationId: String, appLink: String) {
@@ -81,7 +79,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationAppLinkAsync(applicationId: String, appLink: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationAppLinkRequest(applicationId, appLink) }
+        return completableFuture { updateApplicationAppLink(applicationId, appLink) }
     }
 
     override suspend fun updateApplicationEmailPreferences(applicationId: String, emailPreferences: Platform.EmailPreferences) {
@@ -89,7 +87,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationEmailPreferencesAsync(applicationId: String, emailPreferences: Platform.EmailPreferences): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationEmailPreferencesRequest(applicationId, emailPreferences) }
+        return completableFuture { updateApplicationEmailPreferences(applicationId, emailPreferences) }
     }
 
     override suspend fun updateApplicationLogoUrl(applicationId: String, logoUrl: String) {
@@ -97,7 +95,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun updateApplicationLogoUrlAsync(applicationId: String, logoUrl: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.updateApplicationLogoUrlRequest(applicationId, logoUrl) }
+        return completableFuture { updateApplicationLogoUrl(applicationId, logoUrl) }
     }
 
     override suspend fun deleteApplication(applicationId: String) {
@@ -105,7 +103,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun deleteApplicationAsync(applicationId: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.deleteApplicationRequest(applicationId) }
+        return completableFuture { deleteApplication(applicationId) }
     }
 
     override suspend fun getLogoUploadUrl(applicationId: String, contentType: String): GetLogoUploadUrlResponse {
@@ -113,7 +111,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun getLogoUploadUrlAsync(applicationId: String, contentType: String): CompletableFuture<GetLogoUploadUrlResponse> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.getLogoUploadUrlRequest(applicationId, contentType) }
+        return completableFuture { getLogoUploadUrl(applicationId, contentType) }
     }
 
     override suspend fun addAuthKey(applicationId: String, key: Platform.AuthKey) {
@@ -121,7 +119,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun addAuthKeyAsync(applicationId: String, key: Platform.AuthKey): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.addAuthKeyRequest(applicationId, key) }
+        return completableFuture { addAuthKey(applicationId, key) }
     }
 
     override suspend fun addAuthIssuer(applicationId: String, url: String) {
@@ -129,7 +127,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun addAuthIssuerAsync(applicationId: String, url: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.addAuthIssuerRequest(applicationId, url) }
+        return completableFuture { addAuthIssuer(applicationId, url) }
     }
 
     override suspend fun deleteAuthIssuer(applicationId: String, url: String) {
@@ -137,7 +135,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun deleteAuthIssuerAsync(applicationId: String, url: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.deleteAuthIssuerRequest(applicationId, url) }
+        return completableFuture { deleteAuthIssuer(applicationId, url) }
     }
 
     override suspend fun addCorsDomain(applicationId: String, url: String) {
@@ -145,7 +143,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun addCorsDomainAsync(applicationId: String, url: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.addCorsDomainRequest(applicationId, url) }
+        return completableFuture { addCorsDomain(applicationId, url) }
     }
 
     override suspend fun removeCorsDomain(applicationId: String, url: String) {
@@ -153,7 +151,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun removeCorsDomainAsync(applicationId: String, url: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.removeCorsDomainRequest(applicationId, url) }
+        return completableFuture { removeCorsDomain(applicationId, url) }
     }
 
     override suspend fun addApplicationOwner(applicationId: String, userId: String) {
@@ -161,7 +159,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun addApplicationOwnerAsync(applicationId: String, userId: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.addApplicationOwnerRequest(applicationId, userId) }
+        return completableFuture { addApplicationOwner(applicationId, userId) }
     }
 
     override suspend fun removeApplicationOwner(applicationId: String, userId: String) {
@@ -169,7 +167,7 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun removeApplicationOwnerAsync(applicationId: String, userId: String): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.removeApplicationOwnerRequest(applicationId, userId) }
+        return completableFuture { removeApplicationOwner(applicationId, userId) }
     }
 
     override suspend fun getApplicationOwnersDetails(applicationId: String): List<ApplicationOwnerDetailsResponse> {
@@ -177,6 +175,6 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun getApplicationOwnersDetailsAsync(applicationId: String): CompletableFuture<List<ApplicationOwnerDetailsResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { PlatformClient.getApplicationOwnersDetailsRequest(applicationId) }
+        return completableFuture { getApplicationOwnersDetails(applicationId) }
     }
 }

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/SitesResourceImpl.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/SitesResourceImpl.jvm.kt
@@ -4,9 +4,7 @@ import com.doordeck.multiplatform.sdk.api.SitesResource
 import com.doordeck.multiplatform.sdk.api.responses.SiteLocksResponse
 import com.doordeck.multiplatform.sdk.api.responses.SiteResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserForSiteResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object SitesResourceImpl : SitesResource {
@@ -16,7 +14,7 @@ internal object SitesResourceImpl : SitesResource {
     }
 
     override fun listSitesAsync(): CompletableFuture<List<SiteResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { SitesClient.listSitesRequest() }
+        return completableFuture { listSites() }
     }
 
     override suspend fun getLocksForSite(siteId: String): List<SiteLocksResponse> {
@@ -24,7 +22,7 @@ internal object SitesResourceImpl : SitesResource {
     }
 
     override fun getLocksForSiteAsync(siteId: String): CompletableFuture<List<SiteLocksResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { SitesClient.getLocksForSiteRequest(siteId) }
+        return completableFuture { getLocksForSite(siteId) }
     }
 
     override suspend fun getUsersForSite(siteId: String): List<UserForSiteResponse> {
@@ -32,6 +30,6 @@ internal object SitesResourceImpl : SitesResource {
     }
 
     override fun getUsersForSiteAsync(siteId: String): CompletableFuture<List<UserForSiteResponse>> {
-        return GlobalScope.future(Dispatchers.IO) { SitesClient.getUsersForSiteRequest(siteId) }
+        return completableFuture { getUsersForSite(siteId) }
     }
 }

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/TilesResourceImpl.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/TilesResourceImpl.jvm.kt
@@ -2,9 +2,7 @@ package com.doordeck.multiplatform.sdk.internal.api
 
 import com.doordeck.multiplatform.sdk.api.TilesResource
 import com.doordeck.multiplatform.sdk.api.responses.TileLocksResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
+import com.doordeck.multiplatform.sdk.util.completableFuture
 import java.util.concurrent.CompletableFuture
 
 internal object TilesResourceImpl : TilesResource {
@@ -14,7 +12,7 @@ internal object TilesResourceImpl : TilesResource {
     }
 
     override fun getLocksBelongingToTileAsync(tileId: String): CompletableFuture<TileLocksResponse> {
-        return GlobalScope.future(Dispatchers.IO) { TilesClient.getLocksBelongingToTileRequest(tileId) }
+        return completableFuture { getLocksBelongingToTile(tileId) }
     }
 
     override suspend fun associateMultipleLocks(tileId: String, siteId: String, lockIds: List<String>) {
@@ -22,6 +20,6 @@ internal object TilesResourceImpl : TilesResource {
     }
 
     override fun associateMultipleLocksAsync(tileId: String, siteId: String, lockIds: List<String>): CompletableFuture<Unit> {
-        return GlobalScope.future(Dispatchers.IO) { TilesClient.associateMultipleLocksRequest(tileId, siteId, lockIds) }
+        return completableFuture { associateMultipleLocks(tileId, siteId, lockIds) }
     }
 }

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.jvm.kt
@@ -4,8 +4,12 @@ import com.doordeck.multiplatform.sdk.Constants.CERTIFICATE_PINNER_DOMAIN_PATTER
 import com.doordeck.multiplatform.sdk.Constants.TRUSTED_CERTIFICATES
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.okhttp.OkHttpConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.future
 import okhttp3.CertificatePinner
 import okhttp3.OkHttpClient
+import java.util.concurrent.CompletableFuture
 
 internal actual fun HttpClientConfig<*>.installCertificatePinner() {
     engine {
@@ -17,5 +21,23 @@ internal actual fun HttpClientConfig<*>.installCertificatePinner() {
                 .certificatePinner(certificatePinner)
                 .build()
         }
+    }
+}
+
+/**
+ * Creates a `CompletableFuture` from a suspendable function.
+ *
+ * This function executes the given suspend function within a coroutine context
+ * and returns a `CompletableFuture` that completes once the suspend function
+ * finishes. The coroutine is launched in the `IO` dispatcher.
+ *
+ * @param T The type of the result produced by the suspend function.
+ * @param block The suspend function that will be executed asynchronously.
+ *
+ * @return A `CompletableFuture` that completes with the result of the suspend function.
+ */
+internal inline fun <reified T>completableFuture(crossinline block: suspend () -> T): CompletableFuture<T> {
+    return GlobalScope.future(Dispatchers.IO) {
+        block()
     }
 }


### PR DESCRIPTION
A small simplification for the `async` calls: the `async` calls now invoke the suspend functions from the same object instead of the client. Additionally, I added `completableFuture` and `promise` functions that allow us to make changes to how we handle `async` operations in a single place.