### PR TITLE
Location requirement response update

### DIFF
--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperations.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperations.kt
@@ -41,20 +41,20 @@ object LockOperations {
     data class LocationRequirement @JvmOverloads constructor(
         val latitude: Double,
         val longitude: Double,
-        val enabled: Boolean? = null,
-        val radius: Int = 20,
-        val accuracy: Int = 20
+        val enabled: Boolean = false,
+        val radius: Int = 100,
+        val accuracy: Int = 200
     ) {
         class Builder {
             private var latitude: Double? = null
             private var longitude: Double? = null
-            private var enabled: Boolean? = null
-            private var radius: Int = 20
-            private var accuracy: Int = 20
+            private var enabled: Boolean = false
+            private var radius: Int = 100
+            private var accuracy: Int = 200
 
             fun setLatitude(latitude: Double): Builder = apply { this.latitude = latitude }
             fun setLongitude(longitude: Double): Builder = apply { this.longitude = longitude }
-            fun setEnabled(enabled: Boolean?): Builder = apply { this.enabled = enabled }
+            fun setEnabled(enabled: Boolean): Builder = apply { this.enabled = enabled }
             fun setRadius(radius: Int): Builder = apply { this.radius = radius }
             fun setAccuracy(accuracy: Int): Builder = apply { this.accuracy = accuracy }
 

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperations.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperations.kt
@@ -42,21 +42,21 @@ object LockOperations {
         val latitude: Double,
         val longitude: Double,
         val enabled: Boolean? = null,
-        val radius: Int? = null,
-        val accuracy: Int? = null
+        val radius: Int = 20,
+        val accuracy: Int = 20
     ) {
         class Builder {
             private var latitude: Double? = null
             private var longitude: Double? = null
             private var enabled: Boolean? = null
-            private var radius: Int? = null
-            private var accuracy: Int? = null
+            private var radius: Int = 20
+            private var accuracy: Int = 20
 
             fun setLatitude(latitude: Double): Builder = apply { this.latitude = latitude }
             fun setLongitude(longitude: Double): Builder = apply { this.longitude = longitude }
             fun setEnabled(enabled: Boolean?): Builder = apply { this.enabled = enabled }
-            fun setRadius(radius: Int?): Builder = apply { this.radius = radius }
-            fun setAccuracy(accuracy: Int?): Builder = apply { this.accuracy = accuracy }
+            fun setRadius(radius: Int): Builder = apply { this.radius = radius }
+            fun setAccuracy(accuracy: Int): Builder = apply { this.accuracy = accuracy }
 
             fun build(): LocationRequirement {
                 return LocationRequirement(

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/requests/LockOperationRequests.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/requests/LockOperationRequests.kt
@@ -169,7 +169,7 @@ internal data class TimeRequirementRequest(
 internal data class LocationRequirementRequest(
     val latitude: Double,
     val longitude: Double,
-    val enabled: Boolean? = null,
+    val enabled: Boolean,
     val radius: Int,
     val accuracy: Int
 )

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/requests/LockOperationRequests.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/requests/LockOperationRequests.kt
@@ -170,6 +170,6 @@ internal data class LocationRequirementRequest(
     val latitude: Double,
     val longitude: Double,
     val enabled: Boolean? = null,
-    val radius: Int? = null,
-    val accuracy: Int? = null
+    val radius: Int,
+    val accuracy: Int
 )

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/LockOperationResponses.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/LockOperationResponses.kt
@@ -58,8 +58,8 @@ data class LocationRequirementResponse(
     val latitude: Double,
     val longitude: Double,
     val enabled: Boolean? = null,
-    val radius: Int? = null,
-    val accuracy: Int? = null
+    val radius: Int,
+    val accuracy: Int
 )
 
 @JsExport

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/LockOperationResponses.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/LockOperationResponses.kt
@@ -57,7 +57,7 @@ data class TimeRequirementResponse(
 data class LocationRequirementResponse(
     val latitude: Double,
     val longitude: Double,
-    val enabled: Boolean? = null,
+    val enabled: Boolean,
     val radius: Int,
     val accuracy: Int
 )

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
@@ -434,7 +434,7 @@ internal fun randomTimeRequirement(): LockOperations.TimeRequirement = LockOpera
 internal fun randomLocationRequirement(): LockOperations.LocationRequirement = LockOperations.LocationRequirement(
     latitude = randomDouble(),
     longitude = randomDouble(),
-    enabled = randomNullable { randomBoolean() },
+    enabled = randomBoolean(),
     radius = randomInt(),
     accuracy = randomInt()
 )

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
@@ -435,8 +435,8 @@ internal fun randomLocationRequirement(): LockOperations.LocationRequirement = L
     latitude = randomDouble(),
     longitude = randomDouble(),
     enabled = randomNullable { randomBoolean() },
-    radius = randomNullable { randomInt() },
-    accuracy = randomNullable { randomInt() }
+    radius = randomInt(),
+    accuracy = randomInt()
 )
 
 internal fun randomUnlockBetween(): LockOperations.UnlockBetween = LockOperations.UnlockBetween(

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
@@ -174,7 +174,7 @@ internal fun randomTimeRequirementResponse(): TimeRequirementResponse = TimeRequ
 internal fun randomLocationRequirementResponse(): LocationRequirementResponse = LocationRequirementResponse(
     latitude = randomDouble(),
     longitude = randomDouble(),
-    enabled = randomNullable { randomBoolean() },
+    enabled = randomBoolean(),
     radius = randomInt(),
     accuracy = randomInt()
 )

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.kt
@@ -175,8 +175,8 @@ internal fun randomLocationRequirementResponse(): LocationRequirementResponse = 
     latitude = randomDouble(),
     longitude = randomDouble(),
     enabled = randomNullable { randomBoolean() },
-    radius = randomNullable { randomInt() },
-    accuracy = randomNullable { randomInt() }
+    radius = randomInt(),
+    accuracy = randomInt()
 )
 
 internal fun randomShareableLockResponse(): ShareableLockResponse = ShareableLockResponse(

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperationsData.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperationsData.mingw.kt
@@ -99,7 +99,7 @@ data class UpdateLockSettingLocationRestrictionsData(
 data class LocationRequirementData(
     val latitude: Double,
     val longitude: Double,
-    val enabled: Boolean? = null,
+    val enabled: Boolean,
     val radius: Int,
     val accuracy: Int
 )

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperationsData.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperationsData.mingw.kt
@@ -100,8 +100,8 @@ data class LocationRequirementData(
     val latitude: Double,
     val longitude: Double,
     val enabled: Boolean? = null,
-    val radius: Int? = null,
-    val accuracy: Int? = null
+    val radius: Int = 20,
+    val accuracy: Int = 20
 )
 
 @Serializable

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperationsData.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperationsData.mingw.kt
@@ -100,8 +100,8 @@ data class LocationRequirementData(
     val latitude: Double,
     val longitude: Double,
     val enabled: Boolean? = null,
-    val radius: Int = 20,
-    val accuracy: Int = 20
+    val radius: Int,
+    val accuracy: Int
 )
 
 @Serializable

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/LockOperations.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/LockOperations.cs
@@ -12,14 +12,14 @@ public class LocationRequirement(
     double latitude,
     double longitude,
     bool? enabled = null,
-    int? radius = null,
-    int? accuracy = null)
+    int radius = 20,
+    int accuracy = 20)
 {
     public double Latitude { get; set; } = latitude;
     public double Longitude { get; set; } = longitude;
     public bool? Enabled { get; set; } = enabled;
-    public int? Radius { get; set; } = radius;
-    public int? Accuracy { get; set; } = accuracy;
+    public int Radius { get; set; } = radius;
+    public int Accuracy { get; set; } = accuracy;
 }
 
 public class UnlockOperation(BaseOperation baseOperation, List<string>? directAccessEndpoints = null)

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/LockOperations.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/LockOperations.cs
@@ -11,13 +11,13 @@ public class TimeRequirement(string start, string end, string timezone, List<str
 public class LocationRequirement(
     double latitude,
     double longitude,
-    bool? enabled = null,
-    int radius = 20,
-    int accuracy = 20)
+    bool enabled = false,
+    int radius = 100,
+    int accuracy = 200)
 {
     public double Latitude { get; set; } = latitude;
     public double Longitude { get; set; } = longitude;
-    public bool? Enabled { get; set; } = enabled;
+    public bool Enabled { get; set; } = enabled;
     public int Radius { get; set; } = radius;
     public int Accuracy { get; set; } = accuracy;
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/LockOperationResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/LockOperationResponses.cs
@@ -46,8 +46,8 @@ public class LocationRequirementResponse
     public double Latitude { get; set; }
     public double Longitude { get; set; }
     public bool? Enabled { get; set; } = null;
-    public int? Radius { get; set; } = null;
-    public int? Accuracy { get; set; } = null;
+    public int Radius { get; set; };
+    public int Accuracy { get; set; };
 }
 
 public class UnlockBetweenSettingResponse

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/LockOperationResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/LockOperationResponses.cs
@@ -45,7 +45,7 @@ public class LocationRequirementResponse
 {
     public double Latitude { get; set; }
     public double Longitude { get; set; }
-    public bool? Enabled { get; set; } = null;
+    public bool Enabled { get; set; };
     public int Radius { get; set; };
     public int Accuracy { get; set; };
 }

--- a/doordeck-sdk/src/mingwMain/resources/python/model/data/lock_operations.i
+++ b/doordeck-sdk/src/mingwMain/resources/python/model/data/lock_operations.i
@@ -12,8 +12,8 @@ class LocationRequirement:
     latitude: float
     longitude: float
     enabled: typing.Optional[bool] = None
-    radius: typing.Optional[int] = None
-    accuracy: typing.Optional[int] = None
+    radius: int = 20
+    accuracy: int = 20
 
 @dataclass
 class ShareLock:

--- a/doordeck-sdk/src/mingwMain/resources/python/model/data/lock_operations.i
+++ b/doordeck-sdk/src/mingwMain/resources/python/model/data/lock_operations.i
@@ -11,9 +11,9 @@ class TimeRequirement:
 class LocationRequirement:
     latitude: float
     longitude: float
-    enabled: typing.Optional[bool] = None
-    radius: int = 20
-    accuracy: int = 20
+    enabled: bool = False
+    radius: int = 100
+    accuracy: int = 200
 
 @dataclass
 class ShareLock:


### PR DESCRIPTION
This PR updates the Location requirement's request and response as follows:

Request:
* `radius` and `accuracy` fields cannot be null (I confirmed the request fails if they are). Additionally, I set the default value for both fields to 20.

Response:
* `enabled`, `radius` and `accuracy` cannot be null.