### PR TITLE
BouncyCastle for Android

### DIFF
--- a/doordeck-sdk/build.gradle.kts
+++ b/doordeck-sdk/build.gradle.kts
@@ -196,6 +196,7 @@ kotlin {
             dependencies {
                 implementation(libs.ktor.client.okhttp)
                 implementation(libs.security.crypto)
+                implementation(libs.bouncycastle)
             }
         }
 

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.android.kt
@@ -5,8 +5,10 @@ import com.doordeck.multiplatform.sdk.model.data.Crypto
 import io.ktor.util.decodeBase64Bytes
 import kotlinx.datetime.Clock
 import kotlinx.datetime.toKotlinInstant
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.KeyFactory
 import java.security.KeyPairGenerator
+import java.security.Security
 import java.security.Signature
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
@@ -17,6 +19,11 @@ actual object CryptoManager {
 
     private const val ALGORITHM = "Ed25519"
     private const val CERTIFICATE_TYPE = "X.509"
+
+    init {
+        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
+        Security.addProvider(BouncyCastleProvider())
+    }
 
     actual fun generateKeyPair(): Crypto.KeyPair {
         val key = KeyPairGenerator.getInstance(ALGORITHM).generateKeyPair()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.5.2"
+bouncycastle = "1.80"
 kotlin = "2.1.10"
 multiplatform-settings = "1.3.0"
 android-minSdk = "26"
@@ -15,6 +16,7 @@ asn1js = "3.0.5"
 pkijs = "3.2.4"
 
 [libraries]
+bouncycastle = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
 multiplatform-settings-test = { module = "com.russhwolf:multiplatform-settings-test", version.ref = "multiplatform-settings" }


### PR DESCRIPTION
I'm still unsure why the Android tests are passing and why I can execute a test targeting Android that generates a key without this, but it fails when I try to generate a key from an Android project.