### PR TITLE
Fusion client response validator

### DIFF
--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/Platform.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/Platform.kt
@@ -56,6 +56,7 @@ internal fun createFusionHttpClient(): HttpClient {
         installContentNegotiation()
         installTimeout()
         installUserAgent()
+        installResponseValidator()
         installDefaultRequest(determineHost = {
             ContextManagerImpl.getFusionHost()
         })


### PR DESCRIPTION
It looks like the exceptions from the Fusion endpoints are all mapped to internal server errors, so we can use the existing response validator from the cloud client.