### PR TITLE
Removing the deprecated package inside the android manifest file

### DIFF
--- a/doordeck-sdk/src/androidMain/AndroidManifest.xml
+++ b/doordeck-sdk/src/androidMain/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.doordeck.multiplatform.sdk">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <application>
         <provider


### PR DESCRIPTION
The package definition inside the Android Manifest is deprecated; the [namespace](https://github.com/doordeck/doordeck-headless-sdk/blob/9a674560118eae252719a5fbac65e3eba9383012/doordeck-sdk/build.gradle.kts#L308) definition is used instead