### PR TITLE
username & password fields from net2 controller should be nullable

### DIFF
--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/data/Fusion.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/data/Fusion.kt
@@ -109,8 +109,8 @@ object Fusion {
     @SerialName("net2")
     data class PaxtonNet2Controller(
         val host: String,
-        val username: String,
-        val password: String,
+        val username: String? = null,
+        val password: String? = null,
         val address: String,
         val output: Short
     ) : LockController

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Fusion.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Fusion.cs
@@ -110,8 +110,8 @@ public class MitrefinchController : LockController
 public class PaxtonNet2Controller : LockController
 {
     public string Host { get; set; } = string.Empty;
-    public string Username { get; set; } = string.Empty;
-    public string Password { get; set; } = string.Empty;
+    public string? Username { get; set; } = null;
+    public string? Password { get; set; } = null;
     public string Address { get; set; } = string.Empty;
     public short Output { get; set; } = 0;
 }

--- a/doordeck-sdk/src/mingwMain/resources/python/model/data/fusion.i
+++ b/doordeck-sdk/src/mingwMain/resources/python/model/data/fusion.i
@@ -121,8 +121,8 @@ class MitrefinchController(LockController):
 class PaxtonNet2Controller(LockController):
     type: str = field(init=False)
     host: str
-    username: str
-    password: str
+    username: Optional[str] = None
+    password: Optional[str] = None
     address: str
     output: int
 


### PR DESCRIPTION
Right now the test from net2 controller is always failing because there are 11 integrations without username & password.

https://github.com/doordeck/doordeck-headless-sdk/actions/runs/14266858810/job/39990644093

`FusionClientTest[jvm] > shouldTestNet2[jvm] STANDARD_OUT
    Failed to test net2: Illegal input: Fields [username, password] are required for type with serial name 'net2', but they were missing at path: $[2].integration.key
`