### PR TITLE
CSharp updates

### DIFF
--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.android.kt
@@ -219,7 +219,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun batchShareLockAsync(batchShareLockOperation: LockOperations.BatchShareLockOperation): CompletableFuture<Unit> {
-        return completableFuture { LockOperationsClient.batchShareLockRequest(batchShareLockOperation) }
+        return completableFuture { batchShareLock(batchShareLockOperation) }
     }
 
     override suspend fun revokeAccessToLock(revokeAccessToLockOperation: LockOperations.RevokeAccessToLockOperation) {

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.jvm.kt
@@ -219,7 +219,7 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun batchShareLockAsync(batchShareLockOperation: LockOperations.BatchShareLockOperation): CompletableFuture<Unit> {
-        return completableFuture { LockOperationsClient.batchShareLockRequest(batchShareLockOperation) }
+        return completableFuture { batchShareLock(batchShareLockOperation) }
     }
 
     override suspend fun revokeAccessToLock(revokeAccessToLockOperation: LockOperations.RevokeAccessToLockOperation) {

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountResource.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountResource.mingw.kt
@@ -25,6 +25,7 @@ actual interface AccountResource {
      * @see <a href="https://developer.doordeck.com/docs/#logout">API Doc</a>
      */
     fun logout()
+    fun logoutJson(): String
 
     /**
      * Register ephemeral key
@@ -57,6 +58,8 @@ actual interface AccountResource {
      */
     @DoordeckOnly
     fun reverifyEmail()
+    @DoordeckOnly
+    fun reverifyEmailJson(): String
 
     /**
      * Change password
@@ -66,7 +69,7 @@ actual interface AccountResource {
     @DoordeckOnly
     fun changePassword(oldPassword: String, newPassword: String)
     @DoordeckOnly
-    fun changePasswordJson(data: String)
+    fun changePasswordJson(data: String): String
 
     /**
      * Get user details
@@ -82,7 +85,7 @@ actual interface AccountResource {
      * @see <a href="https://developer.doordeck.com/docs/#update-user-details">API Doc</a>
      */
     fun updateUserDetails(displayName: String)
-    fun updateUserDetailsJson(data: String)
+    fun updateUserDetailsJson(data: String): String
 
     /**
      * Delete account
@@ -90,6 +93,7 @@ actual interface AccountResource {
      * @see <a href="https://developer.doordeck.com/docs/#delete-account">API Doc</a>
      */
     fun deleteAccount()
+    fun deleteAccountJson(): String
 }
 
 actual fun account(): AccountResource = AccountResourceImpl

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountlessResource.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountlessResource.mingw.kt
@@ -26,19 +26,19 @@ actual interface AccountlessResource {
      * @see <a href="https://developer.doordeck.com/docs/#verify-email">API Doc</a>
      */
     fun verifyEmail(code: String)
-    fun verifyEmailJson(data: String)
+    fun verifyEmailJson(data: String): String
 
     /**
      * Password reset
      */
     fun passwordReset(email: String)
-    fun passwordResetJson(data: String)
+    fun passwordResetJson(data: String): String
 
     /**
      * Password reset verify
      */
     fun passwordResetVerify(userId: String, token: String, password: String)
-    fun passwordResetVerifyJson(data: String)
+    fun passwordResetVerifyJson(data: String): String
 }
 
 actual fun accountless(): AccountlessResource = AccountlessResourceImpl

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/FusionResource.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/FusionResource.mingw.kt
@@ -31,13 +31,13 @@ actual interface FusionResource {
     fun enableDoor(name: String, siteId: String, controller: Fusion.LockController)
 
     @DoordeckOnly
-    fun enableDoorJson(data: String)
+    fun enableDoorJson(data: String): String
 
     @DoordeckOnly
     fun deleteDoor(deviceId: String)
 
     @DoordeckOnly
-    fun deleteDoorJson(data: String)
+    fun deleteDoorJson(data: String): String
 
     @DoordeckOnly
     fun getDoorStatus(deviceId: String): DoorStateResponse
@@ -49,13 +49,13 @@ actual interface FusionResource {
     fun startDoor(deviceId: String)
 
     @DoordeckOnly
-    fun startDoorJson(data: String)
+    fun startDoorJson(data: String): String
 
     @DoordeckOnly
     fun stopDoor(deviceId: String)
 
     @DoordeckOnly
-    fun stopDoorJson(data: String)
+    fun stopDoorJson(data: String): String
 }
 
 actual fun fusion(): FusionResource = FusionResourceImpl

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/HelperResource.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/HelperResource.mingw.kt
@@ -6,7 +6,7 @@ import com.doordeck.multiplatform.sdk.internal.api.HelperResourceImpl
 
 actual interface HelperResource {
     fun uploadPlatformLogo(applicationId: String, contentType: String, image: ByteArray)
-    fun uploadPlatformLogoJson(data: String)
+    fun uploadPlatformLogoJson(data: String): String
 
     fun assistedLogin(email: String, password: String): AssistedLoginResponse
     fun assistedLoginJson(data: String): String
@@ -15,7 +15,7 @@ actual interface HelperResource {
     fun assistedRegisterEphemeralKeyJson(data: String? = null): String
 
     fun assistedRegister(email: String, password: String, displayName: String? = null, force: Boolean = false)
-    fun assistedRegisterJson(data: String)
+    fun assistedRegisterJson(data: String): String
 }
 
 actual fun helper(): HelperResource = HelperResourceImpl

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsResource.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsResource.mingw.kt
@@ -58,7 +58,7 @@ actual interface LockOperationsResource {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     fun updateLockName(lockId: String, name: String? = null)
-    fun updateLockNameJson(data: String)
+    fun updateLockNameJson(data: String): String
 
     /**
      * Update lock properties - Favourite
@@ -66,7 +66,7 @@ actual interface LockOperationsResource {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     fun updateLockFavourite(lockId: String, favourite: Boolean? = null)
-    fun updateLockFavouriteJson(data: String)
+    fun updateLockFavouriteJson(data: String): String
 
     /**
      * Update lock properties - Colour
@@ -74,7 +74,7 @@ actual interface LockOperationsResource {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     fun updateLockColour(lockId: String, colour: String? = null)
-    fun updateLockColourJson(data: String)
+    fun updateLockColourJson(data: String): String
 
     /**
      * Update lock properties - Settings - Default name
@@ -82,7 +82,7 @@ actual interface LockOperationsResource {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     fun updateLockSettingDefaultName(lockId: String, name: String? = null)
-    fun updateLockSettingDefaultNameJson(data: String)
+    fun updateLockSettingDefaultNameJson(data: String): String
 
     /**
      * Set lock properties - Settings - Permitted addresses
@@ -90,7 +90,7 @@ actual interface LockOperationsResource {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     fun setLockSettingPermittedAddresses(lockId: String, permittedAddresses: List<String>)
-    fun setLockSettingPermittedAddressesJson(data: String)
+    fun setLockSettingPermittedAddressesJson(data: String): String
 
     /**
      * Update lock properties - Settings - Hidden
@@ -98,7 +98,7 @@ actual interface LockOperationsResource {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     fun updateLockSettingHidden(lockId: String, hidden: Boolean)
-    fun updateLockSettingHiddenJson(data: String)
+    fun updateLockSettingHiddenJson(data: String): String
 
     /**
      * Set lock properties - Settings - Usage requirements - Time
@@ -106,7 +106,7 @@ actual interface LockOperationsResource {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     fun setLockSettingTimeRestrictions(lockId: String, times: List<LockOperations.TimeRequirement>)
-    fun setLockSettingTimeRestrictionsJson(data: String)
+    fun setLockSettingTimeRestrictionsJson(data: String): String
 
     /**
      * Update lock properties - Settings - Usage requirements - Location
@@ -114,7 +114,7 @@ actual interface LockOperationsResource {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     fun updateLockSettingLocationRestrictions(lockId: String, location: LockOperations.LocationRequirement? = null)
-    fun updateLockSettingLocationRestrictionsJson(data: String)
+    fun updateLockSettingLocationRestrictionsJson(data: String): String
 
     /**
      * Get user’s public key
@@ -204,7 +204,7 @@ actual interface LockOperationsResource {
      * @see <a href="https://developer.doordeck.com/docs/#unlock">API Doc</a>
      */
     fun unlock(unlockOperation: LockOperations.UnlockOperation)
-    fun unlockJson(data: String)
+    fun unlockJson(data: String): String
 
     /**
      * Share a lock
@@ -212,15 +212,15 @@ actual interface LockOperationsResource {
      * @see <a href="https://developer.doordeck.com/docs/#share-a-lock">API Doc</a>
      */
     fun shareLock(shareLockOperation: LockOperations.ShareLockOperation)
-    fun shareLockJson(data: String)
+    fun shareLockJson(data: String): String
 
     /**
      * Batch share a lock
      *
      * @see <a href="https://developer.doordeck.com/docs/#batch-share-a-lock-v2">API Doc</a>
      */
-    suspend fun batchShareLock(batchShareLockOperation: LockOperations.BatchShareLockOperation)
-    fun batchShareLockJson(data: String)
+    fun batchShareLock(batchShareLockOperation: LockOperations.BatchShareLockOperation)
+    fun batchShareLockJson(data: String): String
 
     /**
      * Revoke access to a lock
@@ -228,7 +228,7 @@ actual interface LockOperationsResource {
      * @see <a href="https://developer.doordeck.com/docs/#revoke-access-to-a-lock">API Doc</a>
      */
     fun revokeAccessToLock(revokeAccessToLockOperation: LockOperations.RevokeAccessToLockOperation)
-    fun revokeAccessToLockJson(data: String)
+    fun revokeAccessToLockJson(data: String): String
 
     /**
      * Update secure settings - Unlock duration
@@ -236,7 +236,7 @@ actual interface LockOperationsResource {
      * @see <a href="https://developer.doordeck.com/docs/#update-secure-settings">API Doc</a>
      */
     fun updateSecureSettingUnlockDuration(updateSecureSettingUnlockDuration: LockOperations.UpdateSecureSettingUnlockDuration)
-    fun updateSecureSettingUnlockDurationJson(data: String)
+    fun updateSecureSettingUnlockDurationJson(data: String): String
 
     /**
      * Update secure settings - Unlock between
@@ -244,7 +244,7 @@ actual interface LockOperationsResource {
      * @see <a href="https://developer.doordeck.com/docs/#update-secure-settings">API Doc</a>
      */
     fun updateSecureSettingUnlockBetween(updateSecureSettingUnlockBetween: LockOperations.UpdateSecureSettingUnlockBetween)
-    fun updateSecureSettingUnlockBetweenJson(data: String)
+    fun updateSecureSettingUnlockBetweenJson(data: String): String
 
     /**
      * Get pinned locks

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/PlatformResource.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/PlatformResource.mingw.kt
@@ -16,7 +16,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun createApplication(application: Platform.CreateApplication)
     @DoordeckOnly
-    fun createApplicationJson(data: String)
+    fun createApplicationJson(data: String): String
 
     /**
      * List applications
@@ -46,7 +46,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun updateApplicationName(applicationId: String, name: String)
     @DoordeckOnly
-    fun updateApplicationNameJson(data: String)
+    fun updateApplicationNameJson(data: String): String
 
     /**
      * Update application - Company name
@@ -56,7 +56,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun updateApplicationCompanyName(applicationId: String, companyName: String)
     @DoordeckOnly
-    fun updateApplicationCompanyNameJson(data: String)
+    fun updateApplicationCompanyNameJson(data: String): String
 
     /**
      * Update application - Mailing address
@@ -66,7 +66,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun updateApplicationMailingAddress(applicationId: String, mailingAddress: String)
     @DoordeckOnly
-    fun updateApplicationMailingAddressJson(data: String)
+    fun updateApplicationMailingAddressJson(data: String): String
 
     /**
      * Update application - Privacy policy
@@ -76,7 +76,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun updateApplicationPrivacyPolicy(applicationId: String, privacyPolicy: String)
     @DoordeckOnly
-    fun updateApplicationPrivacyPolicyJson(data: String)
+    fun updateApplicationPrivacyPolicyJson(data: String): String
 
     /**
      * Update application - Support contact
@@ -86,7 +86,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun updateApplicationSupportContact(applicationId: String, supportContact: String)
     @DoordeckOnly
-    fun updateApplicationSupportContactJson(data: String)
+    fun updateApplicationSupportContactJson(data: String): String
 
     /**
      * Update application - App link
@@ -96,7 +96,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun updateApplicationAppLink(applicationId: String, appLink: String)
     @DoordeckOnly
-    fun updateApplicationAppLinkJson(data: String)
+    fun updateApplicationAppLinkJson(data: String): String
 
     /**
      * Update application - Email preferences
@@ -106,7 +106,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun updateApplicationEmailPreferences(applicationId: String, emailPreferences: Platform.EmailPreferences)
     @DoordeckOnly
-    fun updateApplicationEmailPreferencesJson(data: String)
+    fun updateApplicationEmailPreferencesJson(data: String): String
 
     /**
      * Update application - Logo url
@@ -116,7 +116,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun updateApplicationLogoUrl(applicationId: String, logoUrl: String)
     @DoordeckOnly
-    fun updateApplicationLogoUrlJson(data: String)
+    fun updateApplicationLogoUrlJson(data: String): String
 
     /**
      * Delete application
@@ -126,7 +126,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun deleteApplication(applicationId: String)
     @DoordeckOnly
-    fun deleteApplicationJson(data: String)
+    fun deleteApplicationJson(data: String): String
 
     /**
      * Get logo upload URL
@@ -146,7 +146,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun addAuthKey(applicationId: String, key: Platform.AuthKey)
     @DoordeckOnly
-    fun addAuthKeyJson(data: String)
+    fun addAuthKeyJson(data: String): String
 
     /**
      * Add auth issuer
@@ -156,7 +156,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun addAuthIssuer(applicationId: String, url: String)
     @DoordeckOnly
-    fun addAuthIssuerJson(data: String)
+    fun addAuthIssuerJson(data: String): String
 
     /**
      * Delete auth issuer
@@ -166,7 +166,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun deleteAuthIssuer(applicationId: String, url: String)
     @DoordeckOnly
-    fun deleteAuthIssuerJson(data: String)
+    fun deleteAuthIssuerJson(data: String): String
 
     /**
      * Add CORS domain
@@ -176,7 +176,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun addCorsDomain(applicationId: String, url: String)
     @DoordeckOnly
-    fun addCorsDomainJson(data: String)
+    fun addCorsDomainJson(data: String): String
 
     /**
      * Remove CORS domain
@@ -186,7 +186,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun removeCorsDomain(applicationId: String, url: String)
     @DoordeckOnly
-    fun removeCorsDomainJson(data: String)
+    fun removeCorsDomainJson(data: String): String
 
     /**
      * Add application owner
@@ -196,7 +196,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun addApplicationOwner(applicationId: String, userId: String)
     @DoordeckOnly
-    fun addApplicationOwnerJson(data: String)
+    fun addApplicationOwnerJson(data: String): String
 
     /**
      * Remove application owner
@@ -206,7 +206,7 @@ actual interface PlatformResource {
     @DoordeckOnly
     fun removeApplicationOwner(applicationId: String, userId: String)
     @DoordeckOnly
-    fun removeApplicationOwnerJson(data: String)
+    fun removeApplicationOwnerJson(data: String): String
 
     /**
      * Get application owners details

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/TilesResource.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/TilesResource.mingw.kt
@@ -21,7 +21,7 @@ actual interface TilesResource {
     @SiteAdmin
     fun associateMultipleLocks(tileId: String, siteId: String, lockIds: List<String>)
     @SiteAdmin
-    fun associateMultipleLocksJson(data: String)
+    fun associateMultipleLocksJson(data: String): String
 }
 
 actual fun tiles(): TilesResource = TilesResourceImpl

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/model/ResultData.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/model/ResultData.kt
@@ -1,0 +1,20 @@
+package com.doordeck.multiplatform.sdk.api.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResultData<T>(
+    val success: SuccessResultData<T>? = null,
+    val failure: FailedResultData? = null
+)
+
+@Serializable
+data class SuccessResultData<T>(
+    val result: T? = null
+)
+
+@Serializable
+data class FailedResultData(
+    val exceptionType: String,
+    val exceptionMessage: String
+)

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountResourceImpl.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountResourceImpl.mingw.kt
@@ -14,7 +14,7 @@ import com.doordeck.multiplatform.sdk.api.responses.TokenResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserDetailsResponse
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
 import com.doordeck.multiplatform.sdk.util.fromJson
-import com.doordeck.multiplatform.sdk.util.toJson
+import com.doordeck.multiplatform.sdk.util.resultData
 import kotlinx.coroutines.runBlocking
 
 internal object AccountResourceImpl : AccountResource {
@@ -24,12 +24,20 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun refreshTokenJson(data: String?): String {
-        val refreshTokenData = data?.fromJson<RefreshTokenData>()
-        return refreshToken(refreshTokenData?.refreshToken).toJson()
+        return resultData {
+            val refreshTokenData = data?.fromJson<RefreshTokenData>()
+            refreshToken(refreshTokenData?.refreshToken)
+        }
     }
 
     override fun logout() {
         return runBlocking { AccountClient.logoutRequest() }
+    }
+
+    override fun logoutJson(): String {
+        return resultData {
+            logout()
+        }
     }
 
     override fun registerEphemeralKey(publicKey: ByteArray?): RegisterEphemeralKeyResponse {
@@ -37,8 +45,10 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun registerEphemeralKeyJson(data: String?): String {
-        val registerEphemeralKeyData = data?.fromJson<RegisterEphemeralKeyData>()
-        return registerEphemeralKey(registerEphemeralKeyData?.publicKey?.decodeBase64ToByteArray()).toJson()
+        return resultData {
+            val registerEphemeralKeyData = data?.fromJson<RegisterEphemeralKeyData>()
+            registerEphemeralKey(registerEphemeralKeyData?.publicKey?.decodeBase64ToByteArray())
+        }
     }
 
     override fun registerEphemeralKeyWithSecondaryAuthentication(publicKey: ByteArray?, method: TwoFactorMethod?): RegisterEphemeralKeyWithSecondaryAuthenticationResponse {
@@ -46,8 +56,10 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun registerEphemeralKeyWithSecondaryAuthenticationJson(data: String?): String {
-        val registerEphemeralKeyWithSecondaryAuthenticationData = data?.fromJson<RegisterEphemeralKeyWithSecondaryAuthenticationData>()
-        return registerEphemeralKeyWithSecondaryAuthentication(registerEphemeralKeyWithSecondaryAuthenticationData?.publicKey?.decodeBase64ToByteArray(), registerEphemeralKeyWithSecondaryAuthenticationData?.method).toJson()
+        return resultData {
+            val registerEphemeralKeyWithSecondaryAuthenticationData = data?.fromJson<RegisterEphemeralKeyWithSecondaryAuthenticationData>()
+            registerEphemeralKeyWithSecondaryAuthentication(registerEphemeralKeyWithSecondaryAuthenticationData?.publicKey?.decodeBase64ToByteArray(), registerEphemeralKeyWithSecondaryAuthenticationData?.method)
+        }
     }
 
     override fun verifyEphemeralKeyRegistration(code: String, privateKey: ByteArray?): RegisterEphemeralKeyResponse {
@@ -55,21 +67,31 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun verifyEphemeralKeyRegistrationJson(data: String): String {
-        val verifyEphemeralKeyRegistrationData = data.fromJson<VerifyEphemeralKeyRegistrationData>()
-        return verifyEphemeralKeyRegistration(verifyEphemeralKeyRegistrationData.code, verifyEphemeralKeyRegistrationData.privateKey?.decodeBase64ToByteArray()).toJson()
+        return resultData {
+            val verifyEphemeralKeyRegistrationData = data.fromJson<VerifyEphemeralKeyRegistrationData>()
+            verifyEphemeralKeyRegistration(verifyEphemeralKeyRegistrationData.code, verifyEphemeralKeyRegistrationData.privateKey?.decodeBase64ToByteArray())
+        }
     }
 
     override fun reverifyEmail() {
         return runBlocking { AccountClient.reverifyEmailRequest() }
     }
 
+    override fun reverifyEmailJson(): String {
+        return resultData {
+            reverifyEmail()
+        }
+    }
+
     override fun changePassword(oldPassword: String, newPassword: String) {
         return runBlocking { AccountClient.changePasswordRequest(oldPassword, newPassword) }
     }
 
-    override fun changePasswordJson(data: String) {
-        val changePasswordData = data.fromJson<ChangePasswordData>()
-        return changePassword(changePasswordData.oldPassword, changePasswordData.newPassword)
+    override fun changePasswordJson(data: String): String {
+        return resultData {
+            val changePasswordData = data.fromJson<ChangePasswordData>()
+            changePassword(changePasswordData.oldPassword, changePasswordData.newPassword)
+        }
     }
 
     override fun getUserDetails(): UserDetailsResponse {
@@ -77,19 +99,29 @@ internal object AccountResourceImpl : AccountResource {
     }
 
     override fun getUserDetailsJson(): String {
-        return getUserDetails().toJson()
+        return resultData {
+            getUserDetails()
+        }
     }
 
     override fun updateUserDetails(displayName: String) {
         return runBlocking { AccountClient.updateUserDetailsRequest(displayName) }
     }
 
-    override fun updateUserDetailsJson(data: String) {
-        val updateUserDetailsData = data.fromJson<UpdateUserDetailsData>()
-        return updateUserDetails(updateUserDetailsData.displayName)
+    override fun updateUserDetailsJson(data: String): String {
+        return resultData {
+            val updateUserDetailsData = data.fromJson<UpdateUserDetailsData>()
+            updateUserDetails(updateUserDetailsData.displayName)
+        }
     }
 
     override fun deleteAccount() {
         return runBlocking { AccountClient.deleteAccountRequest() }
+    }
+
+    override fun deleteAccountJson(): String {
+        return resultData {
+            deleteAccount()
+        }
     }
 }

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountlessResourceImpl.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/AccountlessResourceImpl.mingw.kt
@@ -9,7 +9,7 @@ import com.doordeck.multiplatform.sdk.api.model.VerifyEmailData
 import com.doordeck.multiplatform.sdk.api.responses.TokenResponse
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
 import com.doordeck.multiplatform.sdk.util.fromJson
-import com.doordeck.multiplatform.sdk.util.toJson
+import com.doordeck.multiplatform.sdk.util.resultData
 import kotlinx.coroutines.runBlocking
 
 internal object AccountlessResourceImpl : AccountlessResource {
@@ -19,8 +19,10 @@ internal object AccountlessResourceImpl : AccountlessResource {
     }
 
     override fun loginJson(data: String): String {
-        val loginData = data.fromJson<LoginData>()
-        return login(loginData.email, loginData.password).toJson()
+        return resultData {
+            val loginData = data.fromJson<LoginData>()
+            login(loginData.email, loginData.password)
+        }
     }
 
     override fun registration(email: String, password: String, displayName: String?, force: Boolean, publicKey: ByteArray?): TokenResponse {
@@ -28,34 +30,42 @@ internal object AccountlessResourceImpl : AccountlessResource {
     }
 
     override fun registrationJson(data: String): String {
-        val registrationData = data.fromJson<RegistrationData>()
-        return registration(registrationData.email, registrationData.password, registrationData.displayName, registrationData.force, registrationData.publicKey?.decodeBase64ToByteArray()).toJson()
+        return resultData {
+            val registrationData = data.fromJson<RegistrationData>()
+            registration(registrationData.email, registrationData.password, registrationData.displayName, registrationData.force, registrationData.publicKey?.decodeBase64ToByteArray())
+        }
     }
 
     override fun verifyEmail(code: String) {
         return runBlocking { AccountlessClient.verifyEmailRequest(code) }
     }
 
-    override fun verifyEmailJson(data: String) {
-        val verifyEmailData = data.fromJson<VerifyEmailData>()
-        return verifyEmail(verifyEmailData.code)
+    override fun verifyEmailJson(data: String): String {
+        return resultData {
+            val verifyEmailData = data.fromJson<VerifyEmailData>()
+            verifyEmail(verifyEmailData.code)
+        }
     }
 
     override fun passwordReset(email: String) {
         return runBlocking { AccountlessClient.passwordResetRequest(email) }
     }
 
-    override fun passwordResetJson(data: String) {
-        val passwordResetData = data.fromJson<PasswordResetData>()
-        return passwordReset(passwordResetData.email)
+    override fun passwordResetJson(data: String): String {
+        return resultData {
+            val passwordResetData = data.fromJson<PasswordResetData>()
+            passwordReset(passwordResetData.email)
+        }
     }
 
     override fun passwordResetVerify(userId: String, token: String, password: String) {
         return runBlocking { AccountlessClient.passwordResetVerifyRequest(userId, token, password) }
     }
 
-    override fun passwordResetVerifyJson(data: String) {
-        val passwordResetVerifyData = data.fromJson<PasswordResetVerifyData>()
-        return passwordResetVerify(passwordResetVerifyData.userId, passwordResetVerifyData.token, passwordResetVerifyData.password)
+    override fun passwordResetVerifyJson(data: String): String {
+        return resultData {
+            val passwordResetVerifyData = data.fromJson<PasswordResetVerifyData>()
+            passwordResetVerify(passwordResetVerifyData.userId, passwordResetVerifyData.token, passwordResetVerifyData.password)
+        }
     }
 }

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/FusionResourceImpl.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/FusionResourceImpl.mingw.kt
@@ -14,7 +14,7 @@ import com.doordeck.multiplatform.sdk.api.responses.FusionLoginResponse
 import com.doordeck.multiplatform.sdk.api.responses.IntegrationConfigurationResponse
 import com.doordeck.multiplatform.sdk.api.responses.IntegrationTypeResponse
 import com.doordeck.multiplatform.sdk.util.fromJson
-import com.doordeck.multiplatform.sdk.util.toJson
+import com.doordeck.multiplatform.sdk.util.resultData
 import kotlinx.coroutines.runBlocking
 
 internal object FusionResourceImpl : FusionResource {
@@ -24,8 +24,10 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun loginJson(data: String): String {
-        val fusionLoginData = data.fromJson<FusionLoginData>()
-        return login(fusionLoginData.email, fusionLoginData.password).toJson()
+        return resultData {
+            val fusionLoginData = data.fromJson<FusionLoginData>()
+            login(fusionLoginData.email, fusionLoginData.password)
+        }
     }
 
     override fun getIntegrationType(): IntegrationTypeResponse {
@@ -33,7 +35,9 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun getIntegrationTypeJson(): String {
-        return getIntegrationType().toJson()
+        return resultData {
+            getIntegrationType()
+        }
     }
 
     override fun getIntegrationConfiguration(type: String): List<IntegrationConfigurationResponse> {
@@ -41,26 +45,32 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun getIntegrationConfigurationJson(data: String): String {
-        val getIntegrationConfigurationData = data.fromJson<GetIntegrationConfigurationData>()
-        return getIntegrationConfiguration(getIntegrationConfigurationData.type).toJson()
+        return resultData {
+            val getIntegrationConfigurationData = data.fromJson<GetIntegrationConfigurationData>()
+            getIntegrationConfiguration(getIntegrationConfigurationData.type)
+        }
     }
 
     override fun enableDoor(name: String, siteId: String, controller: Fusion.LockController) {
         return runBlocking { FusionClient.enableDoorRequest(name, siteId, controller) }
     }
 
-    override fun enableDoorJson(data: String) {
-        val enableDoorData = data.fromJson<EnableDoorData>()
-        return enableDoor(enableDoorData.name, enableDoorData.siteId, enableDoorData.controller)
+    override fun enableDoorJson(data: String): String {
+        return resultData {
+            val enableDoorData = data.fromJson<EnableDoorData>()
+            enableDoor(enableDoorData.name, enableDoorData.siteId, enableDoorData.controller)
+        }
     }
 
     override fun deleteDoor(deviceId: String) {
         return runBlocking { FusionClient.deleteDoorRequest(deviceId) }
     }
 
-    override fun deleteDoorJson(data: String) {
-        val deleteDoorData = data.fromJson<DeleteDoorData>()
-        return deleteDoor(deleteDoorData.deviceId)
+    override fun deleteDoorJson(data: String): String {
+        return resultData {
+            val deleteDoorData = data.fromJson<DeleteDoorData>()
+            deleteDoor(deleteDoorData.deviceId)
+        }
     }
 
     override fun getDoorStatus(deviceId: String): DoorStateResponse {
@@ -68,25 +78,31 @@ internal object FusionResourceImpl : FusionResource {
     }
 
     override fun getDoorStatusJson(data: String): String {
-        val getDoorStatusData = data.fromJson<GetDoorStatusData>()
-        return getDoorStatus(getDoorStatusData.deviceId).toJson()
+        return resultData {
+            val getDoorStatusData = data.fromJson<GetDoorStatusData>()
+            getDoorStatus(getDoorStatusData.deviceId)
+        }
     }
 
     override fun startDoor(deviceId: String) {
         return runBlocking { FusionClient.startDoorRequest(deviceId) }
     }
 
-    override fun startDoorJson(data: String) {
-        val startDoorData = data.fromJson<StartDoorData>()
-        return startDoor(startDoorData.deviceId)
+    override fun startDoorJson(data: String): String {
+        return resultData {
+            val startDoorData = data.fromJson<StartDoorData>()
+            startDoor(startDoorData.deviceId)
+        }
     }
 
     override fun stopDoor(deviceId: String) {
         return runBlocking { FusionClient.stopDoorRequest(deviceId) }
     }
 
-    override fun stopDoorJson(data: String) {
-        val stopDoorData = data.fromJson<StopDoorData>()
-        return stopDoor(stopDoorData.deviceId)
+    override fun stopDoorJson(data: String): String {
+        return resultData {
+            val stopDoorData = data.fromJson<StopDoorData>()
+            stopDoor(stopDoorData.deviceId)
+        }
     }
 }

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/HelperResourceImpl.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/HelperResourceImpl.mingw.kt
@@ -9,7 +9,7 @@ import com.doordeck.multiplatform.sdk.api.responses.AssistedLoginResponse
 import com.doordeck.multiplatform.sdk.api.responses.AssistedRegisterEphemeralKeyResponse
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
 import com.doordeck.multiplatform.sdk.util.fromJson
-import com.doordeck.multiplatform.sdk.util.toJson
+import com.doordeck.multiplatform.sdk.util.resultData
 import kotlinx.coroutines.runBlocking
 
 internal object HelperResourceImpl : HelperResource {
@@ -18,9 +18,11 @@ internal object HelperResourceImpl : HelperResource {
         return runBlocking { HelperClient.uploadPlatformLogoRequest(applicationId, contentType, image) }
     }
 
-    override fun uploadPlatformLogoJson(data: String) {
-        val uploadPlatformLogoData = data.fromJson<UploadPlatformLogoData>()
-        return runBlocking { HelperClient.uploadPlatformLogoRequest(uploadPlatformLogoData.applicationId, uploadPlatformLogoData.contentType, uploadPlatformLogoData.image.decodeBase64ToByteArray()) }
+    override fun uploadPlatformLogoJson(data: String): String {
+        return resultData {
+            val uploadPlatformLogoData = data.fromJson<UploadPlatformLogoData>()
+            uploadPlatformLogo(uploadPlatformLogoData.applicationId, uploadPlatformLogoData.contentType, uploadPlatformLogoData.image.decodeBase64ToByteArray())
+        }
     }
 
     override fun assistedLogin(email: String, password: String): AssistedLoginResponse {
@@ -28,8 +30,10 @@ internal object HelperResourceImpl : HelperResource {
     }
 
     override fun assistedLoginJson(data: String): String {
-        val assistedLoginData = data.fromJson<AssistedLoginData>()
-        return runBlocking { HelperClient.assistedLoginRequest(assistedLoginData.email, assistedLoginData.password) }.toJson()
+        return resultData {
+            val assistedLoginData = data.fromJson<AssistedLoginData>()
+            assistedLogin(assistedLoginData.email, assistedLoginData.password)
+        }
     }
 
     override fun assistedRegisterEphemeralKey(publicKey: ByteArray?): AssistedRegisterEphemeralKeyResponse {
@@ -37,8 +41,10 @@ internal object HelperResourceImpl : HelperResource {
     }
 
     override fun assistedRegisterEphemeralKeyJson(data: String?): String {
-        val assistedRegisterEphemeralKeyData = data?.fromJson<AssistedRegisterEphemeralKeyData>()
-        return runBlocking { HelperClient.assistedRegisterEphemeralKeyRequest(assistedRegisterEphemeralKeyData?.publicKey?.decodeBase64ToByteArray()) }.toJson()
+        return resultData {
+            val assistedRegisterEphemeralKeyData = data?.fromJson<AssistedRegisterEphemeralKeyData>()
+            assistedRegisterEphemeralKey(assistedRegisterEphemeralKeyData?.publicKey?.decodeBase64ToByteArray())
+        }
     }
 
     override fun assistedRegister(email: String, password: String, displayName: String?, force: Boolean) {
@@ -52,10 +58,10 @@ internal object HelperResourceImpl : HelperResource {
         }
     }
 
-    override fun assistedRegisterJson(data: String) {
-        val assistedRegisterData = data.fromJson<AssistedRegisterData>()
-        return runBlocking {
-            HelperClient.assistedRegisterRequest(
+    override fun assistedRegisterJson(data: String): String {
+        return resultData {
+            val assistedRegisterData = data.fromJson<AssistedRegisterData>()
+            assistedRegister(
                 email = assistedRegisterData.email,
                 password = assistedRegisterData.password,
                 displayName = assistedRegisterData.displayName,

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsResourceImpl.mingw.kt
@@ -47,7 +47,7 @@ import com.doordeck.multiplatform.sdk.api.responses.ShareableLockResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserLockResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserPublicKeyResponse
 import com.doordeck.multiplatform.sdk.util.fromJson
-import com.doordeck.multiplatform.sdk.util.toJson
+import com.doordeck.multiplatform.sdk.util.resultData
 import kotlinx.coroutines.runBlocking
 
 internal object LockOperationsResourceImpl : LockOperationsResource {
@@ -57,8 +57,10 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getSingleLockJson(data: String): String {
-        val getSingleLockData = data.fromJson<GetSingleLockData>()
-        return getSingleLock(getSingleLockData.lockId).toJson()
+        return resultData {
+            val getSingleLockData = data.fromJson<GetSingleLockData>()
+            getSingleLock(getSingleLockData.lockId)
+        }
     }
 
     override fun getLockAuditTrail(lockId: String, start: Int, end: Int): List<AuditResponse> {
@@ -66,8 +68,10 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getLockAuditTrailJson(data: String): String {
-        val getLockAuditTrailData = data.fromJson<GetLockAuditTrailData>()
-        return getLockAuditTrail(getLockAuditTrailData.lockId, getLockAuditTrailData.start, getLockAuditTrailData.end).toJson()
+        return resultData {
+            val getLockAuditTrailData = data.fromJson<GetLockAuditTrailData>()
+            getLockAuditTrail(getLockAuditTrailData.lockId, getLockAuditTrailData.start, getLockAuditTrailData.end)
+        }
     }
 
     override fun getAuditForUser(userId: String, start: Int, end: Int): List<AuditResponse> {
@@ -75,8 +79,10 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getAuditForUserJson(data: String): String {
-        val getAuditForUserData = data.fromJson<GetAuditForUserData>()
-        return getAuditForUser(getAuditForUserData.userId, getAuditForUserData.start, getAuditForUserData.end).toJson()
+        return resultData {
+            val getAuditForUserData = data.fromJson<GetAuditForUserData>()
+            getAuditForUser(getAuditForUserData.userId, getAuditForUserData.start, getAuditForUserData.end)
+        }
     }
 
     override fun getUsersForLock(lockId: String): List<UserLockResponse> {
@@ -84,8 +90,10 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUsersForLockJson(data: String): String {
-        val getUsersForLockData = data.fromJson<GetUsersForLockData>()
-        return getUsersForLock(getUsersForLockData.lockId).toJson()
+        return resultData {
+            val getUsersForLockData = data.fromJson<GetUsersForLockData>()
+            getUsersForLock(getUsersForLockData.lockId)
+        }
     }
 
     override fun getLocksForUser(userId: String): LockUserResponse {
@@ -93,80 +101,98 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getLocksForUserJson(data: String): String {
-        val getLocksForUserData = data.fromJson<GetLocksForUserData>()
-        return getLocksForUser(getLocksForUserData.userId).toJson()
+        return resultData {
+            val getLocksForUserData = data.fromJson<GetLocksForUserData>()
+            getLocksForUser(getLocksForUserData.userId)
+        }
     }
 
     override fun updateLockName(lockId: String, name: String?) {
         return runBlocking { LockOperationsClient.updateLockNameRequest(lockId, name) }
     }
 
-    override fun updateLockNameJson(data: String) {
-        val updateLockNameData = data.fromJson<UpdateLockNameData>()
-        return updateLockName(updateLockNameData.lockId, updateLockNameData.name)
+    override fun updateLockNameJson(data: String): String {
+        return resultData {
+            val updateLockNameData = data.fromJson<UpdateLockNameData>()
+            updateLockName(updateLockNameData.lockId, updateLockNameData.name)
+        }
     }
 
     override fun updateLockFavourite(lockId: String, favourite: Boolean?) {
         return runBlocking { LockOperationsClient.updateLockFavouriteRequest(lockId, favourite) }
     }
 
-    override fun updateLockFavouriteJson(data: String) {
-        val updateLockFavouriteData = data.fromJson<UpdateLockFavouriteData>()
-        return updateLockFavourite(updateLockFavouriteData.lockId, updateLockFavouriteData.favourite)
+    override fun updateLockFavouriteJson(data: String): String {
+        return resultData {
+            val updateLockFavouriteData = data.fromJson<UpdateLockFavouriteData>()
+            updateLockFavourite(updateLockFavouriteData.lockId, updateLockFavouriteData.favourite)
+        }
     }
 
     override fun updateLockColour(lockId: String, colour: String?) {
         return runBlocking { LockOperationsClient.updateLockColourRequest(lockId, colour) }
     }
 
-    override fun updateLockColourJson(data: String) {
-        val updateLockColourData = data.fromJson<UpdateLockColourData>()
-        return updateLockColour(updateLockColourData.lockId, updateLockColourData.colour)
+    override fun updateLockColourJson(data: String): String {
+        return resultData {
+            val updateLockColourData = data.fromJson<UpdateLockColourData>()
+            updateLockColour(updateLockColourData.lockId, updateLockColourData.colour)
+        }
     }
 
     override fun updateLockSettingDefaultName(lockId: String, name: String?) {
         return runBlocking { LockOperationsClient.updateLockSettingDefaultNameRequest(lockId, name) }
     }
 
-    override fun updateLockSettingDefaultNameJson(data: String) {
-        val updateLockSettingDefaultNameData = data.fromJson<UpdateLockSettingDefaultNameData>()
-        return updateLockSettingDefaultName(updateLockSettingDefaultNameData.lockId, updateLockSettingDefaultNameData.name)
+    override fun updateLockSettingDefaultNameJson(data: String): String {
+        return resultData {
+            val updateLockSettingDefaultNameData = data.fromJson<UpdateLockSettingDefaultNameData>()
+            updateLockSettingDefaultName(updateLockSettingDefaultNameData.lockId, updateLockSettingDefaultNameData.name)
+        }
     }
 
     override fun setLockSettingPermittedAddresses(lockId: String, permittedAddresses: List<String>) {
         return runBlocking { LockOperationsClient.setLockSettingPermittedAddressesRequest(lockId, permittedAddresses) }
     }
 
-    override fun setLockSettingPermittedAddressesJson(data: String) {
-        val setLockSettingPermittedAddressesData = data.fromJson<SetLockSettingPermittedAddressesData>()
-        return setLockSettingPermittedAddresses(setLockSettingPermittedAddressesData.lockId, setLockSettingPermittedAddressesData.permittedAddresses)
+    override fun setLockSettingPermittedAddressesJson(data: String): String {
+        return resultData {
+            val setLockSettingPermittedAddressesData = data.fromJson<SetLockSettingPermittedAddressesData>()
+            setLockSettingPermittedAddresses(setLockSettingPermittedAddressesData.lockId, setLockSettingPermittedAddressesData.permittedAddresses)
+        }
     }
 
     override fun updateLockSettingHidden(lockId: String, hidden: Boolean) {
         return runBlocking { LockOperationsClient.updateLockSettingHiddenRequest(lockId, hidden) }
     }
 
-    override fun updateLockSettingHiddenJson(data: String) {
-        val updateLockSettingHiddenData = data.fromJson<UpdateLockSettingHiddenData>()
-        return updateLockSettingHidden(updateLockSettingHiddenData.lockId, updateLockSettingHiddenData.hidden)
+    override fun updateLockSettingHiddenJson(data: String): String {
+        return resultData {
+            val updateLockSettingHiddenData = data.fromJson<UpdateLockSettingHiddenData>()
+            updateLockSettingHidden(updateLockSettingHiddenData.lockId, updateLockSettingHiddenData.hidden)
+        }
     }
 
     override fun setLockSettingTimeRestrictions(lockId: String, times: List<LockOperations.TimeRequirement>) {
         return runBlocking { LockOperationsClient.setLockSettingTimeRestrictionsRequest(lockId, times) }
     }
 
-    override fun setLockSettingTimeRestrictionsJson(data: String) {
-        val setLockSettingTimeRestrictionsData = data.fromJson<SetLockSettingTimeRestrictionsData>()
-        return setLockSettingTimeRestrictions(setLockSettingTimeRestrictionsData.lockId, setLockSettingTimeRestrictionsData.times.toTimeRequirementList())
+    override fun setLockSettingTimeRestrictionsJson(data: String): String {
+        return resultData {
+            val setLockSettingTimeRestrictionsData = data.fromJson<SetLockSettingTimeRestrictionsData>()
+            setLockSettingTimeRestrictions(setLockSettingTimeRestrictionsData.lockId, setLockSettingTimeRestrictionsData.times.toTimeRequirementList())
+        }
     }
 
     override fun updateLockSettingLocationRestrictions(lockId: String, location: LockOperations.LocationRequirement?) {
         return runBlocking { LockOperationsClient.updateLockSettingLocationRestrictionsRequest(lockId, location) }
     }
 
-    override fun updateLockSettingLocationRestrictionsJson(data: String) {
-        val updateLockSettingLocationRestrictionsData = data.fromJson<UpdateLockSettingLocationRestrictionsData>()
-        return updateLockSettingLocationRestrictions(updateLockSettingLocationRestrictionsData.lockId, updateLockSettingLocationRestrictionsData.location?.toLocationRequirement())
+    override fun updateLockSettingLocationRestrictionsJson(data: String): String {
+        return resultData {
+            val updateLockSettingLocationRestrictionsData = data.fromJson<UpdateLockSettingLocationRestrictionsData>()
+            updateLockSettingLocationRestrictions(updateLockSettingLocationRestrictionsData.lockId, updateLockSettingLocationRestrictionsData.location?.toLocationRequirement())
+        }
     }
 
     override fun getUserPublicKey(userEmail: String, visitor: Boolean): UserPublicKeyResponse {
@@ -174,8 +200,10 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyJson(data: String): String {
-        val getUserPublicKeyData = data.fromJson<GetUserPublicKeyData>()
-        return getUserPublicKey(getUserPublicKeyData.userEmail, getUserPublicKeyData.visitor).toJson()
+        return resultData {
+            val getUserPublicKeyData = data.fromJson<GetUserPublicKeyData>()
+            getUserPublicKey(getUserPublicKeyData.userEmail, getUserPublicKeyData.visitor)
+        }
     }
 
     override fun getUserPublicKeyByEmail(email: String): UserPublicKeyResponse {
@@ -183,8 +211,10 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByEmailJson(data: String): String {
-        val getUserPublicKeyData = data.fromJson<GetUserPublicKeyByEmailData>()
-        return getUserPublicKeyByEmail(getUserPublicKeyData.email).toJson()
+        return resultData {
+            val getUserPublicKeyData = data.fromJson<GetUserPublicKeyByEmailData>()
+            getUserPublicKeyByEmail(getUserPublicKeyData.email)
+        }
     }
 
     override fun getUserPublicKeyByTelephone(telephone: String): UserPublicKeyResponse {
@@ -192,8 +222,10 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByTelephoneJson(data: String): String {
-        val getUserPublicKeyByTelephoneData = data.fromJson<GetUserPublicKeyByTelephoneData>()
-        return getUserPublicKeyByTelephone(getUserPublicKeyByTelephoneData.telephone).toJson()
+        return resultData {
+            val getUserPublicKeyByTelephoneData = data.fromJson<GetUserPublicKeyByTelephoneData>()
+            getUserPublicKeyByTelephone(getUserPublicKeyByTelephoneData.telephone)
+        }
     }
 
     override fun getUserPublicKeyByLocalKey(localKey: String): UserPublicKeyResponse {
@@ -201,8 +233,10 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByLocalKeyJson(data: String): String {
-        val getUserPublicKeyByLocalKeyData = data.fromJson<GetUserPublicKeyByLocalKeyData>()
-        return getUserPublicKeyByLocalKey(getUserPublicKeyByLocalKeyData.localKey).toJson()
+        return resultData {
+            val getUserPublicKeyByLocalKeyData = data.fromJson<GetUserPublicKeyByLocalKeyData>()
+            getUserPublicKeyByLocalKey(getUserPublicKeyByLocalKeyData.localKey)
+        }
     }
 
     override fun getUserPublicKeyByForeignKey(foreignKey: String): UserPublicKeyResponse {
@@ -210,8 +244,10 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByForeignKeyJson(data: String): String {
-        val getUserPublicKeyByForeignKeyData = data.fromJson<GetUserPublicKeyByForeignKeyData>()
-        return getUserPublicKeyByForeignKey(getUserPublicKeyByForeignKeyData.foreignKey).toJson()
+        return resultData {
+            val getUserPublicKeyByForeignKeyData = data.fromJson<GetUserPublicKeyByForeignKeyData>()
+            getUserPublicKeyByForeignKey(getUserPublicKeyByForeignKeyData.foreignKey)
+        }
     }
 
     override fun getUserPublicKeyByIdentity(identity: String): UserPublicKeyResponse {
@@ -219,8 +255,10 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByIdentityJson(data: String): String {
-        val getUserPublicKeyByIdentityData = data.fromJson<GetUserPublicKeyByIdentityData>()
-        return getUserPublicKeyByIdentity(getUserPublicKeyByIdentityData.identity).toJson()
+        return resultData {
+            val getUserPublicKeyByIdentityData = data.fromJson<GetUserPublicKeyByIdentityData>()
+            getUserPublicKeyByIdentity(getUserPublicKeyByIdentityData.identity)
+        }
     }
 
     override fun getUserPublicKeyByEmails(emails: List<String>): List<BatchUserPublicKeyResponse> {
@@ -228,8 +266,10 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByEmailsJson(data: String): String {
-        val getUserPublicKeyByEmailsData = data.fromJson<GetUserPublicKeyByEmailsData>()
-        return getUserPublicKeyByEmails(getUserPublicKeyByEmailsData.emails).toJson()
+        return resultData {
+            val getUserPublicKeyByEmailsData = data.fromJson<GetUserPublicKeyByEmailsData>()
+            getUserPublicKeyByEmails(getUserPublicKeyByEmailsData.emails)
+        }
     }
 
     override fun getUserPublicKeyByTelephones(telephones: List<String>): List<BatchUserPublicKeyResponse> {
@@ -237,8 +277,10 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByTelephonesJson(data: String): String {
-        val getUserPublicKeyByTelephonesData = data.fromJson<GetUserPublicKeyByTelephonesData>()
-        return getUserPublicKeyByTelephones(getUserPublicKeyByTelephonesData.telephones).toJson()
+        return resultData {
+            val getUserPublicKeyByTelephonesData = data.fromJson<GetUserPublicKeyByTelephonesData>()
+            getUserPublicKeyByTelephones(getUserPublicKeyByTelephonesData.telephones)
+        }
     }
 
     override fun getUserPublicKeyByLocalKeys(localKeys: List<String>): List<BatchUserPublicKeyResponse> {
@@ -246,8 +288,10 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByLocalKeysJson(data: String): String {
-        val getUserPublicKeyByLocalKeysData = data.fromJson<GetUserPublicKeyByLocalKeysData>()
-        return getUserPublicKeyByLocalKeys(getUserPublicKeyByLocalKeysData.localKeys).toJson()
+        return resultData {
+            val getUserPublicKeyByLocalKeysData = data.fromJson<GetUserPublicKeyByLocalKeysData>()
+            getUserPublicKeyByLocalKeys(getUserPublicKeyByLocalKeysData.localKeys)
+        }
     }
 
     override fun getUserPublicKeyByForeignKeys(foreignKeys: List<String>): List<BatchUserPublicKeyResponse> {
@@ -255,62 +299,76 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getUserPublicKeyByForeignKeysJson(data: String): String {
-        val getUserPublicKeyByForeignKeysData = data.fromJson<GetUserPublicKeyByForeignKeysData>()
-        return getUserPublicKeyByForeignKeys(getUserPublicKeyByForeignKeysData.foreignKeys).toJson()
+        return resultData {
+            val getUserPublicKeyByForeignKeysData = data.fromJson<GetUserPublicKeyByForeignKeysData>()
+            getUserPublicKeyByForeignKeys(getUserPublicKeyByForeignKeysData.foreignKeys)
+        }
     }
 
     override fun unlock(unlockOperation: LockOperations.UnlockOperation) {
         return runBlocking { LockOperationsClient.unlockRequest(unlockOperation) }
     }
 
-    override fun unlockJson(data: String) {
-        val unlockOperationData = data.fromJson<UnlockOperationData>()
-        return unlock(unlockOperationData.toUnlockOperation())
+    override fun unlockJson(data: String): String {
+        return resultData {
+            val unlockOperationData = data.fromJson<UnlockOperationData>()
+            unlock(unlockOperationData.toUnlockOperation())
+        }
     }
 
     override fun shareLock(shareLockOperation: LockOperations.ShareLockOperation) {
         return runBlocking { LockOperationsClient.shareLockRequest(shareLockOperation) }
     }
 
-    override fun shareLockJson(data: String) {
-        val shareLockOperationData = data.fromJson<ShareLockOperationData>()
-        return shareLock(shareLockOperationData.toShareLockOperation())
+    override fun shareLockJson(data: String): String {
+        return resultData {
+            val shareLockOperationData = data.fromJson<ShareLockOperationData>()
+            shareLock(shareLockOperationData.toShareLockOperation())
+        }
     }
 
-    override suspend fun batchShareLock(batchShareLockOperation: LockOperations.BatchShareLockOperation) {
+    override fun batchShareLock(batchShareLockOperation: LockOperations.BatchShareLockOperation) {
         return runBlocking { LockOperationsClient.batchShareLockRequest(batchShareLockOperation) }
     }
 
-    override fun batchShareLockJson(data: String) {
-        val batchShareLockOperationData = data.fromJson<BatchShareLockOperationData>()
-        return runBlocking { LockOperationsClient.batchShareLockRequest(batchShareLockOperationData.toBatchShareLockOperation()) }
+    override fun batchShareLockJson(data: String): String {
+        return resultData {
+            val batchShareLockOperationData = data.fromJson<BatchShareLockOperationData>()
+            batchShareLock(batchShareLockOperationData.toBatchShareLockOperation())
+        }
     }
 
     override fun revokeAccessToLock(revokeAccessToLockOperation: LockOperations.RevokeAccessToLockOperation) {
         return runBlocking { LockOperationsClient.revokeAccessToLockRequest(revokeAccessToLockOperation) }
     }
 
-    override fun revokeAccessToLockJson(data: String) {
-        val revokeAccessToLockOperationData = data.fromJson<RevokeAccessToLockOperationData>()
-        return revokeAccessToLock(revokeAccessToLockOperationData.toRevokeAccessToLockOperation())
+    override fun revokeAccessToLockJson(data: String): String {
+        return resultData {
+            val revokeAccessToLockOperationData = data.fromJson<RevokeAccessToLockOperationData>()
+            revokeAccessToLock(revokeAccessToLockOperationData.toRevokeAccessToLockOperation())
+        }
     }
 
     override fun updateSecureSettingUnlockDuration(updateSecureSettingUnlockDuration: LockOperations.UpdateSecureSettingUnlockDuration) {
         return runBlocking { LockOperationsClient.updateSecureSettingUnlockDurationRequest(updateSecureSettingUnlockDuration) }
     }
 
-    override fun updateSecureSettingUnlockDurationJson(data: String) {
-        val updateSecureSettingUnlockDurationData = data.fromJson<UpdateSecureSettingUnlockDurationData>()
-        return updateSecureSettingUnlockDuration(updateSecureSettingUnlockDurationData.toUpdateSecureSettingUnlockDuration())
+    override fun updateSecureSettingUnlockDurationJson(data: String): String {
+        return resultData {
+            val updateSecureSettingUnlockDurationData = data.fromJson<UpdateSecureSettingUnlockDurationData>()
+            updateSecureSettingUnlockDuration(updateSecureSettingUnlockDurationData.toUpdateSecureSettingUnlockDuration())
+        }
     }
 
     override fun updateSecureSettingUnlockBetween(updateSecureSettingUnlockBetween: LockOperations.UpdateSecureSettingUnlockBetween) {
         return runBlocking { LockOperationsClient.updateSecureSettingUnlockBetweenRequest(updateSecureSettingUnlockBetween) }
     }
 
-    override fun updateSecureSettingUnlockBetweenJson(data: String) {
-        val updateSecureSettingUnlockBetweenData = data.fromJson<UpdateSecureSettingUnlockBetweenData>()
-        return updateSecureSettingUnlockBetween(updateSecureSettingUnlockBetweenData.toUpdateSecureSettingUnlockBetween())
+    override fun updateSecureSettingUnlockBetweenJson(data: String): String {
+        return resultData {
+            val updateSecureSettingUnlockBetweenData = data.fromJson<UpdateSecureSettingUnlockBetweenData>()
+            updateSecureSettingUnlockBetween(updateSecureSettingUnlockBetweenData.toUpdateSecureSettingUnlockBetween())
+        }
     }
 
     override fun getPinnedLocks(): List<LockResponse> {
@@ -318,7 +376,9 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getPinnedLocksJson(): String {
-        return getPinnedLocks().toJson()
+        return resultData {
+            getPinnedLocks()
+        }
     }
 
     override fun getShareableLocks(): List<ShareableLockResponse> {
@@ -326,6 +386,8 @@ internal object LockOperationsResourceImpl : LockOperationsResource {
     }
 
     override fun getShareableLocksJson(): String {
-        return getShareableLocks().toJson()
+        return resultData {
+            getShareableLocks()
+        }
     }
 }

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/PlatformResourceImpl.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/PlatformResourceImpl.mingw.kt
@@ -29,7 +29,7 @@ import com.doordeck.multiplatform.sdk.api.responses.ApplicationOwnerDetailsRespo
 import com.doordeck.multiplatform.sdk.api.responses.ApplicationResponse
 import com.doordeck.multiplatform.sdk.api.responses.GetLogoUploadUrlResponse
 import com.doordeck.multiplatform.sdk.util.fromJson
-import com.doordeck.multiplatform.sdk.util.toJson
+import com.doordeck.multiplatform.sdk.util.resultData
 import kotlinx.coroutines.runBlocking
 
 internal object PlatformResourceImpl : PlatformResource {
@@ -38,9 +38,11 @@ internal object PlatformResourceImpl : PlatformResource {
         return runBlocking { PlatformClient.createApplicationRequest(application) }
     }
 
-    override fun createApplicationJson(data: String) {
-        val createApplicationData = data.fromJson<CreateApplicationData>()
-        return createApplication(createApplicationData.toCreateApplication())
+    override fun createApplicationJson(data: String): String {
+        return resultData {
+            val createApplicationData = data.fromJson<CreateApplicationData>()
+            createApplication(createApplicationData.toCreateApplication())
+        }
     }
 
     override fun listApplications(): List<ApplicationResponse> {
@@ -48,7 +50,9 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun listApplicationsJson(): String {
-        return listApplications().toJson()
+        return resultData {
+            listApplications()
+        }
     }
 
     override fun getApplication(applicationId: String): ApplicationResponse {
@@ -56,89 +60,109 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun getApplicationJson(data: String): String {
-        val getApplicationData = data.fromJson<GetApplicationData>()
-        return getApplication(getApplicationData.applicationId).toJson()
+        return resultData {
+            val getApplicationData = data.fromJson<GetApplicationData>()
+            getApplication(getApplicationData.applicationId)
+        }
     }
 
     override fun updateApplicationName(applicationId: String, name: String) {
         return runBlocking { PlatformClient.updateApplicationNameRequest(applicationId, name) }
     }
 
-    override fun updateApplicationNameJson(data: String) {
-        val updateApplicationName = data.fromJson<UpdateApplicationNameData>()
-        return updateApplicationName(updateApplicationName.applicationId, updateApplicationName.name)
+    override fun updateApplicationNameJson(data: String): String {
+        return resultData {
+            val updateApplicationName = data.fromJson<UpdateApplicationNameData>()
+            updateApplicationName(updateApplicationName.applicationId, updateApplicationName.name)
+        }
     }
 
     override fun updateApplicationCompanyName(applicationId: String, companyName: String) {
         return runBlocking { PlatformClient.updateApplicationCompanyNameRequest(applicationId, companyName) }
     }
 
-    override fun updateApplicationCompanyNameJson(data: String) {
-        val updateApplicationCompanyName = data.fromJson<UpdateApplicationCompanyNameData>()
-        return updateApplicationCompanyName(updateApplicationCompanyName.applicationId, updateApplicationCompanyName.companyName)
+    override fun updateApplicationCompanyNameJson(data: String): String {
+        return resultData {
+            val updateApplicationCompanyName = data.fromJson<UpdateApplicationCompanyNameData>()
+            updateApplicationCompanyName(updateApplicationCompanyName.applicationId, updateApplicationCompanyName.companyName)
+        }
     }
 
     override fun updateApplicationMailingAddress(applicationId: String, mailingAddress: String) {
         return runBlocking { PlatformClient.updateApplicationMailingAddressRequest(applicationId, mailingAddress) }
     }
 
-    override fun updateApplicationMailingAddressJson(data: String) {
-        val updateApplicationMailingAddressData = data.fromJson<UpdateApplicationMailingAddressData>()
-        return updateApplicationMailingAddress(updateApplicationMailingAddressData.applicationId, updateApplicationMailingAddressData.mailingAddress)
+    override fun updateApplicationMailingAddressJson(data: String): String {
+        return resultData {
+            val updateApplicationMailingAddressData = data.fromJson<UpdateApplicationMailingAddressData>()
+            updateApplicationMailingAddress(updateApplicationMailingAddressData.applicationId, updateApplicationMailingAddressData.mailingAddress)
+        }
     }
 
     override fun updateApplicationPrivacyPolicy(applicationId: String, privacyPolicy: String) {
         return runBlocking { PlatformClient.updateApplicationPrivacyPolicyRequest(applicationId, privacyPolicy) }
     }
 
-    override fun updateApplicationPrivacyPolicyJson(data: String) {
-        val updateApplicationPrivacyPolicyData = data.fromJson<UpdateApplicationPrivacyPolicyData>()
-        return updateApplicationPrivacyPolicy(updateApplicationPrivacyPolicyData.applicationId, updateApplicationPrivacyPolicyData.privacyPolicy)
+    override fun updateApplicationPrivacyPolicyJson(data: String): String {
+        return resultData {
+            val updateApplicationPrivacyPolicyData = data.fromJson<UpdateApplicationPrivacyPolicyData>()
+            updateApplicationPrivacyPolicy(updateApplicationPrivacyPolicyData.applicationId, updateApplicationPrivacyPolicyData.privacyPolicy)
+        }
     }
 
     override fun updateApplicationSupportContact(applicationId: String, supportContact: String) {
         return runBlocking { PlatformClient.updateApplicationSupportContactRequest(applicationId, supportContact) }
     }
 
-    override fun updateApplicationSupportContactJson(data: String) {
-        val updateApplicationSupportContactData = data.fromJson<UpdateApplicationSupportContactData>()
-        return updateApplicationSupportContact(updateApplicationSupportContactData.applicationId, updateApplicationSupportContactData.supportContact)
+    override fun updateApplicationSupportContactJson(data: String): String {
+        return resultData {
+            val updateApplicationSupportContactData = data.fromJson<UpdateApplicationSupportContactData>()
+            updateApplicationSupportContact(updateApplicationSupportContactData.applicationId, updateApplicationSupportContactData.supportContact)
+        }
     }
 
     override fun updateApplicationAppLink(applicationId: String, appLink: String) {
         return runBlocking { PlatformClient.updateApplicationAppLinkRequest(applicationId, appLink) }
     }
 
-    override fun updateApplicationAppLinkJson(data: String) {
-        val updateApplicationAppLinkData = data.fromJson<UpdateApplicationAppLinkData>()
-        return updateApplicationAppLink(updateApplicationAppLinkData.applicationId, updateApplicationAppLinkData.appLink)
+    override fun updateApplicationAppLinkJson(data: String): String {
+        return resultData {
+            val updateApplicationAppLinkData = data.fromJson<UpdateApplicationAppLinkData>()
+            updateApplicationAppLink(updateApplicationAppLinkData.applicationId, updateApplicationAppLinkData.appLink)
+        }
     }
 
     override fun updateApplicationEmailPreferences(applicationId: String, emailPreferences: Platform.EmailPreferences) {
         return runBlocking { PlatformClient.updateApplicationEmailPreferencesRequest(applicationId, emailPreferences) }
     }
 
-    override fun updateApplicationEmailPreferencesJson(data: String) {
-        val updateApplicationEmailPreferencesData = data.fromJson<UpdateApplicationEmailPreferencesData>()
-        return updateApplicationEmailPreferences(updateApplicationEmailPreferencesData.applicationId, updateApplicationEmailPreferencesData.emailPreferences.toEmailPreferences())
+    override fun updateApplicationEmailPreferencesJson(data: String): String {
+        return resultData {
+            val updateApplicationEmailPreferencesData = data.fromJson<UpdateApplicationEmailPreferencesData>()
+            updateApplicationEmailPreferences(updateApplicationEmailPreferencesData.applicationId, updateApplicationEmailPreferencesData.emailPreferences.toEmailPreferences())
+        }
     }
 
     override fun updateApplicationLogoUrl(applicationId: String, logoUrl: String) {
         return runBlocking { PlatformClient.updateApplicationLogoUrlRequest(applicationId, logoUrl) }
     }
 
-    override fun updateApplicationLogoUrlJson(data: String) {
-        val updateApplicationLogoUrlData = data.fromJson<UpdateApplicationLogoUrlData>()
-        return updateApplicationLogoUrl(updateApplicationLogoUrlData.applicationId, updateApplicationLogoUrlData.logoUrl)
+    override fun updateApplicationLogoUrlJson(data: String): String {
+        return resultData {
+            val updateApplicationLogoUrlData = data.fromJson<UpdateApplicationLogoUrlData>()
+            updateApplicationLogoUrl(updateApplicationLogoUrlData.applicationId, updateApplicationLogoUrlData.logoUrl)
+        }
     }
 
     override fun deleteApplication(applicationId: String) {
         return runBlocking { PlatformClient.deleteApplicationRequest(applicationId) }
     }
 
-    override fun deleteApplicationJson(data: String) {
-        val deleteApplicationData = data.fromJson<DeleteApplicationData>()
-        return deleteApplication(deleteApplicationData.applicationId)
+    override fun deleteApplicationJson(data: String): String {
+        return resultData {
+            val deleteApplicationData = data.fromJson<DeleteApplicationData>()
+            deleteApplication(deleteApplicationData.applicationId)
+        }
     }
 
     override fun getLogoUploadUrl(applicationId: String, contentType: String): GetLogoUploadUrlResponse {
@@ -146,71 +170,87 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun getLogoUploadUrlJson(data: String): String {
-        val getLogoUploadUrlData = data.fromJson<GetLogoUploadUrlData>()
-        return getLogoUploadUrl(getLogoUploadUrlData.applicationId, getLogoUploadUrlData.contentType).toJson()
+        return resultData {
+            val getLogoUploadUrlData = data.fromJson<GetLogoUploadUrlData>()
+            getLogoUploadUrl(getLogoUploadUrlData.applicationId, getLogoUploadUrlData.contentType)
+        }
     }
 
     override fun addAuthKey(applicationId: String, key: Platform.AuthKey) {
         return runBlocking { PlatformClient.addAuthKeyRequest(applicationId, key) }
     }
 
-    override fun addAuthKeyJson(data: String) {
-        val addAuthKeyData = data.fromJson<AddAuthKeyData>()
-        return addAuthKey(addAuthKeyData.applicationId, addAuthKeyData.key.toAuthKey())
+    override fun addAuthKeyJson(data: String): String {
+        return resultData {
+            val addAuthKeyData = data.fromJson<AddAuthKeyData>()
+            addAuthKey(addAuthKeyData.applicationId, addAuthKeyData.key.toAuthKey())
+        }
     }
 
     override fun addAuthIssuer(applicationId: String, url: String) {
         return runBlocking { PlatformClient.addAuthIssuerRequest(applicationId, url) }
     }
 
-    override fun addAuthIssuerJson(data: String) {
-        val addAuthIssuerData = data.fromJson<AddAuthIssuerData>()
-        return addAuthIssuer(addAuthIssuerData.applicationId, addAuthIssuerData.url)
+    override fun addAuthIssuerJson(data: String): String {
+        return resultData {
+            val addAuthIssuerData = data.fromJson<AddAuthIssuerData>()
+            addAuthIssuer(addAuthIssuerData.applicationId, addAuthIssuerData.url)
+        }
     }
 
     override fun deleteAuthIssuer(applicationId: String, url: String) {
         return runBlocking { PlatformClient.deleteAuthIssuerRequest(applicationId, url) }
     }
 
-    override fun deleteAuthIssuerJson(data: String) {
-        val deleteAuthIssuerData = data.fromJson<DeleteAuthIssuerData>()
-        return deleteAuthIssuer(deleteAuthIssuerData.applicationId, deleteAuthIssuerData.url)
+    override fun deleteAuthIssuerJson(data: String): String {
+        return resultData {
+            val deleteAuthIssuerData = data.fromJson<DeleteAuthIssuerData>()
+            deleteAuthIssuer(deleteAuthIssuerData.applicationId, deleteAuthIssuerData.url)
+        }
     }
 
     override fun addCorsDomain(applicationId: String, url: String) {
         return runBlocking { PlatformClient.addCorsDomainRequest(applicationId, url) }
     }
 
-    override fun addCorsDomainJson(data: String) {
-        val addCorsDomainData = data.fromJson<AddCorsDomainData>()
-        return addCorsDomain(addCorsDomainData.applicationId, addCorsDomainData.url)
+    override fun addCorsDomainJson(data: String): String {
+        return resultData {
+            val addCorsDomainData = data.fromJson<AddCorsDomainData>()
+            addCorsDomain(addCorsDomainData.applicationId, addCorsDomainData.url)
+        }
     }
 
     override fun removeCorsDomain(applicationId: String, url: String) {
         return runBlocking { PlatformClient.removeCorsDomainRequest(applicationId, url) }
     }
 
-    override fun removeCorsDomainJson(data: String) {
-        val removeCorsDomainData = data.fromJson<RemoveCorsDomainData>()
-        return removeCorsDomain(removeCorsDomainData.applicationId, removeCorsDomainData.url)
+    override fun removeCorsDomainJson(data: String): String {
+        return resultData {
+            val removeCorsDomainData = data.fromJson<RemoveCorsDomainData>()
+            removeCorsDomain(removeCorsDomainData.applicationId, removeCorsDomainData.url)
+        }
     }
 
     override fun addApplicationOwner(applicationId: String, userId: String) {
         return runBlocking { PlatformClient.addApplicationOwnerRequest(applicationId, userId) }
     }
 
-    override fun addApplicationOwnerJson(data: String) {
-        val addApplicationOwnerData = data.fromJson<AddApplicationOwnerData>()
-        return addApplicationOwner(addApplicationOwnerData.applicationId, addApplicationOwnerData.userId)
+    override fun addApplicationOwnerJson(data: String): String {
+        return resultData {
+            val addApplicationOwnerData = data.fromJson<AddApplicationOwnerData>()
+            addApplicationOwner(addApplicationOwnerData.applicationId, addApplicationOwnerData.userId)
+        }
     }
 
     override fun removeApplicationOwner(applicationId: String, userId: String) {
         return runBlocking { PlatformClient.removeApplicationOwnerRequest(applicationId, userId) }
     }
 
-    override fun removeApplicationOwnerJson(data: String) {
-        val removeApplicationOwnerData = data.fromJson<RemoveApplicationOwnerData>()
-        return removeApplicationOwner(removeApplicationOwnerData.applicationId, removeApplicationOwnerData.userId)
+    override fun removeApplicationOwnerJson(data: String): String {
+        return resultData {
+            val removeApplicationOwnerData = data.fromJson<RemoveApplicationOwnerData>()
+            removeApplicationOwner(removeApplicationOwnerData.applicationId, removeApplicationOwnerData.userId)
+        }
     }
 
     override fun getApplicationOwnersDetails(applicationId: String): List<ApplicationOwnerDetailsResponse> {
@@ -218,7 +258,9 @@ internal object PlatformResourceImpl : PlatformResource {
     }
 
     override fun getApplicationOwnersDetailsJson(data: String): String {
-        val getApplicationOwnersDetailsData = data.fromJson<GetApplicationOwnersDetailsData>()
-        return getApplicationOwnersDetails(getApplicationOwnersDetailsData.applicationId).toJson()
+        return resultData {
+            val getApplicationOwnersDetailsData = data.fromJson<GetApplicationOwnersDetailsData>()
+            getApplicationOwnersDetails(getApplicationOwnersDetailsData.applicationId)
+        }
     }
 }

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/SitesResourceImpl.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/SitesResourceImpl.mingw.kt
@@ -7,7 +7,7 @@ import com.doordeck.multiplatform.sdk.api.responses.SiteLocksResponse
 import com.doordeck.multiplatform.sdk.api.responses.SiteResponse
 import com.doordeck.multiplatform.sdk.api.responses.UserForSiteResponse
 import com.doordeck.multiplatform.sdk.util.fromJson
-import com.doordeck.multiplatform.sdk.util.toJson
+import com.doordeck.multiplatform.sdk.util.resultData
 import kotlinx.coroutines.runBlocking
 
 internal object SitesResourceImpl : SitesResource {
@@ -17,7 +17,9 @@ internal object SitesResourceImpl : SitesResource {
     }
 
     override fun listSitesJson(): String {
-        return listSites().toJson()
+        return resultData {
+            listSites()
+        }
     }
 
     override fun getLocksForSite(siteId: String): List<SiteLocksResponse> {
@@ -25,8 +27,10 @@ internal object SitesResourceImpl : SitesResource {
     }
 
     override fun getLocksForSiteJson(data: String): String {
-        val getLocksForSiteData = data.fromJson<GetLocksForSiteData>()
-        return getLocksForSite(getLocksForSiteData.siteId).toJson()
+        return resultData {
+            val getLocksForSiteData = data.fromJson<GetLocksForSiteData>()
+            getLocksForSite(getLocksForSiteData.siteId)
+        }
     }
 
     override fun getUsersForSite(siteId: String): List<UserForSiteResponse> {
@@ -34,7 +38,9 @@ internal object SitesResourceImpl : SitesResource {
     }
 
     override fun getUsersForSiteJson(data: String): String {
-        val getUsersForSiteData = data.fromJson<GetUsersForSiteData>()
-        return getUsersForSite(getUsersForSiteData.siteId).toJson()
+        return resultData {
+            val getUsersForSiteData = data.fromJson<GetUsersForSiteData>()
+            getUsersForSite(getUsersForSiteData.siteId)
+        }
     }
 }

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/TilesResourceImpl.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/TilesResourceImpl.mingw.kt
@@ -5,7 +5,7 @@ import com.doordeck.multiplatform.sdk.api.model.AssociateMultipleLocksData
 import com.doordeck.multiplatform.sdk.api.model.GetLocksBelongingToTileData
 import com.doordeck.multiplatform.sdk.api.responses.TileLocksResponse
 import com.doordeck.multiplatform.sdk.util.fromJson
-import com.doordeck.multiplatform.sdk.util.toJson
+import com.doordeck.multiplatform.sdk.util.resultData
 import kotlinx.coroutines.runBlocking
 
 internal object TilesResourceImpl : TilesResource {
@@ -15,16 +15,20 @@ internal object TilesResourceImpl : TilesResource {
     }
 
     override fun getLocksBelongingToTileJson(data: String): String {
-        val getLocksBelongingToTileData = data.fromJson<GetLocksBelongingToTileData>()
-        return getLocksBelongingToTile(getLocksBelongingToTileData.tileId).toJson()
+        return resultData {
+            val getLocksBelongingToTileData = data.fromJson<GetLocksBelongingToTileData>()
+            getLocksBelongingToTile(getLocksBelongingToTileData.tileId)
+        }
     }
 
     override fun associateMultipleLocks(tileId: String, siteId: String, lockIds: List<String>) {
         return runBlocking { TilesClient.associateMultipleLocksRequest(tileId, siteId, lockIds) }
     }
 
-    override fun associateMultipleLocksJson(data: String) {
-        val associateMultipleLocksData = data.fromJson<AssociateMultipleLocksData>()
-        return associateMultipleLocks(associateMultipleLocksData.tileId, associateMultipleLocksData.siteId, associateMultipleLocksData.lockIds)
+    override fun associateMultipleLocksJson(data: String): String {
+        return resultData {
+            val associateMultipleLocksData = data.fromJson<AssociateMultipleLocksData>()
+            associateMultipleLocks(associateMultipleLocksData.tileId, associateMultipleLocksData.siteId, associateMultipleLocksData.lockIds)
+        }
     }
 }

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.mingw.kt
@@ -17,6 +17,16 @@ fun ApiEnvironment.getApiEnvironmentName(): String {
     return name
 }
 
+/**
+ * Executes a block of code and captures its result. Wraps either the result of the block or any exception thrown
+ * during its execution into a serialized JSON `ResultData` string.
+ *
+ * @param T The type of the result produced by the block.
+ * @param block A lambda function that represents the code to execute.
+ * @return A JSON string representing the result. If the block executes successfully,
+ *          the result is wrapped in `SuccessResultData`.
+ *          If an exception occurs, it is wrapped in `FailedResultData` along with an error message.
+ */
 internal inline fun <reified T>resultData(crossinline block: () -> T): String {
     return try {
         val result = block()

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.mingw.kt
@@ -1,6 +1,9 @@
 package com.doordeck.multiplatform.sdk.util
 
 import com.doordeck.multiplatform.sdk.api.model.ApiEnvironment
+import com.doordeck.multiplatform.sdk.api.model.FailedResultData
+import com.doordeck.multiplatform.sdk.api.model.ResultData
+import com.doordeck.multiplatform.sdk.api.model.SuccessResultData
 import io.ktor.client.HttpClientConfig
 
 internal actual fun HttpClientConfig<*>.installCertificatePinner() {
@@ -12,4 +15,15 @@ internal actual fun HttpClientConfig<*>.installCertificatePinner() {
  */
 fun ApiEnvironment.getApiEnvironmentName(): String {
     return name
+}
+
+internal inline fun <reified T>resultData(crossinline block: () -> T): String {
+    return try {
+        val result = block()
+        val success = if (result != Unit) result else null
+        ResultData(SuccessResultData(success))
+    } catch (exception: Exception) {
+        val errorMessage = exception.message ?: exception.cause?.message ?: "Unknown error occurred"
+        ResultData(failure = FailedResultData(exception.toString(), errorMessage))
+    }.toJson()
 }

--- a/doordeck-sdk/src/mingwMain/resources/doordeck_headless_sdk/Exceptions.cs
+++ b/doordeck-sdk/src/mingwMain/resources/doordeck_headless_sdk/Exceptions.cs
@@ -1,0 +1,114 @@
+namespace Doordeck.Headless.Sdk.Model;
+
+using System;
+using System.Collections.Generic;
+
+// Base exception class
+public class SdkException : Exception
+{
+    public SdkException(string message, Exception innerException = null)
+        : base(message, innerException) { }
+}
+
+// SDK Exceptions
+public class MissingContextFieldException : SdkException
+{
+    public MissingContextFieldException(string message)
+        : base(message) { }
+}
+
+public class BatchShareFailedException : SdkException
+{
+    public List<string> UserIds { get; }
+
+    public BatchShareFailedException(string message, List<string> userIds)
+        : base(message)
+    {
+        UserIds = userIds;
+    }
+}
+
+// API Exceptions
+public class BadRequestException : SdkException
+{
+    public BadRequestException(string message)
+        : base(message) { }
+}
+
+public class UnauthorizedException : SdkException
+{
+    public UnauthorizedException(string message)
+        : base(message) { }
+}
+
+public class ForbiddenException : SdkException
+{
+    public ForbiddenException(string message)
+        : base(message) { }
+}
+
+public class NotFoundException : SdkException
+{
+    public NotFoundException(string message)
+        : base(message) { }
+}
+
+public class MethodNotAllowedException : SdkException
+{
+    public MethodNotAllowedException(string message)
+        : base(message) { }
+}
+
+public class NotAcceptableException : SdkException
+{
+    public NotAcceptableException(string message)
+        : base(message) { }
+}
+
+public class ConflictException : SdkException
+{
+    public ConflictException(string message)
+        : base(message) { }
+}
+
+public class GoneException : SdkException
+{
+    public GoneException(string message)
+        : base(message) { }
+}
+
+public class LockedException : SdkException
+{
+    public LockedException(string message)
+        : base(message) { }
+}
+
+public class TooEarlyException : SdkException
+{
+    public TooEarlyException(string message)
+        : base(message) { }
+}
+
+public class TooManyRequestsException : SdkException
+{
+    public TooManyRequestsException(string message)
+        : base(message) { }
+}
+
+public class InternalServerErrorException : SdkException
+{
+    public InternalServerErrorException(string message)
+        : base(message) { }
+}
+
+public class ServiceUnavailableException : SdkException
+{
+    public ServiceUnavailableException(string message)
+        : base(message) { }
+}
+
+public class GatewayTimeoutException : SdkException
+{
+    public GatewayTimeoutException(string message)
+        : base(message) { }
+}

--- a/doordeck-sdk/src/mingwMain/resources/doordeck_headless_sdk/Model/Responses/LockOperationResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/doordeck_headless_sdk/Model/Responses/LockOperationResponses.cs
@@ -125,29 +125,22 @@
         public string DeviceId { get; set; } = string.Empty;
         public double Timestamp { get; set; }
         public AuditEvent Type { get; set; }
-        public UserAuditIssuerResponse Issuer { get; set; } = new UserAuditIssuerResponse();
-        public UserAuditSubjectResponse? Subject { get; set; } = null;
+        public AuditIssuerResponse Issuer { get; set; } = new AuditIssuerResponse();
+        public AuditSubjectResponse? Subject { get; set; } = null;
         public bool Rejected { get; set; }
     }
 
-    public class UserAuditIssuerResponse
+    public class AuditIssuerResponse
     {
         public string UserId { get; set; } = string.Empty;
+        public string? Email { get; set; } = null;
+        public string? Ip { get; set; } = null;
     }
 
-    public class UserAuditSubjectResponse
+    public class AuditSubjectResponse
     {
         public string UserId { get; set; } = string.Empty;
         public string Email { get; set; } = string.Empty;
-    }
-
-    public class LockAuditTrailResponse
-    {
-        public double Timestamp { get; set; }
-        public AuditEvent Type { get; set; }
-        public string? User { get; set; } = null;
-        public string? Email { get; set; } = null;
         public string? DisplayName { get; set; } = null;
-        public string? Message { get; set; } = null;
     }
 }

--- a/doordeck-sdk/src/mingwMain/resources/doordeck_headless_sdk/Model/ResultData.cs
+++ b/doordeck-sdk/src/mingwMain/resources/doordeck_headless_sdk/Model/ResultData.cs
@@ -1,0 +1,22 @@
+﻿namespace Doordeck.Headless.Sdk.Model
+{
+    public class ResultData<T>
+    {
+        public SuccessResultData<T>? Success { get; set; } = null;
+        public FailedResultData? Failure { get; set; } = null;
+
+        public bool IsSuccess => Success is not null;
+        public bool IsFailure => Failure is not null;
+    }
+
+    public class SuccessResultData<T>
+    {
+        public T? Result { get; set; } = default;
+    }
+
+    public class FailedResultData
+    {
+        public string ExceptionType { get; set; } = string.Empty;
+        public string ExceptionMessage { get; set; } = string.Empty;
+    }
+}

--- a/doordeck-sdk/src/mingwMain/resources/doordeck_headless_sdk/Utils/Utils.cs
+++ b/doordeck-sdk/src/mingwMain/resources/doordeck_headless_sdk/Utils/Utils.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using System.Text.Json;
+using Doordeck.Headless.Sdk.Model;
 
 namespace Doordeck.Headless.Sdk.Utils
 {
@@ -39,5 +40,83 @@ namespace Doordeck.Headless.Sdk.Utils
 
         public static List<string> StringToCertificateChain(this string input) =>
             input.Split("|").ToList();
+
+        public static ResultData<T> HandleException<T>(this ResultData<T> input)
+        {
+            if (input.IsSuccess) return input;
+            var exceptionType = input.Failure!.ExceptionType;
+            if (exceptionType.Contains("SdkException"))
+            {
+                throw new SdkException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("MissingContextFieldException"))
+            {
+                throw new MissingContextFieldException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("BatchShareFailedException"))
+            {
+                throw new BatchShareFailedException(input.Failure.ExceptionMessage, new List<string>());
+            }
+            else if (exceptionType.Contains("BadRequestException"))
+            {
+                throw new BadRequestException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("UnauthorizedException"))
+            {
+                throw new UnauthorizedException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("ForbiddenException"))
+            {
+                throw new ForbiddenException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("NotFoundException"))
+            {
+                throw new NotFoundException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("MethodNotAllowedException"))
+            {
+                throw new MethodNotAllowedException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("NotAcceptableException"))
+            {
+                throw new NotAcceptableException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("ConflictException"))
+            {
+                throw new ConflictException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("GoneException"))
+            {
+                throw new GoneException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("LockedException"))
+            {
+                throw new LockedException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("TooEarlyException"))
+            {
+                throw new TooEarlyException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("TooManyRequestsException"))
+            {
+                throw new TooManyRequestsException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("InternalServerErrorException"))
+            {
+                throw new InternalServerErrorException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("ServiceUnavailableException"))
+            {
+                throw new ServiceUnavailableException(input.Failure.ExceptionMessage);
+            }
+            else if (exceptionType.Contains("GatewayTimeoutException"))
+            {
+                throw new GatewayTimeoutException(input.Failure.ExceptionMessage);
+            }
+            else
+            {
+                throw new SdkException("Unhandled exception type: " + exceptionType);
+            }
+        }
     }
 }

--- a/doordeck-sdk/src/mingwMain/resources/doordeck_headless_sdk/Wrapper/Fusion.cs
+++ b/doordeck-sdk/src/mingwMain/resources/doordeck_headless_sdk/Wrapper/Fusion.cs
@@ -32,88 +32,78 @@ public unsafe class Fusion : IResource
         return Process<FusionLoginResponse>(
             _fusionResource.loginJson,
             null,
-            null,
             data
         );
     }
-    
+
     public IntegrationTypeResponse GetIntegrationType()
     {
         return Process<IntegrationTypeResponse>(
-            null,
             null,
             _fusionResource.getIntegrationTypeJson,
             null
         );
     }
-    
+
     public List<IntegrationConfigurationResponse> GetIntegrationConfiguration(GetIntegrationConfigurationData data)
     {
         return Process<List<IntegrationConfigurationResponse>>(
             _fusionResource.getIntegrationConfigurationJson,
             null,
-            null,
             data
         );
     }
-    
+
     public void EnableDoor(EnableDoorData data)
     {
         Process<object>(
-            null,
             _fusionResource.enableDoorJson,
             null,
             data
         );
     }
-    
+
     public void DeleteDoor(DeleteDoorData data)
     {
         Process<object>(
-            null,
             _fusionResource.deleteDoorJson,
             null,
             data
         );
     }
-    
+
     public DoorStateResponse GetDoorStatus(GetDoorStatusData data)
     {
         return Process<DoorStateResponse>(
             _fusionResource.getDoorStatusJson,
             null,
-            null,
             data
         );
     }
-    
+
     public void StartDoor(StartDoorData data)
     {
         Process<object>(
-            null,
-            _fusionResource.startDoor,
+            _fusionResource.startDoorJson,
             null,
             data
         );
     }
-    
+
     public void StopDoor(StopDoorData data)
     {
         Process<object>(
-            null,
-            _fusionResource.stopDoor,
+            _fusionResource.stopDoorJson,
             null,
             data
         );
     }
-    
+
     private TResponse Process<TResponse>(
         delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_FusionResource,
-            sbyte*, sbyte*> withDataAndWithResponse,
+            sbyte*, sbyte*> processDataWithResponse,
         delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_FusionResource,
-            sbyte*, void> withDataAndWithoutResponse,
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_FusionResource,
-            sbyte*> withoutDataAndWithResponse,
+            sbyte*> processWithoutDataWithResponse,
         object? data
     )
     {
@@ -121,16 +111,17 @@ public unsafe class Fusion : IResource
         sbyte* result = null;
         try
         {
-            var withResponse = typeof(TResponse) != typeof(object);
-            var withData = data != null;
+            var hasData = data != null;
+            result = hasData ? processDataWithResponse(_fusion, sData) :
+                processWithoutDataWithResponse(_fusion);
 
-            if (withData && withResponse)
-                result = withDataAndWithResponse(_fusion, sData);
-            else if (withData && !withResponse)
-                withDataAndWithoutResponse(_fusion, sData);
-            else if (!withData && withResponse)
-                result = withoutDataAndWithResponse(_fusion);
-            return result != null ? Utils.Utils.FromData<TResponse>(result)! : default!;
+            var resultData = result != null
+                ? Utils.Utils.FromData<ResultData<TResponse>>(result)
+                : default!;
+
+            resultData.HandleException();
+
+            return resultData.Success!.Result ?? default!;
         }
         finally
         {

--- a/doordeck-sdk/src/mingwMain/resources/doordeck_headless_sdk/Wrapper/LockOperations.cs
+++ b/doordeck-sdk/src/mingwMain/resources/doordeck_headless_sdk/Wrapper/LockOperations.cs
@@ -33,7 +33,6 @@ public unsafe class LockOperations : IResource
         return Process<LockResponse>(
             _lockOperationsResource.getSingleLockJson,
             null,
-            null,
             data
         );
     }
@@ -42,7 +41,6 @@ public unsafe class LockOperations : IResource
     {
         return Process<List<AuditResponse>>(
             _lockOperationsResource.getLockAuditTrailJson,
-            null,
             null,
             data
         );
@@ -53,7 +51,6 @@ public unsafe class LockOperations : IResource
         return Process<List<AuditResponse>>(
             _lockOperationsResource.getAuditForUserJson,
             null,
-            null,
             data
         );
     }
@@ -62,7 +59,6 @@ public unsafe class LockOperations : IResource
     {
         return Process<List<UserLockResponse>>(
             _lockOperationsResource.getUsersForLockJson,
-            null,
             null,
             data
         );
@@ -73,7 +69,6 @@ public unsafe class LockOperations : IResource
         return Process<LockUserResponse>(
             _lockOperationsResource.getLocksForUserJson,
             null,
-            null,
             data
         );
     }
@@ -81,7 +76,6 @@ public unsafe class LockOperations : IResource
     public void UpdateLockName(UpdateLockNameData data)
     {
         Process<object>(
-            null,
             _lockOperationsResource.updateLockNameJson,
             null,
             data
@@ -91,7 +85,6 @@ public unsafe class LockOperations : IResource
     public void UpdateLockFavourite(UpdateLockFavouriteData data)
     {
         Process<object>(
-            null,
             _lockOperationsResource.updateLockFavouriteJson,
             null,
             data
@@ -101,7 +94,6 @@ public unsafe class LockOperations : IResource
     public void UpdateLockColour(UpdateLockColourData data)
     {
         Process<object>(
-            null,
             _lockOperationsResource.updateLockColourJson,
             null,
             data
@@ -111,7 +103,6 @@ public unsafe class LockOperations : IResource
     public void UpdateLockSettingDefaultName(UpdateLockSettingDefaultNameData data)
     {
         Process<object>(
-            null,
             _lockOperationsResource.updateLockSettingDefaultNameJson,
             null,
             data
@@ -121,7 +112,6 @@ public unsafe class LockOperations : IResource
     public void SetLockSettingPermittedAddresses(SetLockSettingPermittedAddressesData data)
     {
         Process<object>(
-            null,
             _lockOperationsResource.setLockSettingPermittedAddressesJson,
             null,
             data
@@ -131,7 +121,6 @@ public unsafe class LockOperations : IResource
     public void UpdateLockSettingHidden(UpdateLockSettingHiddenData data)
     {
         Process<object>(
-            null,
             _lockOperationsResource.updateLockSettingHiddenJson,
             null,
             data
@@ -141,7 +130,6 @@ public unsafe class LockOperations : IResource
     public void SetLockSettingTimeRestrictions(SetLockSettingTimeRestrictionsData data)
     {
         Process<object>(
-            null,
             _lockOperationsResource.setLockSettingTimeRestrictionsJson,
             null,
             data
@@ -151,7 +139,6 @@ public unsafe class LockOperations : IResource
     public void UpdateLockSettingLocationRestrictions(UpdateLockSettingLocationRestrictionsData data)
     {
         Process<object>(
-            null,
             _lockOperationsResource.updateLockSettingLocationRestrictionsJson,
             null,
             data
@@ -163,7 +150,6 @@ public unsafe class LockOperations : IResource
         return Process<UserPublicKeyResponse>(
             _lockOperationsResource.getUserPublicKeyJson,
             null,
-            null,
             data
         );
     }
@@ -172,7 +158,6 @@ public unsafe class LockOperations : IResource
     {
         return Process<UserPublicKeyResponse>(
             _lockOperationsResource.getUserPublicKeyByEmailJson,
-            null,
             null,
             data
         );
@@ -183,7 +168,6 @@ public unsafe class LockOperations : IResource
         return Process<UserPublicKeyResponse>(
             _lockOperationsResource.getUserPublicKeyByTelephoneJson,
             null,
-            null,
             data
         );
     }
@@ -192,7 +176,6 @@ public unsafe class LockOperations : IResource
     {
         return Process<UserPublicKeyResponse>(
             _lockOperationsResource.getUserPublicKeyByLocalKeyJson,
-            null,
             null,
             data
         );
@@ -203,7 +186,6 @@ public unsafe class LockOperations : IResource
         return Process<UserPublicKeyResponse>(
             _lockOperationsResource.getUserPublicKeyByForeignKeyJson,
             null,
-            null,
             data
         );
     }
@@ -212,7 +194,6 @@ public unsafe class LockOperations : IResource
     {
         return Process<UserPublicKeyResponse>(
             _lockOperationsResource.getUserPublicKeyByIdentityJson,
-            null,
             null,
             data
         );
@@ -223,7 +204,6 @@ public unsafe class LockOperations : IResource
         return Process<List<BatchUserPublicKeyResponse>>(
             _lockOperationsResource.getUserPublicKeyByEmailsJson,
             null,
-            null,
             data
         );
     }
@@ -232,7 +212,6 @@ public unsafe class LockOperations : IResource
     {
         return Process<List<BatchUserPublicKeyResponse>>(
             _lockOperationsResource.getUserPublicKeyByTelephonesJson,
-            null,
             null,
             data
         );
@@ -243,7 +222,6 @@ public unsafe class LockOperations : IResource
         return Process<List<BatchUserPublicKeyResponse>>(
             _lockOperationsResource.getUserPublicKeyByLocalKeysJson,
             null,
-            null,
             data
         );
     }
@@ -253,7 +231,6 @@ public unsafe class LockOperations : IResource
         return Process<List<BatchUserPublicKeyResponse>>(
             _lockOperationsResource.getUserPublicKeyByForeignKeysJson,
             null,
-            null,
             data
         );
     }
@@ -261,7 +238,6 @@ public unsafe class LockOperations : IResource
     public void Unlock(UnlockOperationData data)
     {
         Process<object>(
-            null,
             _lockOperationsResource.unlockJson,
             null,
             data
@@ -271,7 +247,6 @@ public unsafe class LockOperations : IResource
     public void ShareLock(ShareLockOperationData data)
     {
         Process<object>(
-            null,
             _lockOperationsResource.shareLockJson,
             null,
             data
@@ -281,7 +256,6 @@ public unsafe class LockOperations : IResource
     public void BatchShareLock(BatchShareLockOperationData data)
     {
         Process<object>(
-            null,
             _lockOperationsResource.batchShareLockJson,
             null,
             data
@@ -291,7 +265,6 @@ public unsafe class LockOperations : IResource
     public void RevokeAccessToLock(RevokeAccessToLockOperationData data)
     {
         Process<object>(
-            null,
             _lockOperationsResource.revokeAccessToLockJson,
             null,
             data
@@ -301,7 +274,6 @@ public unsafe class LockOperations : IResource
     public void UpdateSecureSettingUnlockDuration(UpdateSecureSettingUnlockDurationData data)
     {
         Process<object>(
-            null,
             _lockOperationsResource.updateSecureSettingUnlockDurationJson,
             null,
             data
@@ -311,7 +283,6 @@ public unsafe class LockOperations : IResource
     public void UpdateSecureSettingUnlockBetween(UpdateSecureSettingUnlockBetweenData data)
     {
         Process<object>(
-            null,
             _lockOperationsResource.updateSecureSettingUnlockBetweenJson,
             null,
             data
@@ -322,7 +293,6 @@ public unsafe class LockOperations : IResource
     {
         return Process<List<LockResponse>>(
             null,
-            null,
             _lockOperationsResource.getPinnedLocksJson,
             null
         );
@@ -332,7 +302,6 @@ public unsafe class LockOperations : IResource
     {
         return Process<List<ShareableLockResponse>>(
             null,
-            null,
             _lockOperationsResource.getShareableLocksJson,
             null
         );
@@ -340,11 +309,9 @@ public unsafe class LockOperations : IResource
 
     private TResponse Process<TResponse>(
         delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_LockOperationsResource,
-            sbyte*, sbyte*> withDataAndWithResponse,
+            sbyte*, sbyte*> processDataWithResponse,
         delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_LockOperationsResource,
-            sbyte*, void> withDataAndWithoutResponse,
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_LockOperationsResource,
-            sbyte*> withoutDataAndWithResponse,
+            sbyte*> processWithoutDataWithResponse,
         object? data
     )
     {
@@ -352,16 +319,17 @@ public unsafe class LockOperations : IResource
         sbyte* result = null;
         try
         {
-            var withResponse = typeof(TResponse) != typeof(object);
-            var withData = data != null;
+            var hasData = data != null;
+            result = hasData ? processDataWithResponse(_lockOperations, sData) :
+                processWithoutDataWithResponse(_lockOperations);
 
-            if (withData && withResponse)
-                result = withDataAndWithResponse(_lockOperations, sData);
-            else if (withData && !withResponse)
-                withDataAndWithoutResponse(_lockOperations, sData);
-            else if (!withData && withResponse)
-                result = withoutDataAndWithResponse(_lockOperations);
-            return result != null ? Utils.Utils.FromData<TResponse>(result)! : default!;
+            var resultData = result != null
+                ? Utils.Utils.FromData<ResultData<TResponse>>(result)
+                : default!;
+
+            resultData.HandleException();
+
+            return resultData.Success!.Result ?? default!;
         }
         finally
         {

--- a/doordeck-sdk/src/mingwMain/resources/doordeck_headless_sdk/Wrapper/Platform.cs
+++ b/doordeck-sdk/src/mingwMain/resources/doordeck_headless_sdk/Wrapper/Platform.cs
@@ -30,7 +30,6 @@ public unsafe class Platform : IResource
     public void CreateApplication(CreateApplicationData data)
     {
         Process<object>(
-            null,
             _platformResource.createApplicationJson,
             null,
             data
@@ -40,7 +39,6 @@ public unsafe class Platform : IResource
     public List<ApplicationResponse> ListApplications()
     {
         return Process<List<ApplicationResponse>>(
-            null,
             null,
             _platformResource.listApplicationsJson,
             null
@@ -52,7 +50,6 @@ public unsafe class Platform : IResource
         return Process<ApplicationResponse>(
             _platformResource.getApplicationJson,
             null,
-            null,
             data
         );
     }
@@ -60,7 +57,6 @@ public unsafe class Platform : IResource
     public void UpdateApplicationName(UpdateApplicationNameData data)
     {
         Process<object>(
-            null,
             _platformResource.updateApplicationNameJson,
             null,
             data
@@ -70,7 +66,6 @@ public unsafe class Platform : IResource
     public void UpdateApplicationCompanyName(UpdateApplicationCompanyNameData data)
     {
         Process<object>(
-            null,
             _platformResource.updateApplicationCompanyNameJson,
             null,
             data
@@ -80,7 +75,6 @@ public unsafe class Platform : IResource
     public void UpdateApplicationMailingAddress(UpdateApplicationMailingAddressData data)
     {
         Process<object>(
-            null,
             _platformResource.updateApplicationMailingAddressJson,
             null,
             data
@@ -90,7 +84,6 @@ public unsafe class Platform : IResource
     public void UpdateApplicationPrivacyPolicy(UpdateApplicationPrivacyPolicyData data)
     {
         Process<object>(
-            null,
             _platformResource.updateApplicationPrivacyPolicyJson,
             null,
             data
@@ -100,7 +93,6 @@ public unsafe class Platform : IResource
     public void UpdateApplicationSupportContact(UpdateApplicationSupportContactData data)
     {
         Process<object>(
-            null,
             _platformResource.updateApplicationSupportContactJson,
             null,
             data
@@ -110,7 +102,6 @@ public unsafe class Platform : IResource
     public void UpdateApplicationAppLink(UpdateApplicationAppLinkData data)
     {
         Process<object>(
-            null,
             _platformResource.updateApplicationAppLinkJson,
             null,
             data
@@ -120,7 +111,6 @@ public unsafe class Platform : IResource
     public void UpdateApplicationEmailPreferences(UpdateApplicationEmailPreferencesData data)
     {
         Process<object>(
-            null,
             _platformResource.updateApplicationEmailPreferencesJson,
             null,
             data
@@ -130,7 +120,6 @@ public unsafe class Platform : IResource
     public void UpdateApplicationLogoUrl(UpdateApplicationLogoUrlData data)
     {
         Process<object>(
-            null,
             _platformResource.updateApplicationLogoUrlJson,
             null,
             data
@@ -140,7 +129,6 @@ public unsafe class Platform : IResource
     public void DeleteApplication(DeleteApplicationData data)
     {
         Process<object>(
-            null,
             _platformResource.deleteApplicationJson,
             null,
             data
@@ -152,7 +140,6 @@ public unsafe class Platform : IResource
         return Process<GetLogoUploadUrlResponse>(
             _platformResource.getLogoUploadUrlJson,
             null,
-            null,
             data
         );
     }
@@ -160,7 +147,6 @@ public unsafe class Platform : IResource
     public void AddAuthKey(AddAuthKeyData data)
     {
         Process<object>(
-            null,
             _platformResource.addAuthKeyJson,
             null,
             data
@@ -170,7 +156,6 @@ public unsafe class Platform : IResource
     public void AddAuthIssuer(AddAuthIssuerData data)
     {
         Process<object>(
-            null,
             _platformResource.addAuthIssuerJson,
             null,
             data
@@ -180,7 +165,6 @@ public unsafe class Platform : IResource
     public void DeleteAuthIssuer(DeleteAuthIssuerData data)
     {
         Process<object>(
-            null,
             _platformResource.deleteAuthIssuerJson,
             null,
             data
@@ -190,7 +174,6 @@ public unsafe class Platform : IResource
     public void AddCorsDomain(AddCorsDomainData data)
     {
         Process<object>(
-            null,
             _platformResource.addCorsDomainJson,
             null,
             data
@@ -200,7 +183,6 @@ public unsafe class Platform : IResource
     public void RemoveCorsDomain(RemoveCorsDomainData data)
     {
         Process<object>(
-            null,
             _platformResource.removeCorsDomainJson,
             null,
             data
@@ -210,7 +192,6 @@ public unsafe class Platform : IResource
     public void AddApplicationOwner(AddApplicationOwnerData data)
     {
         Process<object>(
-            null,
             _platformResource.addApplicationOwnerJson,
             null,
             data
@@ -220,7 +201,6 @@ public unsafe class Platform : IResource
     public void RemoveApplicationOwner(RemoveApplicationOwnerData data)
     {
         Process<object>(
-            null,
             _platformResource.removeApplicationOwnerJson,
             null,
             data
@@ -232,18 +212,15 @@ public unsafe class Platform : IResource
         return Process<List<ApplicationOwnerDetailsResponse>>(
             _platformResource.getApplicationOwnersDetailsJson,
             null,
-            null,
             data
         );
     }
 
     private TResponse Process<TResponse>(
         delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_PlatformResource,
-            sbyte*, sbyte*> withDataAndWithResponse,
+            sbyte*, sbyte*> processDataWithResponse,
         delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_PlatformResource,
-            sbyte*, void> withDataAndWithoutResponse,
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_PlatformResource,
-            sbyte*> withoutDataAndWithResponse,
+            sbyte*> processWithoutDataWithResponse,
         object? data
     )
     {
@@ -251,16 +228,17 @@ public unsafe class Platform : IResource
         sbyte* result = null;
         try
         {
-            var withResponse = typeof(TResponse) != typeof(object);
-            var withData = data != null;
+            var hasData = data != null;
+            result = hasData ? processDataWithResponse(_platform, sData) :
+                processWithoutDataWithResponse(_platform);
 
-            if (withData && withResponse)
-                result = withDataAndWithResponse(_platform, sData);
-            else if (withData && !withResponse)
-                withDataAndWithoutResponse(_platform, sData);
-            else if (!withData && withResponse)
-                result = withoutDataAndWithResponse(_platform);
-            return result != null ? Utils.Utils.FromData<TResponse>(result)! : default!;
+            var resultData = result != null
+                ? Utils.Utils.FromData<ResultData<TResponse>>(result)
+                : default!;
+
+            resultData.HandleException();
+
+            return resultData.Success!.Result ?? default!;
         }
         finally
         {


### PR DESCRIPTION
This is the best way I found to deal with exceptions. I was not aware that `unmanaged exceptions` cannot be caught with `managed code`. This was causing the SDK to crash on any exception.

Now, all the resource functions return a `ResultData` object containing either the response or the exception information.

Note: I want to try something before merging it, but it can be reviewed in the meantime.