### PR TITLE
Certificate chain test

### DIFF
--- a/doordeck-sdk/build.gradle.kts
+++ b/doordeck-sdk/build.gradle.kts
@@ -183,6 +183,7 @@ kotlin {
                 implementation(libs.ktor.client.encoding)
                 implementation(libs.kotlinx.datetime)
                 implementation(libs.multiplatform.settings)
+                implementation(libs.indispensable.asn1)
             }
         }
 

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/util/CertificateUtils.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/util/CertificateUtils.kt
@@ -11,9 +11,9 @@ internal fun String.isCertificateAboutToExpire(): Boolean {
     return try {
         // Retrieve the 'Not After' element
         val notAfterElement = Asn1Element.parse(decodeBase64ToByteArray())
-            .asSequence().children.elementAtOrNull(0)?.asSequence()
-            ?.children?.elementAtOrNull(4)?.asSequence()    // Validity
-            ?.children?.elementAtOrNull(1)  // Not after
+            .asSequence().children.elementAtOrNull(0)?.asSequence() // Tabs
+            ?.children?.elementAtOrNull(4)?.asSequence() // Validity
+            ?.children?.elementAtOrNull(1) // Not after
         if (notAfterElement == null) {
             return true
         }

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/util/CertificateUtils.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/util/CertificateUtils.kt
@@ -1,66 +1,26 @@
 package com.doordeck.multiplatform.sdk.util
 
+import at.asitplus.signum.indispensable.asn1.Asn1Element
+import at.asitplus.signum.indispensable.asn1.Asn1Time
+import at.asitplus.signum.indispensable.asn1.encoding.parse
 import com.doordeck.multiplatform.sdk.crypto.MIN_CERTIFICATE_LIFETIME_DAYS
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
 import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toInstant
 
-internal fun String.isCertificateAboutToExpire(): Boolean = try {
-    val notAfter = extractNotAfter(decodeBase64ToByteArray())
-    val notAfterInstant = parseNotAfter(notAfter.decodeToString())
-    Clock.System.now() >= notAfterInstant - MIN_CERTIFICATE_LIFETIME_DAYS
-} catch (exception: Exception) {
-    true
-}
-
-private fun extractNotAfter(certificate: ByteArray): ByteArray {
-    // ASN.1 tag for UTC time (0x17) is used to identify time-related fields in X.509 certificates.
-    val notBeforeTag = byteArrayOf(0x17) // 0x17 represents the ASN.1 tag for UTC time.
-
-    // Find the index where the "Not Before" field starts in the certificate.
-    // The certificate is a sequence of bytes, and we're looking for a match to the "Not Before" tag.
-    val index = certificate.indices.first {
-        // Check if the tag at the current index matches the "Not Before" tag.
-        it <= certificate.size - notBeforeTag.size &&
-                certificate.copyOfRange(it, it + notBeforeTag.size).contentEquals(notBeforeTag)
+internal fun String.isCertificateAboutToExpire(): Boolean {
+    return try {
+        // Retrieve the 'Not After' element
+        val notAfterElement = Asn1Element.parse(decodeBase64ToByteArray())
+            .asSequence().children.elementAtOrNull(0)?.asSequence()
+            ?.children?.elementAtOrNull(4)?.asSequence()    // Validity
+            ?.children?.elementAtOrNull(1)  // Not after
+        if (notAfterElement == null) {
+            return true
+        }
+        val notAfterInstant = Asn1Time.decodeFromDer(notAfterElement.derEncoded)
+            .instant
+        return Clock.System.now() >= notAfterInstant - MIN_CERTIFICATE_LIFETIME_DAYS
+    } catch (exception: Throwable) {
+        true
     }
-
-    // The byte after the "Not Before" tag contains the length of the "Not Before" field in the certificate.
-    // The length byte is located at index + 1.
-    val notBeforeLength = certificate[index + 1].toInt()
-
-    // The "Not Before" field ends at index + 2 + notBeforeLength.
-    val notBeforeEndIndex = index + 2 + notBeforeLength
-
-    // Now, we are looking for the "Not After" field which comes immediately after the "Not Before" field.
-    // We search for the "Not After" tag, which is the same as the "Not Before" tag (0x17) for UTC time.
-    val notAfterTag = byteArrayOf(0x17) // Same ASN.1 tag (0x17) for UTC time, indicating "Not After".
-
-    // Search within the remaining portion of the certificate, starting from the end of the "Not Before" field.
-    val notAfterIndex = (notBeforeEndIndex until certificate.size).first {
-        // Look for the "Not After" tag in the current range of the certificate bytes.
-        certificate.slice(it until it + notAfterTag.size).toByteArray().contentEquals(notAfterTag)
-    }
-
-    // The byte after the "Not After" tag contains the length of the "Not After" field.
-    // The length byte is located at notAfterIndex + 1.
-    val notAfterLength = certificate[notAfterIndex + 1].toInt()
-
-    // Extract and return the "Not After" field using the length information.
-    // The "Not After" field starts at notAfterIndex + 2 and ends at notAfterIndex + 2 + notAfterLength.
-    return certificate.copyOfRange(notAfterIndex + 2, notAfterIndex + 2 + notAfterLength)
-}
-
-private fun parseNotAfter(timeString: String): Instant {
-    val year = 2000 + timeString.substring(0, 2).toInt()
-    val month = timeString.substring(2, 4).toInt()
-    val day = timeString.substring(4, 6).toInt()
-    val hour = timeString.substring(6, 8).toInt()
-    val minute = timeString.substring(8, 10).toInt()
-    val second = timeString.substring(10, 12).toInt()
-    val localDateTime = LocalDateTime(year, month, day, hour, minute, second)
-    return localDateTime.toInstant(TimeZone.UTC)
 }

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/clients/AccountClientTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/clients/AccountClientTest.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -55,6 +57,8 @@ class AccountClientTest : IntegrationTest() {
         // Then
         assertTrue { result.certificateChain.isNotEmpty() }
         assertEquals(TEST_MAIN_USER_ID, result.userId)
+        assertNotNull(ContextManagerImpl.getCertificateChain())
+        assertFalse { ContextManagerImpl.isCertificateChainAboutToExpire() }
     }
 
     @Test

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/util/CertificateUtilsTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/util/CertificateUtilsTest.kt
@@ -2,26 +2,14 @@ package com.doordeck.multiplatform.sdk.util
 
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class CertificateUtilsTest {
     @Test
-    fun shouldVerifyExpireDateFuture() = runTest {
-        // Given
-        val certificate = "MIIDADCCAeigAwIBAgIGAZOS7Z/dMA0GCSqGSIb3DQEBCwUAMEExDjAMBgNVBAMMBXRlc3RzMQswCQYDVQQGEwJVUzEiMCAGCSqGSIb3DQEJARYTYmVybmF0QGRvb3JkZWNrLmNvbTAeFw0yNDEyMDQxODI3NDZaFw00NDExMjkxODI3NDZaMEExDjAMBgNVBAMMBXRlc3RzMQswCQYDVQQGEwJVUzEiMCAGCSqGSIb3DQEJARYTYmVybmF0QGRvb3JkZWNrLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKVUdDhA08HC4GycerNe2PdHre6tZfviddT3L9vGalTVjBl+5VBfsKieg8tgfYANh1tfDEBzIfRkm2/AQ8hUK+0f8oAzo/utgM9r9LR1oadU6WTX8UiEpkzBVjpazh05dMDZhZyNRpfWLgGcqQ/rzMkHAeD3XG2FcYvy35HFnMMtPcSVhYWwKaeoBB0fiiGaYdkJz2YiZN35jPMCB83uBgxiaPkTfK47S9pZz89tztvMGq9oXewOS2rxIljECcGEB3kQlWRWOVvw5nZIKzv2TxPoXWZKBfRcL/nTgURaiCACD3m+rNYHzkWgdXUo4ICA9WB7wzFkPdjv0oyl65r9SQcCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAlVSckJ68fF1l70TvUrMUUMooD64q3dX3rEsoKcQg6vY9gwzKNUAjIh0wTllF1RmtNux9NUm0wEhWqT6f3EpQAnYTFxhmF3nyop7O2ybFDXmW6lCppVKTMQuacgPMZwEZbaPNEeznCZloGnoJw7WFdLm3sC0+KGagEn96kaYe/ZzxE8iA1Jj0OZu+4UggkmdQ0LqWHnWiSvqNzlC806kVrg47E6RmmTh/gMCykbEHTGX3cyAiT0VGjDkvMdvINEx2dwHDCFh9Szm3raC4a0g0S+EknATwUIrZhuIhOch0aXH+m/Oove286mr27tesqN6ZEw6j5hKO5Jj7KnS9Hon7BA=="
-
-        // When
-        val result = certificate.isCertificateAboutToExpire()
-
-        // Then
-        assertFalse { result }
-    }
-
-    @Test
     fun shouldVerifyExpireDateExpired() = runTest {
         // Given
+        // 2024-12-05T18:30:26Z
         val certificate = "MIIDADCCAeigAwIBAgIGAZOS8A/NMA0GCSqGSIb3DQEBCwUAMEExDjAMBgNVBAMMBXRlc3RzMQswCQYDVQQGEwJVUzEiMCAGCSqGSIb3DQEJARYTYmVybmF0QGRvb3JkZWNrLmNvbTAeFw0yNDEyMDQxODMwMjZaFw0yNDEyMDUxODMwMjZaMEExDjAMBgNVBAMMBXRlc3RzMQswCQYDVQQGEwJVUzEiMCAGCSqGSIb3DQEJARYTYmVybmF0QGRvb3JkZWNrLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMIdLEAhDBz8cpqN9I8KNpVrdHmcobNqmHxpN36KmJ7G5K5i7Uv3SPKfrLw2zvf15+VPkvxDIeciegRkEfW5p0rjJy0ecKudi7kSmQYxKs8m/PMYmT/0qHpx+I9i3Uz/Wln7mvFIvQi+855USMgh37N6kruBO1bBDCSpM/yS0WC3szdmTG4QHxFRqlDkzGuLDhT+thM1mzhRhwTuL/+B9C3Z4SP/wd+lWQXeOtwRIZgjUrLbczwdVUeIR5tG4bV46y2OSMvwTrFVa87ZkcBpOzkVXsK4oMpujYJsoMJyOcRPjdFfpZC2B6tcQhI5p31/SrWPE6Y8M1/ctgqkks/80ykCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAlID39SmMzMMwpUHpDLAspsIXXG6z9AxPSGWY5h8vgaMukUSPZ8rKHbTBU29UrIOw3vzcapn06dDlQtaWLiatjHM3RK6JxMEciggWTr5G3EkM0FV4IBVVJXFyED9HW9wW9MZjijVN5LC+5yV50qZifUt/LwCyS6QZJ/mry2WQ/LZeNmt5VjPKAnP8CrQHa/m4My0rbxglJkjm5Bsh4J+tOp7wDgUZQqyCD0iQ6tUBx+lfKW4wwJFO9EAXz73oH+DHXDT1gTwWaqVVonJBeRsgXfGf7bWe1h8iNBCnXYOMf4qJcwJYADYab1GnpAlscn++KSXJtwWoWXSOTet6DRtf9A=="
 
         // When
@@ -41,5 +29,31 @@ class CertificateUtilsTest {
 
         // Then
         assertTrue { result }
+    }
+
+    @Test
+    fun shouldVerifyGMTExpireDateFuture() = runTest {
+        // Given
+        // 2065-05-03T22:31:02Z
+        val certificate = "MIICXjCCAcegAwIBAgIBADANBgkqhkiG9w0BAQ0FADBLMQswCQYDVQQGEwJlczESMBAGA1UECAwJQ2F0YWxvbmlhMREwDwYDVQQKDAhEb29yZGVjazEVMBMGA1UEAwwMZG9vcmRlY2suY29tMCAXDTI1MDUxMzIyMzEwMloYDzIwNjUwNTAzMjIzMTAyWjBLMQswCQYDVQQGEwJlczESMBAGA1UECAwJQ2F0YWxvbmlhMREwDwYDVQQKDAhEb29yZGVjazEVMBMGA1UEAwwMZG9vcmRlY2suY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDcpf7qHCJMGawKXbohAQLwA8sdcWrEwvXrvHCbKVNDjl4tJTykgU7xSaxyTV32Wep3p6k6tCg3Mcj2lSueXvPAJ1lVa+OB5vVwH5aCsckl0Z5QxYH58jhw/kRJqT/UviqMKKT7D2rx9Moegs+R1cHW7HQTteYrlzjQGmJbSTNDGwIDAQABo1AwTjAdBgNVHQ4EFgQUxmzN4x0YaxHexnO1ymRELYjzFx8wHwYDVR0jBBgwFoAUxmzN4x0YaxHexnO1ymRELYjzFx8wDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOBgQB4mpU3qPUTMw0OVUp76fpx1Nkjfe66O/ywDEojO4LHj55NvO3jZ5aPlMTFw/lTraWO/8qYfA1mEJXaT8TFTUnoGCuZVwzvs6rdh1oHrV2WocLqND2nqD5tY2iBkZrZUnW52/TqafD65SiHVUXUfW/12iBlSAQwghA0jhEwCesMfw=="
+
+        // When
+        val result = certificate.isCertificateAboutToExpire()
+
+        // Then
+        assertFalse { result }
+    }
+
+    @Test
+    fun shouldVerifyUTCExpireDateFuture() = runTest {
+        // Given
+        // 2028-05-12T22:37:48Z
+        val certificate = "MIICXDCCAcWgAwIBAgIBADANBgkqhkiG9w0BAQ0FADBLMQswCQYDVQQGEwJlczESMBAGA1UECAwJQ2F0YWxvbmlhMREwDwYDVQQKDAhEb29yZGVjazEVMBMGA1UEAwwMZG9vcmRlY2suY29tMB4XDTI1MDUxMzIyMzc0OFoXDTI4MDUxMjIyMzc0OFowSzELMAkGA1UEBhMCZXMxEjAQBgNVBAgMCUNhdGFsb25pYTERMA8GA1UECgwIRG9vcmRlY2sxFTATBgNVBAMMDGRvb3JkZWNrLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA30CdHL4m9jRN2ic2Pj5UHtWTaP89jP1BlIIyhvDb7c1bMXqJ04NYF8RQRP/LNuA34I7xJHO0MzGNhChuhu/SZpGT9XHj77iCh+WQyed6eyh+5h0qmToVIJbdLpb+z4dKERLR9NUp/zGn8G27fQmVU2JhRkRsnFtJUFFD6Z6O4IkCAwEAAaNQME4wHQYDVR0OBBYEFAw0TCqXK8ylRrW/uzLobHwiCGqUMB8GA1UdIwQYMBaAFAw0TCqXK8ylRrW/uzLobHwiCGqUMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQENBQADgYEAOrVU9zixzNfPG+6gHOFl0Ptmjj3jBud1BXW2B6uieBbnhRWcqp2WUv4EBMMNeGzLsai3XqDXrDWi5DCThtogWRsjrcdCwlUNKAfE/BQuC+WlsoWPwQix53keFazcaA3A6nozxwLeoLn1mfSGNjjLLCJC4/NLLemUKM6dCaSUM10="
+
+        // When
+        val result = certificate.isCertificateAboutToExpire()
+
+        // Then
+        assertFalse { result }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "8.5.2"
 bouncycastle = "1.80"
+indispensable-asn1 = "3.16.1"
 kotlin = "2.1.20"
 multiplatform-settings = "1.3.0"
 android-minSdk = "26"
@@ -17,6 +18,7 @@ pkijs = "3.2.5"
 
 [libraries]
 bouncycastle = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+indispensable-asn1 = { module = "at.asitplus.signum:indispensable-asn1", version.ref = "indispensable-asn1" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines-test" }


### PR DESCRIPTION
This solution can verify the expiration date of certificates when 'not after' is specified in UTC or GMT, whereas the previous solution failed to handle this.

This task is related to [this](https://github.com/doordeck/doordeck-headless-sdk/issues/111). I tried implementing a platform-specific solution for iOS but completely failed, so I ended up using a third-party library.