### PR TITLE
Assisted login logic update

### DIFF
--- a/docs/04_INITIALIZE.md
+++ b/docs/04_INITIALIZE.md
@@ -30,7 +30,7 @@ By default, the SDK stores the context information on its own, as shown in the f
 | Windows  | `Memory`                     |
 
 > [!NOTE]
-> To override the default secure storage, you must implement the `SecureStorage` interface and pass the class through the `setSecureStorageOverride` function from `SdkConfig`.
+> To override the default secure storage, you must implement the `SecureStorage` interface and pass the class through the `setSecureStorageOverride` function from `SdkConfig` builder.
 
 ## Initialize
 

--- a/docs/06_CONTEXT-MANAGER.md
+++ b/docs/06_CONTEXT-MANAGER.md
@@ -485,7 +485,7 @@ token = sdk.contextManager.get_fusion_auth_token()
 
 ## Clear context
 
-This function removes all stored context fields from the system but does not clear them from memory.
+This function removes all stored context fields from the secure storage.
 
 ### JVM & Android
 <details>

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/clients/AccountClient.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/clients/AccountClient.kt
@@ -72,6 +72,7 @@ internal object AccountClient {
         }.body<RegisterEphemeralKeyResponse>().also {
             ContextManagerImpl.setUserId(it.userId)
             ContextManagerImpl.setCertificateChain(it.certificateChain)
+            ContextManagerImpl.setKeyPairVerified(true)
         }
     }
 
@@ -107,6 +108,7 @@ internal object AccountClient {
         }.body<RegisterEphemeralKeyResponse>().also {
             ContextManagerImpl.setUserId(it.userId)
             ContextManagerImpl.setCertificateChain(it.certificateChain)
+            ContextManagerImpl.setKeyPairVerified(true)
         }
     }
 

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManager.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManager.kt
@@ -132,12 +132,12 @@ interface ContextManager {
     fun getKeyPair(): Crypto.KeyPair?
 
     /**
-     * Sets the key pair verification status
+     * Sets the key pair verification status, the provided values will be automatically stored in secure storage.
      */
     fun setKeyPairVerified(verified: Boolean)
 
     /**
-     * Retrieves the key pair verification status
+     * Retrieves the key pair verification status.
      */
     @CName("isKeyPairVerified")
     fun isKeyPairVerified(): Boolean

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManager.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManager.kt
@@ -132,6 +132,17 @@ interface ContextManager {
     fun getKeyPair(): Crypto.KeyPair?
 
     /**
+     * Sets the key pair verification status
+     */
+    fun setKeyPairVerified(verified: Boolean)
+
+    /**
+     * Retrieves the key pair verification status
+     */
+    @CName("isKeyPairVerified")
+    fun isKeyPairVerified(): Boolean
+
+    /**
      * Checks whether the current key pair is not null and valid by signing a small piece of text and verifying it.
      */
     @CName("isKeyPairValid")

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerImpl.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerImpl.kt
@@ -110,6 +110,14 @@ internal object ContextManagerImpl : ContextManager {
         } else null
     }
 
+    override fun setKeyPairVerified(verified: Boolean) {
+        secureStorage.setKeyPairVerified(verified)
+    }
+
+    override fun isKeyPairVerified(): Boolean {
+        return secureStorage.getKeyPairVerified() ?: false
+    }
+
     internal fun getPublicKey(): ByteArray? {
         return secureStorage.getPublicKey()
     }

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/HelperResponses.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/HelperResponses.kt
@@ -6,11 +6,13 @@ import kotlin.js.JsExport
 @JsExport
 @Serializable
 data class AssistedLoginResponse(
-    val requiresVerification: Boolean
+    val requiresVerification: Boolean,
+    val requiresRetry: Boolean
 )
 
 @JsExport
 @Serializable
 data class AssistedRegisterEphemeralKeyResponse(
-    val requiresVerification: Boolean
+    val requiresVerification: Boolean,
+    val requiresRetry: Boolean
 )

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/DefaultSecureStorage.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/DefaultSecureStorage.kt
@@ -19,6 +19,7 @@ internal class DefaultSecureStorage(private val settings: Settings) : SecureStor
     private val FUSION_AUTH_TOKEN_KEY = "FUSION_AUTH_TOKEN_KEY"
     private val PUBLIC_KEY_KEY = "PUBLIC_KEY_KEY"
     private val PRIVATE_KEY_KEY = "PRIVATE_KEY_KEY"
+    private val KEY_PAIR_VERIFIED = "KEY_PAIR_VERIFIED"
     private val USER_ID_KEY = "USER_ID_KEY"
     private val USER_EMAIL_KEY = "USER_EMAIL_KEY"
     private val CERTIFICATE_CHAIN_KEY = "CERTIFICATE_CHAIN_KEY"
@@ -77,6 +78,14 @@ internal class DefaultSecureStorage(private val settings: Settings) : SecureStor
 
     override fun getPrivateKey(): ByteArray? {
         return settings.getStringOrNull(PRIVATE_KEY_KEY)?.decodeBase64ToByteArray()
+    }
+
+    override fun setKeyPairVerified(verified: Boolean) {
+        settings.putBoolean(KEY_PAIR_VERIFIED, verified)
+    }
+
+    override fun getKeyPairVerified(): Boolean? {
+        return settings.getBooleanOrNull(KEY_PAIR_VERIFIED)
     }
 
     override fun addUserId(userId: String) {

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.kt
@@ -94,6 +94,18 @@ interface SecureStorage {
     fun getPrivateKey(): ByteArray?
 
     /**
+     * Stores the key pair verification status.
+     * @param verified The key pair verification status
+     */
+    fun setKeyPairVerified(verified: Boolean)
+
+    /**
+     * Retrieves the key pair verification status
+     * @return The stored key pair verification status a boolean, or null if not found.
+     */
+    fun getKeyPairVerified(): Boolean?
+
+    /**
      * Stores the user ID.
      * @param userId The user ID to be stored.
      */

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
@@ -575,9 +575,9 @@ fun randomSdkConfig(): SdkConfig = SdkConfig(
 /**
  * Test utils
  */
-private fun randomInt(min: Int = 0, max: Int = Int.MAX_VALUE) = Random.nextInt(min, max)
-private fun randomDouble(from: Double = 0.0, to: Double = 100.0): Double = Random.nextDouble(from, to)
-private fun randomBoolean(): Boolean = Random.nextBoolean()
-private inline fun <T> randomNullable(supplier: () -> T): T? = if (randomBoolean()) supplier() else null
-private fun randomString(): String = Uuid.random().toString()
-private fun randomByteArray(): ByteArray = Random.nextBytes(ByteArray(randomInt(1, 20)))
+internal fun randomInt(min: Int = 0, max: Int = Int.MAX_VALUE) = Random.nextInt(min, max)
+internal fun randomDouble(from: Double = 0.0, to: Double = 100.0): Double = Random.nextDouble(from, to)
+internal fun randomBoolean(): Boolean = Random.nextBoolean()
+internal inline fun <T> randomNullable(supplier: () -> T): T? = if (randomBoolean()) supplier() else null
+internal fun randomString(): String = Uuid.random().toString()
+internal fun randomByteArray(): ByteArray = Random.nextBytes(ByteArray(randomInt(1, 20)))

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerTest.kt
@@ -4,6 +4,7 @@ import com.doordeck.multiplatform.sdk.IntegrationTest
 import com.doordeck.multiplatform.sdk.crypto.CryptoManager
 import com.doordeck.multiplatform.sdk.model.data.ApiEnvironment
 import com.doordeck.multiplatform.sdk.model.data.Context
+import com.doordeck.multiplatform.sdk.randomBoolean
 import com.doordeck.multiplatform.sdk.storage.DefaultSecureStorage
 import com.doordeck.multiplatform.sdk.storage.MemorySettings
 import com.doordeck.multiplatform.sdk.util.Utils.certificateChainToString
@@ -32,16 +33,20 @@ class ContextManagerTest : IntegrationTest() {
         val certificateChain = (1..3).map { Uuid.random().toString() }
         val publicKey = Uuid.random().toString().encodeToByteArray()
         val privateKey = Uuid.random().toString().encodeToByteArray()
+        val keyPairVerified = randomBoolean()
         val settings = DefaultSecureStorage(MemorySettings())
-        ContextManagerImpl.setSecureStorageImpl(settings)
-        ContextManagerImpl.setApiEnvironment(apiEnvironment)
-        ContextManagerImpl.setCloudAuthToken(cloudAuthToken)
-        ContextManagerImpl.setCloudRefreshToken(cloudRefreshToken)
-        ContextManagerImpl.setFusionAuthToken(fusionAuthToken)
-        ContextManagerImpl.setUserId(userId)
-        ContextManagerImpl.setCertificateChain(certificateChain)
-        ContextManagerImpl.setKeyPair(publicKey, privateKey)
-        ContextManagerImpl.setUserEmail(email)
+        ContextManagerImpl.apply {
+            setSecureStorageImpl(settings)
+            setApiEnvironment(apiEnvironment)
+            setCloudAuthToken(cloudAuthToken)
+            setCloudRefreshToken(cloudRefreshToken)
+            setFusionAuthToken(fusionAuthToken)
+            setUserId(userId)
+            setCertificateChain(certificateChain)
+            setKeyPair(publicKey, privateKey)
+            setKeyPairVerified(keyPairVerified)
+            setUserEmail(email)
+        }
 
         // When
         ContextManagerImpl.setSecureStorageImpl(DefaultSecureStorage(MemorySettings())) // Override the storage so that it is not deleted upon a reset call
@@ -57,6 +62,7 @@ class ContextManagerTest : IntegrationTest() {
         assertContentEquals(privateKey, ContextManagerImpl.getPrivateKey())
         assertContentEquals(publicKey, ContextManagerImpl.getKeyPair()?.public)
         assertContentEquals(privateKey, ContextManagerImpl.getKeyPair()?.private)
+        assertEquals(keyPairVerified, ContextManagerImpl.isKeyPairVerified())
         assertEquals(cloudAuthToken, ContextManagerImpl.getCloudAuthToken())
         assertEquals(cloudRefreshToken, ContextManagerImpl.getCloudRefreshToken())
         assertEquals(fusionAuthToken, ContextManagerImpl.getFusionAuthToken())
@@ -74,14 +80,18 @@ class ContextManagerTest : IntegrationTest() {
         val certificateChain = (1..3).map { Uuid.random().toString() }
         val publicKey = Uuid.random().toString().encodeToByteArray()
         val privateKey = Uuid.random().toString().encodeToByteArray()
-        ContextManagerImpl.setApiEnvironment(apiEnvironment)
-        ContextManagerImpl.setCloudAuthToken(cloudAuthToken)
-        ContextManagerImpl.setCloudRefreshToken(cloudRefreshToken)
-        ContextManagerImpl.setFusionAuthToken(fusionAuthToken)
-        ContextManagerImpl.setUserId(userId)
-        ContextManagerImpl.setCertificateChain(certificateChain)
-        ContextManagerImpl.setKeyPair(publicKey, privateKey)
-        ContextManagerImpl.setUserEmail(email)
+        val keyPairVerified = randomBoolean()
+        ContextManagerImpl.apply {
+            setApiEnvironment(apiEnvironment)
+            setCloudAuthToken(cloudAuthToken)
+            setCloudRefreshToken(cloudRefreshToken)
+            setFusionAuthToken(fusionAuthToken)
+            setUserId(userId)
+            setCertificateChain(certificateChain)
+            setKeyPair(publicKey, privateKey)
+            setKeyPairVerified(keyPairVerified)
+            setUserEmail(email)
+        }
 
         // When
         ContextManagerImpl.clearContext()
@@ -95,6 +105,7 @@ class ContextManagerTest : IntegrationTest() {
         assertNull(ContextManagerImpl.getPublicKey())
         assertNull(ContextManagerImpl.getPrivateKey())
         assertNull(ContextManagerImpl.getKeyPair())
+        assertFalse { ContextManagerImpl.isKeyPairVerified() }
         assertNull(ContextManagerImpl.getCloudAuthToken())
         assertNull(ContextManagerImpl.getCloudRefreshToken())
         assertNull(ContextManagerImpl.getFusionAuthToken())


### PR DESCRIPTION
Currently, the assisted login does not attempt to register a new key if an existing key is present in the context. This causes a problem because the key is added to the context before being verified by the backend (via the register key endpoint). With this PR, we will track whether the existing key has been verified or not. If it hasn't been verified, the assisted login will attempt to register the key again.