### PR TITLE
Batch share improvement

### DIFF
--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/api/model/LockOperations.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/api/model/LockOperations.kt
@@ -83,23 +83,3 @@ object LockOperations {
 
     sealed interface Operation
 }
-
-/**
- * Creates a new instance of `LockOperations.BaseOperation` with a newly generated JTI (JSON Token Identifier).
- *
- * The new instance retains all the properties of the original operation except for the JTI,
- * which is replaced with a randomly generated UUID.
- *
- * @receiver The original `LockOperations.BaseOperation` instance.
- * @return A new `LockOperations.BaseOperation` instance with the same properties as the receiver but with a new JTI.
- */
-internal fun LockOperations.BaseOperation.withNewJti() = LockOperations.BaseOperation(
-    userId = userId,
-    userCertificateChain = userCertificateChain,
-    userPrivateKey = userPrivateKey,
-    lockId = lockId,
-    notBefore = notBefore,
-    issuedAt = issuedAt,
-    expiresAt = expiresAt,
-    jti = Uuid.random().toString()
-)

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsClient.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/internal/api/LockOperationsClient.kt
@@ -6,7 +6,6 @@ import com.doordeck.multiplatform.sdk.MissingContextFieldException
 import com.doordeck.multiplatform.sdk.cache.CapabilityCache
 import com.doordeck.multiplatform.sdk.api.model.CapabilityType
 import com.doordeck.multiplatform.sdk.api.model.LockOperations
-import com.doordeck.multiplatform.sdk.api.model.withNewJti
 import com.doordeck.multiplatform.sdk.api.requests.BaseOperationRequest
 import com.doordeck.multiplatform.sdk.api.requests.BatchShareLockOperationRequest
 import com.doordeck.multiplatform.sdk.api.requests.BatchUserPublicKeyRequest
@@ -46,6 +45,7 @@ import com.doordeck.multiplatform.sdk.util.addRequestHeaders
 import com.doordeck.multiplatform.sdk.util.toJson
 import io.ktor.client.request.parameter
 import io.ktor.client.request.setBody
+import kotlin.uuid.Uuid
 
 internal object LockOperationsClient : AbstractResourceImpl() {
 
@@ -339,7 +339,7 @@ internal object LockOperationsClient : AbstractResourceImpl() {
             val failedOperations = batchShareLockOperation.users.mapNotNull { shareLock ->
                 try {
                     shareLockRequest(LockOperations.ShareLockOperation(
-                        baseOperation = batchShareLockOperation.baseOperation.withNewJti(), // Recreate the base operation because we need to use a different JTI for each user
+                        baseOperation = batchShareLockOperation.baseOperation.copy(jti = Uuid.random().toString()),
                         shareLock = shareLock
                     ))
                     null


### PR DESCRIPTION
Now that we are using data classes, we can also use copy, so the function `LockOperations.BaseOperation.withNewJti` is no longer necessary.