### PR TITLE
Force dep versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,5 +24,7 @@ nexusPublishing {
 rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin> {
     rootProject.the<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension>().apply {
         resolution("cross-spawn", "7.0.6")
+        resolution("webpack-dev-server", "5.2.1")
+        resolution("brace-expansion", "2.0.2")
     }
 }


### PR DESCRIPTION
Should solve:
* https://github.com/doordeck/doordeck-headless-sdk/security/dependabot/29
* https://github.com/doordeck/doordeck-headless-sdk/security/dependabot/30
* https://github.com/doordeck/doordeck-headless-sdk/security/dependabot/33