### PR TITLE
Class builders

### DIFF
--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.kt
@@ -5,6 +5,7 @@ import com.doordeck.multiplatform.sdk.model.data.ApiEnvironment
 import com.doordeck.multiplatform.sdk.storage.SecureStorage
 import com.doordeck.multiplatform.sdk.storage.createSecureStorage
 import kotlin.js.JsExport
+import kotlin.jvm.JvmOverloads
 
 /**
  * Configuration settings for the SDK.
@@ -12,10 +13,10 @@ import kotlin.js.JsExport
  * This class holds various configuration options for initializing and operating the SDK.
  */
 @JsExport
-data class SdkConfig(
-    val apiEnvironment: ApiEnvironment?,
-    val cloudAuthToken: String?,
-    val cloudRefreshToken: String?,
+data class SdkConfig @JvmOverloads constructor(
+    val apiEnvironment: ApiEnvironment? = null,
+    val cloudAuthToken: String? = null,
+    val cloudRefreshToken: String? = null,
     val secureStorage: SecureStorage
 ) {
     /**

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.kt
@@ -12,7 +12,7 @@ import kotlin.js.JsExport
  * This class holds various configuration options for initializing and operating the SDK.
  */
 @JsExport
-class SdkConfig private constructor(
+data class SdkConfig(
     val apiEnvironment: ApiEnvironment?,
     val cloudAuthToken: String?,
     val cloudRefreshToken: String?,
@@ -34,28 +34,28 @@ class SdkConfig private constructor(
         /**
          * Sets the API environment for the SDK.
          */
-        fun setApiEnvironment(apiEnvironment: ApiEnvironment): Builder = apply { this.apiEnvironment = apiEnvironment }
+        fun setApiEnvironment(apiEnvironment: ApiEnvironment?): Builder = apply { this.apiEnvironment = apiEnvironment }
 
         /**
          * Sets the cloud authentication token.
          */
-        fun setCloudAuthToken(cloudAuthToken: String): Builder = apply { this.cloudAuthToken = cloudAuthToken }
+        fun setCloudAuthToken(cloudAuthToken: String?): Builder = apply { this.cloudAuthToken = cloudAuthToken }
 
         /**
          * Sets the cloud refresh token.
          */
-        fun setCloudRefreshToken(cloudRefreshToken: String): Builder = apply { this.cloudRefreshToken = cloudRefreshToken }
+        fun setCloudRefreshToken(cloudRefreshToken: String?): Builder = apply { this.cloudRefreshToken = cloudRefreshToken }
 
         /**
          * Sets the Android application context. This should only be provided on Android.
          */
         @JsExport.Ignore
-        fun setApplicationContext(context: ApplicationContext): Builder = apply { this.applicationContext = context }
+        fun setApplicationContext(context: ApplicationContext?): Builder = apply { this.applicationContext = context }
 
         /**
          * Overrides the default secure storage with a custom implementation.
          */
-        fun setSecureStorageOverride(secureStorage: SecureStorage): Builder = apply { this.secureStorage = secureStorage }
+        fun setSecureStorageOverride(secureStorage: SecureStorage?): Builder = apply { this.secureStorage = secureStorage }
 
         /**
          * Builds a new [SdkConfig] instance.

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperations.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperations.kt
@@ -15,7 +15,28 @@ object LockOperations {
         val end: String, // HH:mm
         val timezone: String,
         val days: List<String>
-    )
+    ) {
+        class Builder {
+            private var start: String? = null
+            private var end: String? = null
+            private var timezone: String? = null
+            private var days: List<String>? = null
+
+            fun setStart(start: String): Builder = apply { this.start = start }
+            fun setEnd(end: String): Builder = apply { this.end = end }
+            fun setTimezone(timezone: String) = apply { this.timezone = timezone }
+            fun setDays(days: List<String>) = apply { this.days = days }
+
+            fun build(): TimeRequirement {
+                return TimeRequirement(
+                    start = requireNotNull(start),
+                    end = requireNotNull(end),
+                    timezone = requireNotNull(timezone),
+                    days = requireNotNull(days)
+                )
+            }
+        }
+    }
 
     data class LocationRequirement @JvmOverloads constructor(
         val latitude: Double,
@@ -23,7 +44,31 @@ object LockOperations {
         val enabled: Boolean? = null,
         val radius: Int? = null,
         val accuracy: Int? = null
-    )
+    ) {
+        class Builder {
+            private var latitude: Double? = null
+            private var longitude: Double? = null
+            private var enabled: Boolean? = null
+            private var radius: Int? = null
+            private var accuracy: Int? = null
+
+            fun setLatitude(latitude: Double): Builder = apply { this.latitude = latitude }
+            fun setLongitude(longitude: Double): Builder = apply { this.longitude = longitude }
+            fun setEnabled(enabled: Boolean?): Builder = apply { this.enabled = enabled }
+            fun setRadius(radius: Int?): Builder = apply { this.radius = radius }
+            fun setAccuracy(accuracy: Int?): Builder = apply { this.accuracy = accuracy }
+
+            fun build(): LocationRequirement {
+                return LocationRequirement(
+                    latitude = requireNotNull(latitude),
+                    longitude = requireNotNull(longitude),
+                    enabled = enabled,
+                    radius = radius,
+                    accuracy = accuracy
+                )
+            }
+        }
+    }
 
     data class UnlockBetween @JvmOverloads constructor(
         val start: String, // HH:mm
@@ -31,17 +76,71 @@ object LockOperations {
         val timezone: String,
         val days: List<String>,
         val exceptions: List<String>? = null
-    )
+    ) {
+        class Builder {
+            private var start: String? = null
+            private var end: String? = null
+            private var timezone: String? = null
+            private var days: List<String>? = null
+            private var exceptions: List<String>? = null
+
+            fun setStart(start: String): Builder = apply { this.start = start }
+            fun setEnd(end: String): Builder = apply { this.end = end }
+            fun setTimezone(timezone: String): Builder = apply { this.timezone = timezone }
+            fun setDays(days: List<String>): Builder = apply { this.days = days }
+            fun setExceptions(exceptions: List<String>?): Builder = apply { this.exceptions = exceptions }
+
+            fun build(): UnlockBetween {
+                return UnlockBetween(
+                    start = requireNotNull(start),
+                    end = requireNotNull(end),
+                    timezone = requireNotNull(timezone),
+                    days = requireNotNull(days),
+                    exceptions = exceptions
+                )
+            }
+        }
+    }
 
     data class UnlockOperation @JvmOverloads constructor(
         val baseOperation: BaseOperation,
         val directAccessEndpoints: List<String>? = null
-    ): Operation
+    ): Operation {
+        class Builder {
+            private var baseOperation: BaseOperation? = null
+            private var directAccessEndpoints: List<String>? = null
+
+            fun setBaseOperation(baseOperation: BaseOperation): Builder = apply { this.baseOperation = baseOperation }
+            fun setDirectAccessEndpoints(directAccessEndpoints: List<String>?): Builder = apply { this.directAccessEndpoints = directAccessEndpoints }
+
+            fun build(): UnlockOperation {
+                return UnlockOperation(
+                    baseOperation = requireNotNull(baseOperation),
+                    directAccessEndpoints = directAccessEndpoints
+                )
+            }
+        }
+    }
 
     data class ShareLockOperation(
         val baseOperation: BaseOperation,
         val shareLock: ShareLock
-    ): Operation
+    ): Operation {
+        class Builder {
+            private var baseOperation: BaseOperation? = null
+            private var shareLock: ShareLock? = null
+
+            fun setBaseOperation(baseOperation: BaseOperation): Builder = apply { this.baseOperation = baseOperation }
+            fun setShareLock(shareLock: ShareLock): Builder = apply { this.shareLock = shareLock }
+
+            fun build(): ShareLockOperation {
+                return ShareLockOperation(
+                    baseOperation = requireNotNull(baseOperation),
+                    shareLock = requireNotNull(shareLock)
+                )
+            }
+        }
+    }
 
     data class ShareLock @JvmOverloads constructor(
         val targetUserId: String,
@@ -49,27 +148,111 @@ object LockOperations {
         val targetUserPublicKey: ByteArray,
         val start: Int? = null,
         val end: Int? = null
-    )
+    ) {
+        class Builder {
+            private var targetUserId: String? = null
+            private var targetUserRole: UserRole? = null
+            private var targetUserPublicKey: ByteArray? = null
+            private var start: Int? = null
+            private var end: Int? = null
+
+            fun setTargetUserId(targetUserId: String): Builder = apply { this.targetUserId = targetUserId }
+            fun setTargetUserRole(targetUserRole: UserRole): Builder = apply {this.targetUserRole = targetUserRole }
+            fun setTargetUserPublicKey(targetUserPublicKey: ByteArray): Builder = apply { this.targetUserPublicKey = targetUserPublicKey }
+            fun setStart(start: Int?): Builder = apply { this.start = start }
+            fun setEnd(end: Int?): Builder = apply { this.end = end }
+
+            fun build(): ShareLock {
+                return ShareLock(
+                    targetUserId = requireNotNull(targetUserId),
+                    targetUserRole = requireNotNull(targetUserRole),
+                    targetUserPublicKey = requireNotNull(targetUserPublicKey),
+                    start = start,
+                    end = end
+                )
+            }
+        }
+    }
 
     data class BatchShareLockOperation(
         val baseOperation: BaseOperation,
         val users: List<ShareLock>
-    ): Operation
+    ): Operation {
+        class Builder {
+            private var baseOperation: BaseOperation? = null
+            private var users: List<ShareLock>? = null
+
+            fun setBaseOperation(baseOperation: BaseOperation): Builder = apply { this.baseOperation = baseOperation }
+            fun setUsers(users: List<ShareLock>): Builder = apply { this.users = users }
+
+            fun build(): BatchShareLockOperation {
+                return BatchShareLockOperation(
+                    baseOperation = requireNotNull(baseOperation),
+                    users = requireNotNull(users)
+                )
+            }
+        }
+    }
 
     data class RevokeAccessToLockOperation(
         val baseOperation: BaseOperation,
         val users: List<String>
-    ): Operation
+    ): Operation {
+        class Builder {
+            private var baseOperation: BaseOperation? = null
+            private var users: List<String>? = null
+
+            fun setBaseOperation(baseOperation: BaseOperation): Builder = apply { this.baseOperation = baseOperation }
+            fun setUsers(users: List<String>): Builder = apply { this.users = users }
+
+            fun build(): RevokeAccessToLockOperation {
+                return RevokeAccessToLockOperation(
+                    baseOperation = requireNotNull(baseOperation),
+                    users = requireNotNull(users)
+                )
+            }
+        }
+    }
 
     data class UpdateSecureSettingUnlockDuration(
         val baseOperation: BaseOperation,
         val unlockDuration: Int
-    ): Operation
+    ): Operation {
+        class Builder {
+            private var baseOperation: BaseOperation? = null
+            private var unlockDuration: Int? = null
+
+            fun setBaseOperation(baseOperation: BaseOperation): Builder = apply { this.baseOperation = baseOperation }
+            fun setUnlockDuration(unlockDuration: Int): Builder = apply { this.unlockDuration = unlockDuration }
+
+            fun build(): UpdateSecureSettingUnlockDuration {
+                return UpdateSecureSettingUnlockDuration(
+                    baseOperation = requireNotNull(baseOperation),
+                    unlockDuration = requireNotNull(unlockDuration)
+                )
+            }
+        }
+    }
 
     data class UpdateSecureSettingUnlockBetween @JvmOverloads constructor(
         val baseOperation: BaseOperation,
         val unlockBetween: UnlockBetween? = null
-    ): Operation
+    ): Operation {
+        class Builder {
+            private var baseOperation: BaseOperation? = null
+            private var unlockBetween: UnlockBetween? = null
+
+            fun setBaseOperation(baseOperation: BaseOperation): Builder = apply { this.baseOperation = baseOperation }
+            fun setUnlockBetween(unlockBetween: UnlockBetween?): Builder = apply { this.unlockBetween = unlockBetween }
+
+            fun build(): UpdateSecureSettingUnlockBetween {
+                return UpdateSecureSettingUnlockBetween(
+                    baseOperation = requireNotNull(baseOperation),
+                    unlockBetween = unlockBetween
+                )
+            }
+        }
+    }
 
     data class BaseOperation @JvmOverloads constructor(
         val userId: String? = null,
@@ -80,7 +263,40 @@ object LockOperations {
         val issuedAt: Int = Clock.System.now().epochSeconds.toInt(),
         val expiresAt: Int = (Clock.System.now() + 1.minutes).epochSeconds.toInt(),
         val jti: String = Uuid.random().toString()
-    )
+    ) {
+        class Builder {
+            private var userId: String? = null
+            private var userCertificateChain: List<String>? = null
+            private var userPrivateKey: ByteArray? = null
+            private var lockId: String? = null
+            private var notBefore: Int = Clock.System.now().epochSeconds.toInt()
+            private var issuedAt: Int = Clock.System.now().epochSeconds.toInt()
+            private var expiresAt: Int = (Clock.System.now() + 1.minutes).epochSeconds.toInt()
+            private var jti: String = Uuid.random().toString()
+
+            fun setUserId(userId: String?): Builder = apply { this.userId = userId }
+            fun setUserCertificateChain(userCertificateChain: List<String>?): Builder = apply { this.userCertificateChain = userCertificateChain }
+            fun setUserPrivateKey(userPrivateKey: ByteArray?): Builder = apply { this.userPrivateKey = userPrivateKey }
+            fun setLockId(lockId: String): Builder = apply { this.lockId = lockId }
+            fun setNotBefore(notBefore: Int): Builder = apply { this.notBefore = notBefore }
+            fun setIssuedAt(issuedAt: Int): Builder = apply { this.issuedAt = issuedAt }
+            fun setExpiresAt(expiresAt: Int): Builder = apply { this.expiresAt = expiresAt }
+            fun setJti(jti: String): Builder = apply { this.jti = jti }
+
+            fun build(): BaseOperation {
+                return BaseOperation(
+                    userId = userId,
+                    userCertificateChain = userCertificateChain,
+                    userPrivateKey = userPrivateKey,
+                    lockId = requireNotNull(lockId),
+                    notBefore = notBefore,
+                    issuedAt = issuedAt,
+                    expiresAt = expiresAt,
+                    jti = jti
+                )
+            }
+        }
+    }
 
     sealed interface Operation
 }

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/data/Platform.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/data/Platform.kt
@@ -15,7 +15,40 @@ object Platform {
         val appLink: String? = null,
         val emailPreferences: EmailPreferences? = null,
         val logoUrl: String? = null
-    )
+    ) {
+        class Builder {
+            private var name: String? = null
+            private var companyName: String? = null
+            private var mailingAddress: String? = null
+            private var privacyPolicy: String? = null
+            private var supportContact: String? = null
+            private var appLink: String? = null
+            private var emailPreferences: EmailPreferences? = null
+            private var logoUrl: String? = null
+
+            fun setName(name: String) = apply { this.name = name }
+            fun setCompanyName(companyName: String) = apply { this.companyName = companyName }
+            fun setMailingAddress(mailingAddress: String) = apply { this.mailingAddress = mailingAddress }
+            fun setPrivacyPolicy(privacyPolicy: String?) = apply { this.privacyPolicy = privacyPolicy }
+            fun setSupportContact(supportContact: String?) = apply { this.supportContact = supportContact }
+            fun setAppLink(appLink: String?) = apply { this.appLink = appLink }
+            fun setEmailPreferences(emailPreferences: EmailPreferences?) = apply { this.emailPreferences = emailPreferences }
+            fun setLogoUrl(logoUrl: String?) = apply { this.logoUrl = logoUrl }
+
+            fun build(): CreateApplication {
+                return CreateApplication(
+                    name = requireNotNull(name),
+                    companyName = requireNotNull(companyName),
+                    mailingAddress = requireNotNull(mailingAddress),
+                    privacyPolicy = privacyPolicy,
+                    supportContact = supportContact,
+                    appLink = appLink,
+                    emailPreferences = emailPreferences,
+                    logoUrl = logoUrl
+                )
+            }
+        }
+    }
 
     data class EmailPreferences @JvmOverloads constructor(
         val senderEmail: String? = null,
@@ -24,13 +57,58 @@ object Platform {
         val secondaryColour: String? = null,
         val onlySendEssentialEmails: Boolean? = null,
         val callToAction: EmailCallToAction? = null
-    )
+    ) {
+        class Builder {
+            private var senderEmail: String? = null
+            private var senderName: String? = null
+            private var primaryColour: String? = null
+            private var secondaryColour: String? = null
+            private var onlySendEssentialEmails: Boolean? = null
+            private var callToAction: EmailCallToAction? = null
+
+            fun setSenderEmail(senderEmail: String?) = apply { this.senderEmail = senderEmail }
+            fun setSenderName(senderName: String?) = apply { this.senderName = senderName }
+            fun setPrimaryColour(primaryColour: String?) = apply { this.primaryColour = primaryColour }
+            fun setSecondaryColour(secondaryColour: String?) = apply { this.secondaryColour = secondaryColour }
+            fun setOnlySendEssentialEmails(onlySendEssentialEmails: Boolean?) = apply { this.onlySendEssentialEmails = onlySendEssentialEmails }
+            fun setCallToAction(callToAction: EmailCallToAction?) = apply { this.callToAction = callToAction }
+
+            fun build(): EmailPreferences {
+                return EmailPreferences(
+                    senderEmail = senderEmail,
+                    senderName = senderName,
+                    primaryColour = primaryColour,
+                    secondaryColour = secondaryColour,
+                    onlySendEssentialEmails = onlySendEssentialEmails,
+                    callToAction = callToAction
+                )
+            }
+        }
+    }
 
     data class EmailCallToAction(
         val actionTarget: String,
         val headline: String,
         val actionText: String
-    )
+    ) {
+        class Builder {
+            private var actionTarget: String? = null
+            private var headline: String? = null
+            private var actionText: String? = null
+
+            fun setActionTarget(actionTarget: String) = apply { this.actionTarget = actionTarget }
+            fun setHeadline(headline: String) = apply { this.headline = headline }
+            fun setActionText(actionText: String) = apply { this.actionText = actionText }
+
+            fun build(): EmailCallToAction {
+                return EmailCallToAction(
+                    actionTarget = requireNotNull(actionTarget),
+                    headline = requireNotNull(headline),
+                    actionText = requireNotNull(actionText),
+                )
+            }
+        }
+    }
 
     sealed interface AuthKey {
         val kid: String
@@ -52,7 +130,52 @@ object Platform {
         val dp: String,
         val dq: String,
         val n: String
-    ): AuthKey
+    ): AuthKey {
+        class Builder {
+            private var kty: String = "RSA"
+            private var use: String? = null
+            private var kid: String? = null
+            private var alg: String? = null
+            private var p: String? = null
+            private var q: String? = null
+            private var d: String? = null
+            private var e: String? = null
+            private var qi: String? = null
+            private var dp: String? = null
+            private var dq: String? = null
+            private var n: String? = null
+
+            fun setKty(kty: String) = apply { this.kty = kty }
+            fun setUse(use: String) = apply { this.use = use }
+            fun setKid(kid: String) = apply { this.kid = kid }
+            fun setAlg(alg: String?) = apply { this.alg = alg }
+            fun setP(p: String) = apply { this.p = p }
+            fun setQ(q: String) = apply { this.q = q }
+            fun setD(d: String) = apply { this.d = d }
+            fun setE(e: String) = apply { this.e = e }
+            fun setQi(qi: String) = apply { this.qi = qi }
+            fun setDp(dp: String) = apply { this.dp = dp }
+            fun setDq(dq: String) = apply { this.dq = dq }
+            fun setN(n: String) = apply { this.n = n }
+
+            fun build(): RsaKey {
+                return RsaKey(
+                    kty = kty,
+                    use = requireNotNull(use),
+                    kid = requireNotNull(kid),
+                    alg = alg,
+                    p = requireNotNull(p),
+                    q = requireNotNull(q),
+                    d = requireNotNull(d),
+                    e = requireNotNull(e),
+                    qi = requireNotNull(qi),
+                    dp = requireNotNull(dp),
+                    dq = requireNotNull(dq),
+                    n = requireNotNull(n)
+                )
+            }
+        }
+    }
 
     data class EcKey(
         override val kty: String = "EC",
@@ -63,7 +186,40 @@ object Platform {
         val crv: String,
         val x: String,
         val y: String
-    ): AuthKey
+    ): AuthKey {
+        class Builder {
+            private var kty: String = "EC"
+            private var use: String? = null
+            private var kid: String? = null
+            private var alg: String? = null
+            private var d: String? = null
+            private var crv: String? = null
+            private var x: String? = null
+            private var y: String? = null
+
+            fun setKty(kty: String) = apply { this.kty = kty }
+            fun setUse(use: String) = apply { this.use = use }
+            fun setKid(kid: String) = apply { this.kid = kid }
+            fun setAlg(alg: String?) = apply { this.alg = alg }
+            fun setD(d: String) = apply { this.d = d }
+            fun setCrv(crv: String) = apply { this.crv = crv }
+            fun setX(x: String) = apply { this.x = x }
+            fun setY(y: String) = apply { this.y = y }
+
+            fun build(): EcKey {
+                return EcKey(
+                    kty = kty,
+                    use = requireNotNull(use),
+                    kid = requireNotNull(kid),
+                    alg = alg,
+                    d = requireNotNull(d),
+                    crv = requireNotNull(crv),
+                    x = requireNotNull(x),
+                    y = requireNotNull(y)
+                )
+            }
+        }
+    }
 
     data class Ed25519Key(
         override val kty: String = "OKP",
@@ -73,5 +229,35 @@ object Platform {
         val d: String,
         val crv: String,
         val x: String
-    ): AuthKey
+    ): AuthKey {
+        class Builder {
+            private var kty: String = "OKP"
+            private var use: String? = null
+            private var kid: String? = null
+            private var alg: String? = null
+            private var d: String? = null
+            private var crv: String? = null
+            private var x: String? = null
+
+            fun setKty(kty: String) = apply { this.kty = kty }
+            fun setUse(use: String) = apply { this.use = use }
+            fun setKid(kid: String) = apply { this.kid = kid }
+            fun setAlg(alg: String?) = apply { this.alg = alg }
+            fun setD(d: String) = apply { this.d = d }
+            fun setCrv(crv: String) = apply { this.crv = crv }
+            fun setX(x: String) = apply { this.x = x }
+
+            fun build(): Ed25519Key {
+                return Ed25519Key(
+                    kty = kty,
+                    use = requireNotNull(use),
+                    kid = requireNotNull(kid),
+                    alg = alg,
+                    d = requireNotNull(d),
+                    crv = requireNotNull(crv),
+                    x = requireNotNull(x)
+                )
+            }
+        }
+    }
 }

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
@@ -7,6 +7,7 @@ import com.doordeck.multiplatform.sdk.model.common.CapabilityStatus
 import com.doordeck.multiplatform.sdk.model.common.CapabilityType
 import com.doordeck.multiplatform.sdk.model.common.TwoFactorMethod
 import com.doordeck.multiplatform.sdk.model.common.UserRole
+import com.doordeck.multiplatform.sdk.model.data.LockOperations
 import com.doordeck.multiplatform.sdk.model.responses.ApplicationOwnerDetailsResponse
 import com.doordeck.multiplatform.sdk.model.responses.ApplicationResponse
 import com.doordeck.multiplatform.sdk.model.responses.AuditIssuerResponse
@@ -55,7 +56,7 @@ import kotlin.random.Random
 import kotlin.uuid.Uuid
 
 /**
- * Account
+ * Account responses
  */
 internal fun randomTokenResponse(): TokenResponse = TokenResponse(
     authToken = randomString(),
@@ -79,7 +80,7 @@ internal fun randomRegisterEphemeralKeyWithSecondaryAuthenticationResponse(): Re
 )
 
 /**
- * Fusion
+ * Fusion responses
  */
 internal fun randomFusionLoginResponse(): FusionLoginResponse = FusionLoginResponse(
     authToken = randomString()
@@ -117,7 +118,7 @@ internal fun randomDiscoveredDeviceResponse(): DiscoveredDeviceResponse = Discov
 internal fun randomFusionController(): Fusion.LockController = Fusion.DemoController()
 
 /**
- * Lock operations
+ * Lock operation responses
  */
 internal fun randomLockResponse(): LockResponse = LockResponse(
     id = randomString(),
@@ -250,7 +251,7 @@ internal fun randomAuditIssuerResponse(): AuditIssuerResponse = AuditIssuerRespo
 )
 
 /**
- * Platform
+ * Platform responses
  */
 internal fun randomApplicationResponse(): ApplicationResponse = ApplicationResponse(
     applicationId = randomString(),
@@ -363,7 +364,7 @@ internal fun randomGetLogoUploadUrlResponse(): GetLogoUploadUrlResponse = GetLog
 )
 
 /**
- * Site
+ * Site responses
  */
 internal fun randomSiteResponse(): SiteResponse = SiteResponse(
     id = randomString(),
@@ -406,7 +407,7 @@ internal fun randomUserForSiteResponse(): UserForSiteResponse = UserForSiteRespo
 )
 
 /**
- * Tile
+ * Tile responses
  */
 internal fun randomTileLocksResponse(): TileLocksResponse = TileLocksResponse(
     siteId = randomString(),
@@ -414,8 +415,87 @@ internal fun randomTileLocksResponse(): TileLocksResponse = TileLocksResponse(
     deviceIds = (1..3).map { randomString() }
 )
 
+/**
+ * Lock operation data
+ */
+internal fun randomTimeRequirement(): LockOperations.TimeRequirement = LockOperations.TimeRequirement(
+    start = randomString(),
+    end = randomString(),
+    timezone = randomString(),
+    days = (1..3).map { randomString() }
+)
+
+internal fun randomLocationRequirement(): LockOperations.LocationRequirement = LockOperations.LocationRequirement(
+    latitude = randomDouble(),
+    longitude = randomDouble(),
+    enabled = randomNullable { randomBoolean() },
+    radius = randomNullable { randomInt() },
+    accuracy = randomNullable { randomInt() }
+)
+
+internal fun randomUnlockBetween(): LockOperations.UnlockBetween = LockOperations.UnlockBetween(
+    start = randomString(),
+    end = randomString(),
+    timezone = randomString(),
+    days = (1..3).map { randomString() },
+    exceptions = randomNullable { (1..3).map { randomString() } }
+)
+
+internal fun randomUnlockOperation(): LockOperations.UnlockOperation = LockOperations.UnlockOperation(
+    baseOperation = randomBaseOperation(),
+    directAccessEndpoints = randomNullable { (1..3).map { randomString() } }
+)
+
+internal fun randomShareLockOperation(): LockOperations.ShareLockOperation = LockOperations.ShareLockOperation(
+    baseOperation = randomBaseOperation(),
+    shareLock = randomShareLock()
+)
+
+internal fun randomBatchShareLockOperation(): LockOperations.BatchShareLockOperation = LockOperations.BatchShareLockOperation(
+    baseOperation = randomBaseOperation(),
+    users = (1..3).map { randomShareLock() }
+)
+
+internal fun randomRevokeAccessToLockOperation(): LockOperations.RevokeAccessToLockOperation = LockOperations.RevokeAccessToLockOperation(
+    baseOperation = randomBaseOperation(),
+    users = (1..3).map { randomString() }
+)
+
+internal fun randomUpdateSecureSettingUnlockDuration(): LockOperations.UpdateSecureSettingUnlockDuration = LockOperations.UpdateSecureSettingUnlockDuration(
+    baseOperation = randomBaseOperation(),
+    unlockDuration = randomInt()
+)
+
+internal fun randomUpdateSecureSettingUnlockBetween(): LockOperations.UpdateSecureSettingUnlockBetween = LockOperations.UpdateSecureSettingUnlockBetween(
+    baseOperation = randomBaseOperation(),
+    unlockBetween = randomNullable { randomUnlockBetween() }
+)
+
+internal fun randomShareLock(): LockOperations.ShareLock = LockOperations.ShareLock(
+    targetUserId = randomString(),
+    targetUserRole = UserRole.entries.random(),
+    targetUserPublicKey = randomByteArray(),
+    start = randomNullable { randomInt() },
+    end = randomNullable { randomInt() }
+)
+
+internal fun randomBaseOperation(): LockOperations.BaseOperation = LockOperations.BaseOperation(
+    userId = randomNullable { randomString() },
+    userCertificateChain = randomNullable { (1..3).map { randomString() } },
+    userPrivateKey = randomNullable { randomByteArray() },
+    lockId = randomString(),
+    notBefore = randomInt(),
+    issuedAt = randomInt(),
+    expiresAt = randomInt(),
+    jti = randomString()
+)
+
+/**
+ * Test utils
+ */
 private fun randomInt(min: Int = 0, max: Int = Int.MAX_VALUE) = Random.nextInt(min, max)
 private fun randomDouble(from: Double = 0.0, to: Double = 100.0): Double = Random.nextDouble(from, to)
 private fun randomBoolean(): Boolean = Random.nextBoolean()
 private inline fun <T> randomNullable(supplier: () -> T): T? = if (randomBoolean()) supplier() else null
 private fun randomString(): String = Uuid.random().toString()
+private fun randomByteArray(): ByteArray = Random.nextBytes(ByteArray(randomInt(1, 20)))

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
@@ -1,12 +1,14 @@
 package com.doordeck.multiplatform.sdk
 
 import com.doordeck.multiplatform.sdk.TestConstants.DEFAULT_UPLOAD_URL
+import com.doordeck.multiplatform.sdk.config.SdkConfig
 import com.doordeck.multiplatform.sdk.model.data.Fusion
 import com.doordeck.multiplatform.sdk.model.common.AuditEvent
 import com.doordeck.multiplatform.sdk.model.common.CapabilityStatus
 import com.doordeck.multiplatform.sdk.model.common.CapabilityType
 import com.doordeck.multiplatform.sdk.model.common.TwoFactorMethod
 import com.doordeck.multiplatform.sdk.model.common.UserRole
+import com.doordeck.multiplatform.sdk.model.data.ApiEnvironment
 import com.doordeck.multiplatform.sdk.model.data.LockOperations
 import com.doordeck.multiplatform.sdk.model.data.Platform
 import com.doordeck.multiplatform.sdk.model.data.Platform.EmailCallToAction
@@ -54,6 +56,8 @@ import com.doordeck.multiplatform.sdk.model.responses.UserDetailsResponse
 import com.doordeck.multiplatform.sdk.model.responses.UserForSiteResponse
 import com.doordeck.multiplatform.sdk.model.responses.UserLockResponse
 import com.doordeck.multiplatform.sdk.model.responses.UserPublicKeyResponse
+import com.doordeck.multiplatform.sdk.storage.DefaultSecureStorage
+import com.doordeck.multiplatform.sdk.storage.MemorySettings
 import kotlin.random.Random
 import kotlin.uuid.Uuid
 
@@ -555,6 +559,16 @@ internal fun randomEd25519Key(): Platform.Ed25519Key = Platform.Ed25519Key(
     d = randomString(),
     crv = randomString(),
     x = randomString()
+)
+
+/**
+ * Config
+ */
+fun randomSdkConfig(): SdkConfig = SdkConfig(
+    apiEnvironment = randomNullable { ApiEnvironment.entries.random() },
+    cloudAuthToken = randomNullable { randomString() },
+    cloudRefreshToken = randomNullable { randomString() },
+    secureStorage = DefaultSecureStorage(MemorySettings())
 )
 
 /**

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
@@ -8,6 +8,8 @@ import com.doordeck.multiplatform.sdk.model.common.CapabilityType
 import com.doordeck.multiplatform.sdk.model.common.TwoFactorMethod
 import com.doordeck.multiplatform.sdk.model.common.UserRole
 import com.doordeck.multiplatform.sdk.model.data.LockOperations
+import com.doordeck.multiplatform.sdk.model.data.Platform
+import com.doordeck.multiplatform.sdk.model.data.Platform.EmailCallToAction
 import com.doordeck.multiplatform.sdk.model.responses.ApplicationOwnerDetailsResponse
 import com.doordeck.multiplatform.sdk.model.responses.ApplicationResponse
 import com.doordeck.multiplatform.sdk.model.responses.AuditIssuerResponse
@@ -488,6 +490,71 @@ internal fun randomBaseOperation(): LockOperations.BaseOperation = LockOperation
     issuedAt = randomInt(),
     expiresAt = randomInt(),
     jti = randomString()
+)
+
+/**
+ * Platform data
+ */
+internal fun randomCreateApplication(): Platform.CreateApplication = Platform.CreateApplication(
+    name = randomString(),
+    companyName = randomString(),
+    mailingAddress = randomString(),
+    privacyPolicy = randomNullable { randomString() },
+    supportContact = randomNullable { randomString() },
+    appLink = randomNullable { randomString() },
+    emailPreferences = randomNullable { randomEmailPreferences() },
+    logoUrl = randomNullable { randomString() }
+)
+
+internal fun randomEmailPreferences(): Platform.EmailPreferences = Platform.EmailPreferences(
+    senderEmail = randomNullable { randomString() },
+    senderName = randomNullable { randomString() },
+    primaryColour = randomNullable { randomString() },
+    secondaryColour = randomNullable { randomString() },
+    onlySendEssentialEmails = randomNullable { randomBoolean() },
+    callToAction = randomNullable { randomEmailCallToAction() }
+)
+
+internal fun randomEmailCallToAction(): EmailCallToAction = EmailCallToAction(
+    actionTarget = randomString(),
+    headline = randomString(),
+    actionText = randomString()
+)
+
+internal fun randomRsaKey(): Platform.RsaKey = Platform.RsaKey(
+    kty = randomString(),
+    use = randomString(),
+    kid = randomString(),
+    alg = randomNullable { randomString() },
+    p = randomString(),
+    q = randomString(),
+    d = randomString(),
+    e = randomString(),
+    qi = randomString(),
+    dp = randomString(),
+    dq = randomString(),
+    n = randomString()
+)
+
+internal fun randomEcKey(): Platform.EcKey = Platform.EcKey(
+    kty = randomString(),
+    use = randomString(),
+    kid = randomString(),
+    alg = randomNullable { randomString() },
+    d = randomString(),
+    crv = randomString(),
+    x = randomString(),
+    y = randomString()
+)
+
+internal fun randomEd25519Key(): Platform.Ed25519Key = Platform.Ed25519Key(
+    kty = randomString(),
+    use = randomString(),
+    kid = randomString(),
+    alg = randomNullable { randomString() },
+    d = randomString(),
+    crv = randomString(),
+    x = randomString()
 )
 
 /**

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.kt
@@ -1,0 +1,26 @@
+package com.doordeck.multiplatform.sdk.config
+
+import com.doordeck.multiplatform.sdk.randomSdkConfig
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SdkConfigTest {
+
+    @Test
+    fun shouldBuildSdkConfig () = runTest {
+        // Given
+        val sdkConfig = randomSdkConfig()
+
+        // When
+        val result = SdkConfig.Builder()
+            .setApiEnvironment(sdkConfig.apiEnvironment)
+            .setCloudAuthToken(sdkConfig.cloudAuthToken)
+            .setCloudRefreshToken(sdkConfig.cloudRefreshToken)
+            .setSecureStorageOverride(sdkConfig.secureStorage)
+            .build()
+
+        // Then
+        assertEquals(sdkConfig, result)
+    }
+}

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperationsTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperationsTest.kt
@@ -1,0 +1,182 @@
+package com.doordeck.multiplatform.sdk.model.data
+
+import com.doordeck.multiplatform.sdk.randomBaseOperation
+import com.doordeck.multiplatform.sdk.randomBatchShareLockOperation
+import com.doordeck.multiplatform.sdk.randomLocationRequirement
+import com.doordeck.multiplatform.sdk.randomRevokeAccessToLockOperation
+import com.doordeck.multiplatform.sdk.randomShareLockOperation
+import com.doordeck.multiplatform.sdk.randomTimeRequirement
+import com.doordeck.multiplatform.sdk.randomUnlockBetween
+import com.doordeck.multiplatform.sdk.randomUnlockOperation
+import com.doordeck.multiplatform.sdk.randomUpdateSecureSettingUnlockBetween
+import com.doordeck.multiplatform.sdk.randomUpdateSecureSettingUnlockDuration
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LockOperationsTest {
+
+    @Test
+    fun shouldBuildTimeRequirement() = runTest {
+        // Given
+        val timeRequirement = randomTimeRequirement()
+
+        // When
+        val result = LockOperations.TimeRequirement.Builder()
+            .setStart(timeRequirement.start)
+            .setEnd(timeRequirement.end)
+            .setTimezone(timeRequirement.timezone)
+            .setDays(timeRequirement.days)
+            .build()
+
+        // Then
+        assertEquals(timeRequirement, result)
+    }
+
+    @Test
+    fun shouldBuildLocationRequirement() = runTest {
+        // Given
+        val locationRequirement = randomLocationRequirement()
+
+        // When
+        val result = LockOperations.LocationRequirement.Builder()
+            .setLatitude(locationRequirement.latitude)
+            .setLongitude(locationRequirement.longitude)
+            .setEnabled(locationRequirement.enabled)
+            .setRadius(locationRequirement.radius)
+            .setAccuracy(locationRequirement.accuracy)
+            .build()
+
+        // Then
+        assertEquals(locationRequirement, result)
+    }
+
+    @Test
+    fun shouldBuildUnlockBetween() = runTest {
+        // Given
+        val unlockBetween = randomUnlockBetween()
+
+        // When
+        val result = LockOperations.UnlockBetween.Builder()
+            .setStart(unlockBetween.start)
+            .setEnd(unlockBetween.end)
+            .setTimezone(unlockBetween.timezone)
+            .setDays(unlockBetween.days)
+            .setExceptions(unlockBetween.exceptions)
+            .build()
+
+        // Then
+        assertEquals(unlockBetween, result)
+    }
+
+    @Test
+    fun shouldBuildUnlockOperation() = runTest {
+        // Given
+        val unlockOperation = randomUnlockOperation()
+
+        // When
+        val result = LockOperations.UnlockOperation.Builder()
+            .setBaseOperation(unlockOperation.baseOperation)
+            .setDirectAccessEndpoints(unlockOperation.directAccessEndpoints)
+            .build()
+
+        // Then
+        assertEquals(unlockOperation, result)
+    }
+
+    @Test
+    fun shouldBuildShareLockOperation() = runTest {
+        // Given
+        val shareLockShareLockOperation = randomShareLockOperation()
+
+        // When
+        val result = LockOperations.ShareLockOperation.Builder()
+            .setBaseOperation(shareLockShareLockOperation.baseOperation)
+            .setShareLock(shareLockShareLockOperation.shareLock)
+            .build()
+
+        // When
+        assertEquals(shareLockShareLockOperation, result)
+    }
+
+    @Test
+    fun shouldBuildBatchShareLockOperation() = runTest {
+        // Given
+        val batchShareLockOperation = randomBatchShareLockOperation()
+
+        // When
+        val result = LockOperations.BatchShareLockOperation.Builder()
+            .setBaseOperation(batchShareLockOperation.baseOperation)
+            .setUsers(batchShareLockOperation.users)
+            .build()
+
+        // Then
+        assertEquals(batchShareLockOperation, result)
+    }
+
+    @Test
+    fun shouldBuildRevokeAccessToLockOperation() = runTest {
+        // Given
+        val revokeAccessToLockOperation = randomRevokeAccessToLockOperation()
+
+        // When
+        val result = LockOperations.RevokeAccessToLockOperation.Builder()
+            .setBaseOperation(revokeAccessToLockOperation.baseOperation)
+            .setUsers(revokeAccessToLockOperation.users)
+            .build()
+
+        // Then
+        assertEquals(revokeAccessToLockOperation, result)
+    }
+
+    @Test
+    fun shouldBuildUpdateSecureSettingUnlockDuration() = runTest {
+        // Given
+        val updateSecureSettingUnlockDuration = randomUpdateSecureSettingUnlockDuration()
+
+        // Then
+        val result = LockOperations.UpdateSecureSettingUnlockDuration.Builder()
+            .setBaseOperation(updateSecureSettingUnlockDuration.baseOperation)
+            .setUnlockDuration(updateSecureSettingUnlockDuration.unlockDuration)
+            .build()
+
+        // Then
+        assertEquals(updateSecureSettingUnlockDuration, result)
+    }
+
+    @Test
+    fun shouldBuildUpdateSecureSettingUnlockBetween() = runTest {
+        // Given
+        val updateSecureSettingUnlockBetween = randomUpdateSecureSettingUnlockBetween()
+
+        // Then
+        val result = LockOperations.UpdateSecureSettingUnlockBetween.Builder()
+            .setBaseOperation(updateSecureSettingUnlockBetween.baseOperation)
+            .setUnlockBetween(updateSecureSettingUnlockBetween.unlockBetween)
+            .build()
+
+        // Then
+        assertEquals(updateSecureSettingUnlockBetween, result)
+    }
+
+    @Test
+    fun shouldBuildBaseOperation() = runTest {
+        // Given
+        val baseOperation = randomBaseOperation()
+
+        // When
+        val result = LockOperations.BaseOperation.Builder()
+            .setUserId(baseOperation.userId)
+            .setUserCertificateChain(baseOperation.userCertificateChain)
+            .setUserPrivateKey(baseOperation.userPrivateKey)
+            .setLockId(baseOperation.lockId)
+            .setNotBefore(baseOperation.notBefore)
+            .setIssuedAt(baseOperation.issuedAt)
+            .setExpiresAt(baseOperation.expiresAt)
+            .setJti(baseOperation.jti)
+            .build()
+
+        // Then
+        assertEquals(baseOperation, result)
+    }
+}

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperationsTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperationsTest.kt
@@ -4,6 +4,7 @@ import com.doordeck.multiplatform.sdk.randomBaseOperation
 import com.doordeck.multiplatform.sdk.randomBatchShareLockOperation
 import com.doordeck.multiplatform.sdk.randomLocationRequirement
 import com.doordeck.multiplatform.sdk.randomRevokeAccessToLockOperation
+import com.doordeck.multiplatform.sdk.randomShareLock
 import com.doordeck.multiplatform.sdk.randomShareLockOperation
 import com.doordeck.multiplatform.sdk.randomTimeRequirement
 import com.doordeck.multiplatform.sdk.randomUnlockBetween
@@ -112,6 +113,24 @@ class LockOperationsTest {
 
         // Then
         assertEquals(batchShareLockOperation, result)
+    }
+
+    @Test
+    fun shouldBuildShareLock() = runTest {
+        // Given
+        val shareLock = randomShareLock()
+
+        // When
+        val result = LockOperations.ShareLock.Builder()
+            .setTargetUserId(shareLock.targetUserId)
+            .setTargetUserRole(shareLock.targetUserRole)
+            .setTargetUserPublicKey(shareLock.targetUserPublicKey)
+            .setStart(shareLock.start)
+            .setEnd(shareLock.end)
+            .build()
+
+        // Then
+        assertEquals(shareLock, result)
     }
 
     @Test

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/model/data/PlatformTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/model/data/PlatformTest.kt
@@ -1,0 +1,136 @@
+package com.doordeck.multiplatform.sdk.model.data
+
+import com.doordeck.multiplatform.sdk.randomCreateApplication
+import com.doordeck.multiplatform.sdk.randomEcKey
+import com.doordeck.multiplatform.sdk.randomEd25519Key
+import com.doordeck.multiplatform.sdk.randomEmailCallToAction
+import com.doordeck.multiplatform.sdk.randomEmailPreferences
+import com.doordeck.multiplatform.sdk.randomRsaKey
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlatformTest {
+
+    @Test
+    fun shouldBuildCreateApplication() = runTest {
+        // Given
+        val createApplication = randomCreateApplication()
+
+        // When
+        val result = Platform.CreateApplication.Builder()
+            .setName(createApplication.name)
+            .setCompanyName(createApplication.companyName)
+            .setMailingAddress(createApplication.mailingAddress)
+            .setPrivacyPolicy(createApplication.privacyPolicy)
+            .setSupportContact(createApplication.supportContact)
+            .setAppLink(createApplication.appLink)
+            .setEmailPreferences(createApplication.emailPreferences)
+            .setLogoUrl(createApplication.logoUrl)
+            .build()
+
+        // Then
+        assertEquals(createApplication, result)
+    }
+
+    @Test
+    fun shouldBuildEmailPreferences() = runTest {
+        // Given
+        val emailPreferences = randomEmailPreferences()
+
+        // When
+        val result = Platform.EmailPreferences.Builder()
+            .setSenderEmail(emailPreferences.senderEmail)
+            .setSenderName(emailPreferences.senderName)
+            .setPrimaryColour(emailPreferences.primaryColour)
+            .setSecondaryColour(emailPreferences.secondaryColour)
+            .setOnlySendEssentialEmails(emailPreferences.onlySendEssentialEmails)
+            .setCallToAction(emailPreferences.callToAction)
+            .build()
+
+        // Then
+        assertEquals(emailPreferences, result)
+    }
+
+    @Test
+    fun shouldBuildEmailCallToAction() = runTest {
+        // Given
+        val emailCallToAction = randomEmailCallToAction()
+
+        // When
+        val result = Platform.EmailCallToAction.Builder()
+            .setActionTarget(emailCallToAction.actionTarget)
+            .setHeadline(emailCallToAction.headline)
+            .setActionText(emailCallToAction.actionText)
+            .build()
+
+        // Then
+        assertEquals(emailCallToAction, result)
+    }
+
+    @Test
+    fun shouldBuildRsaKey() = runTest {
+        // Given
+        val rsaKey = randomRsaKey()
+
+        // When
+        val result = Platform.RsaKey.Builder()
+            .setKty(rsaKey.kty)
+            .setUse(rsaKey.use)
+            .setKid(rsaKey.kid)
+            .setAlg(rsaKey.alg)
+            .setP(rsaKey.p)
+            .setQ(rsaKey.q)
+            .setD(rsaKey.d)
+            .setE(rsaKey.e)
+            .setQi(rsaKey.qi)
+            .setDp(rsaKey.dp)
+            .setDq(rsaKey.dq)
+            .setN(rsaKey.n)
+            .build()
+
+        // Then
+        assertEquals(rsaKey, result)
+    }
+
+    @Test
+    fun shouldBuildEcKey() = runTest {
+        // Given
+        val ecKey = randomEcKey()
+
+        // When
+        val result = Platform.EcKey.Builder()
+            .setKty(ecKey.kty)
+            .setUse(ecKey.use)
+            .setKid(ecKey.kid)
+            .setAlg(ecKey.alg)
+            .setD(ecKey.d)
+            .setCrv(ecKey.crv)
+            .setX(ecKey.x)
+            .setY(ecKey.y)
+            .build()
+
+        // Then
+        assertEquals(ecKey, result)
+    }
+
+    @Test
+    fun shouldBuildEd25519Key() = runTest {
+        // Given
+        val ed25519Key = randomEd25519Key()
+
+        // When
+        val result = Platform.Ed25519Key.Builder()
+            .setKty(ed25519Key.kty)
+            .setUse(ed25519Key.use)
+            .setKid(ed25519Key.kid)
+            .setAlg(ed25519Key.alg)
+            .setD(ed25519Key.d)
+            .setCrv(ed25519Key.crv)
+            .setX(ed25519Key.x)
+            .build()
+
+        // Then
+        assertEquals(ed25519Key, result)
+    }
+}


### PR DESCRIPTION
So I have added those class builders to solve the issue with the default parameters in Swift and JS. On Android and JVM, we can still create the classes in the standard way.

Before (Swif example):
```swift
let baseOperation = LockOperations.BaseOperation(userId: nil,
                                                 userCertificateChain: nil,
                                                 userPrivateKey: nil,
                                                 lockId: lockId,
                                                 notBefore: now,
                                                 issuedAt: now,
                                                 expiresAt: expires,
                                                 jti: UUID().uuidString)
let unlockOperation = LockOperations.UnlockOperation(baseOperation: baseOperation, directAccessEndpoints: nil)
try await sdk.lockOperations().unlock(unlockOperation: unlockOperation)
```` 

After:
```swift
let baseOperation = LockOperations.BaseOperation.Build().setLockId(lockId: lockId).build()
let unlockOperation = LockOperations.UnlockOperation.Build().setBaseOperation(baseOperation: baseOperation).build()
try await sdk.lockOperations().unlock(unlockOperation: unlockOperation)
```