### PR TITLE
Verify key pair

### DIFF
--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.android.kt
@@ -83,9 +83,10 @@ actual object AccountApi {
      */
     suspend fun verifyEphemeralKeyRegistration(
         code: String,
+        publicKey: ByteArray? = null,
         privateKey: ByteArray? = null
     ): RegisterEphemeralKeyResponse {
-        return AccountClient.verifyEphemeralKeyRegistrationRequest(code, privateKey)
+        return AccountClient.verifyEphemeralKeyRegistrationRequest(code, publicKey, privateKey)
     }
 
     /**
@@ -93,9 +94,10 @@ actual object AccountApi {
      */
     fun verifyEphemeralKeyRegistrationAsync(
         code: String,
+        publicKey: ByteArray? = null,
         privateKey: ByteArray? = null
     ): CompletableFuture<RegisterEphemeralKeyResponse> {
-        return completableFuture { verifyEphemeralKeyRegistration(code, privateKey) }
+        return completableFuture { verifyEphemeralKeyRegistration(code, publicKey, privateKey) }
     }
 
     /**

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.android.kt
@@ -47,15 +47,15 @@ actual object AccountApi {
     /**
      * @see AccountClient.registerEphemeralKeyRequest
      */
-    suspend fun registerEphemeralKey(publicKey: ByteArray? = null): RegisterEphemeralKeyResponse {
-        return AccountClient.registerEphemeralKeyRequest(publicKey)
+    suspend fun registerEphemeralKey(publicKey: ByteArray? = null, privateKey: ByteArray? = null): RegisterEphemeralKeyResponse {
+        return AccountClient.registerEphemeralKeyRequest(publicKey, privateKey)
     }
 
     /**
      * Async variant of [AccountApi.registerEphemeralKey] returning [CompletableFuture].
      */
-    fun registerEphemeralKeyAsync(publicKey: ByteArray? = null): CompletableFuture<RegisterEphemeralKeyResponse> {
-        return completableFuture { registerEphemeralKey(publicKey) }
+    fun registerEphemeralKeyAsync(publicKey: ByteArray? = null, privateKey: ByteArray? = null): CompletableFuture<RegisterEphemeralKeyResponse> {
+        return completableFuture { registerEphemeralKey(publicKey, privateKey) }
     }
 
     /**

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/api/HelperApi.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/api/HelperApi.android.kt
@@ -41,15 +41,15 @@ actual object HelperApi {
     /**
      * @see HelperClient.assistedRegisterEphemeralKeyRequest
      */
-    suspend fun assistedRegisterEphemeralKey(publicKey: ByteArray? = null): AssistedRegisterEphemeralKeyResponse {
-        return HelperClient.assistedRegisterEphemeralKeyRequest(publicKey)
+    suspend fun assistedRegisterEphemeralKey(publicKey: ByteArray? = null, privateKey: ByteArray? = null): AssistedRegisterEphemeralKeyResponse {
+        return HelperClient.assistedRegisterEphemeralKeyRequest(publicKey, privateKey)
     }
 
     /**
      * Async variant of [HelperApi.assistedRegisterEphemeralKey] returning [CompletableFuture].
      */
-    fun assistedRegisterEphemeralKeyAsync(publicKey: ByteArray? = null): CompletableFuture<AssistedRegisterEphemeralKeyResponse> {
-        return completableFuture { assistedRegisterEphemeralKey(publicKey) }
+    fun assistedRegisterEphemeralKeyAsync(publicKey: ByteArray? = null, privateKey: ByteArray? = null): CompletableFuture<AssistedRegisterEphemeralKeyResponse> {
+        return completableFuture { assistedRegisterEphemeralKey(publicKey, privateKey) }
     }
 
     /**

--- a/doordeck-sdk/src/androidUnitTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.android.kt
+++ b/doordeck-sdk/src/androidUnitTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.android.kt
@@ -50,13 +50,13 @@ class AccountApiTest : MockTest() {
 
     @Test
     fun shouldRegisterEphemeralKey() = runTest {
-        val response = AccountApi.registerEphemeralKey(byteArrayOf())
+        val response = AccountApi.registerEphemeralKey(byteArrayOf(), byteArrayOf())
         assertEquals(REGISTER_EPHEMERAL_KEY_RESPONSE, response)
     }
 
     @Test
     fun shouldRegisterEphemeralKeyAsync() = runTest {
-        val response = AccountApi.registerEphemeralKeyAsync(byteArrayOf()).await()
+        val response = AccountApi.registerEphemeralKeyAsync(byteArrayOf(), byteArrayOf()).await()
         assertEquals(REGISTER_EPHEMERAL_KEY_RESPONSE, response)
     }
 

--- a/doordeck-sdk/src/androidUnitTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.android.kt
+++ b/doordeck-sdk/src/androidUnitTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.android.kt
@@ -105,7 +105,7 @@ class AccountApiTest : MockTest() {
 
     @Test
     fun shouldVerifyEphemeralKeyRegistrationAsync() = runTest {
-        val response = AccountApi.verifyEphemeralKeyRegistrationAsync("", TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()).await()
+        val response = AccountApi.verifyEphemeralKeyRegistrationAsync("", TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(), TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()).await()
         assertEquals(REGISTER_EPHEMERAL_KEY_RESPONSE, response)
     }
 

--- a/doordeck-sdk/src/androidUnitTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.android.kt
+++ b/doordeck-sdk/src/androidUnitTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.android.kt
@@ -5,6 +5,7 @@ import com.doordeck.multiplatform.sdk.REGISTER_EPHEMERAL_KEY_RESPONSE
 import com.doordeck.multiplatform.sdk.REGISTER_EPHEMERAL_KEY_WITH_SECONDARY_AUTHENTICATION_RESPONSE
 import com.doordeck.multiplatform.sdk.TOKEN_RESPONSE
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_PRIVATE_KEY
+import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_PUBLIC_KEY
 import com.doordeck.multiplatform.sdk.USER_DETAILS_RESPONSE
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
 import kotlinx.coroutines.future.await
@@ -98,7 +99,7 @@ class AccountApiTest : MockTest() {
 
     @Test
     fun shouldVerifyEphemeralKeyRegistration() = runTest {
-        val response = AccountApi.verifyEphemeralKeyRegistration("", TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray())
+        val response = AccountApi.verifyEphemeralKeyRegistration("", TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(), TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray())
         assertEquals(REGISTER_EPHEMERAL_KEY_RESPONSE, response)
     }
 

--- a/doordeck-sdk/src/appleMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.apple.kt
+++ b/doordeck-sdk/src/appleMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.apple.kt
@@ -33,8 +33,8 @@ actual object AccountApi {
      * @see AccountClient.registerEphemeralKeyRequest
      */
     @Throws(Exception::class)
-    suspend fun registerEphemeralKey(publicKey: ByteArray? = null): RegisterEphemeralKeyResponse {
-        return AccountClient.registerEphemeralKeyRequest(publicKey)
+    suspend fun registerEphemeralKey(publicKey: ByteArray? = null, privateKey: ByteArray? = null): RegisterEphemeralKeyResponse {
+        return AccountClient.registerEphemeralKeyRequest(publicKey, privateKey)
     }
 
     /**

--- a/doordeck-sdk/src/appleMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.apple.kt
+++ b/doordeck-sdk/src/appleMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.apple.kt
@@ -49,8 +49,8 @@ actual object AccountApi {
      * @see AccountClient.verifyEphemeralKeyRegistrationRequest
      */
     @Throws(Exception::class)
-    suspend fun verifyEphemeralKeyRegistration(code: String, privateKey: ByteArray? = null): RegisterEphemeralKeyResponse {
-        return AccountClient.verifyEphemeralKeyRegistrationRequest(code, privateKey)
+    suspend fun verifyEphemeralKeyRegistration(code: String, publicKey: ByteArray? = null, privateKey: ByteArray? = null): RegisterEphemeralKeyResponse {
+        return AccountClient.verifyEphemeralKeyRegistrationRequest(code, publicKey, privateKey)
     }
 
     /**

--- a/doordeck-sdk/src/appleMain/kotlin/com/doordeck/multiplatform/sdk/api/HelperApi.apple.kt
+++ b/doordeck-sdk/src/appleMain/kotlin/com/doordeck/multiplatform/sdk/api/HelperApi.apple.kt
@@ -28,8 +28,8 @@ actual object HelperApi {
      * @see HelperClient.assistedRegisterEphemeralKeyRequest
      */
     @Throws(Exception::class)
-    suspend fun assistedRegisterEphemeralKey(publicKey: ByteArray? = null): AssistedRegisterEphemeralKeyResponse {
-        return HelperClient.assistedRegisterEphemeralKeyRequest(publicKey)
+    suspend fun assistedRegisterEphemeralKey(publicKey: ByteArray? = null, privateKey: ByteArray? = null): AssistedRegisterEphemeralKeyResponse {
+        return HelperClient.assistedRegisterEphemeralKeyRequest(publicKey, privateKey)
     }
 
     /**

--- a/doordeck-sdk/src/appleTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.apple.kt
+++ b/doordeck-sdk/src/appleTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.apple.kt
@@ -32,7 +32,7 @@ class AccountApiTest : MockTest() {
 
     @Test
     fun shouldRegisterEphemeralKey() = runTest {
-        val response = AccountApi.registerEphemeralKey(byteArrayOf())
+        val response = AccountApi.registerEphemeralKey(byteArrayOf(), byteArrayOf())
         assertEquals(REGISTER_EPHEMERAL_KEY_RESPONSE, response)
     }
 

--- a/doordeck-sdk/src/appleTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.apple.kt
+++ b/doordeck-sdk/src/appleTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.apple.kt
@@ -5,6 +5,7 @@ import com.doordeck.multiplatform.sdk.REGISTER_EPHEMERAL_KEY_RESPONSE
 import com.doordeck.multiplatform.sdk.REGISTER_EPHEMERAL_KEY_WITH_SECONDARY_AUTHENTICATION_RESPONSE
 import com.doordeck.multiplatform.sdk.TOKEN_RESPONSE
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_PRIVATE_KEY
+import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_PUBLIC_KEY
 import com.doordeck.multiplatform.sdk.USER_DETAILS_RESPONSE
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
 import kotlinx.coroutines.test.runTest
@@ -56,7 +57,7 @@ class AccountApiTest : MockTest() {
 
     @Test
     fun shouldVerifyEphemeralKeyRegistration() = runTest {
-        val response = AccountApi.verifyEphemeralKeyRegistration("", TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray())
+        val response = AccountApi.verifyEphemeralKeyRegistration("", TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(), TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray())
         assertEquals(REGISTER_EPHEMERAL_KEY_RESPONSE, response)
     }
 

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/Platform.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/Platform.kt
@@ -88,7 +88,7 @@ internal abstract class BaseHttpClient(clientProvider: () -> HttpClient) {
         get() = _client
 
     /**
-     * Internal function used in tests to override the default http client
+     * Internal function used in testing to override the default HTTP client.
      */
     internal fun overrideClient(httpClient: HttpClient) {
         _client = httpClient

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/Platform.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/Platform.kt
@@ -87,6 +87,9 @@ internal abstract class BaseHttpClient(clientProvider: () -> HttpClient) {
     val client: HttpClient
         get() = _client
 
+    /**
+     * Internal function used in tests to override the default http client
+     */
     internal fun overrideClient(httpClient: HttpClient) {
         _client = httpClient
     }

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/clients/AccountClient.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/clients/AccountClient.kt
@@ -73,8 +73,11 @@ internal object AccountClient {
      * Also marks the key pair as verified in [ContextManagerImpl].
      *
      * @param publicKey The public key to use for the request. If null, uses the public key from [ContextManagerImpl].
+     * @param privateKey The private key to be stored alongside the provided public key.
+     *  This private key is not used in the request. It is only persisted in the [ContextManagerImpl].
+     *  This value should only be provided if the private key isn't already stored in the [ContextManagerImpl].
      * @return [RegisterEphemeralKeyResponse].
-     * @throws MissingContextFieldException if no public key is available (when [publicKey] is null and [ContextManagerImpl] has none).
+     * @throws MissingContextFieldException if no public/private keys are available (when [publicKey] or [privateKey] are null and [ContextManagerImpl] has none).
      * @throws SdkException if an unexpected error occurs while processing the request.
      *
      * @see <a href="https://developer.doordeck.com/docs/#register-ephemeral-key">API Doc</a>

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/clients/AccountClient.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/clients/AccountClient.kt
@@ -95,7 +95,7 @@ internal object AccountClient {
         }.body<RegisterEphemeralKeyResponse>().also {
             ContextManagerImpl.setUserId(it.userId)
             ContextManagerImpl.setCertificateChain(it.certificateChain)
-            ContextManagerImpl.setKeyPair(publicKey, privateKey)
+            ContextManagerImpl.setKeyPair(publicKey = publicKey, privateKey = privateKey)
             ContextManagerImpl.setKeyPairVerified(publicKey)
         }
     }

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/clients/AccountlessClient.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/clients/AccountlessClient.kt
@@ -40,9 +40,11 @@ internal object AccountlessClient {
             addRequestHeaders(apiVersion = ApiVersion.VERSION_2)
             setBody(LoginRequest(email, password))
         }.body<TokenResponse>().also {
-            ContextManagerImpl.setUserEmail(email)
-            ContextManagerImpl.setCloudAuthToken(it.authToken)
-            ContextManagerImpl.setCloudRefreshToken(it.refreshToken)
+            ContextManagerImpl.also { context ->
+                context.setUserEmail(email)
+                context.setCloudAuthToken(it.authToken)
+                context.setCloudRefreshToken(it.refreshToken)
+            }
         }
     }
 
@@ -79,9 +81,11 @@ internal object AccountlessClient {
             )
             parameter(Params.FORCE, force)
         }.body<TokenResponse>().also {
-            ContextManagerImpl.setUserEmail(email)
-            ContextManagerImpl.setCloudAuthToken(it.authToken)
-            ContextManagerImpl.setCloudRefreshToken(it.refreshToken)
+            ContextManagerImpl.also { context ->
+                context.setUserEmail(email)
+                context.setCloudAuthToken(it.authToken)
+                context.setCloudRefreshToken(it.refreshToken)
+            }
         }
     }
 

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/clients/HelperClient.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/clients/HelperClient.kt
@@ -57,7 +57,7 @@ internal object HelperClient {
         // Add the new key pair to the context manager
         if (currentKeyPair == null) {
             ContextManagerImpl.setKeyPair(keyPair.public, keyPair.private)
-            ContextManagerImpl.setKeyPairVerified(false)
+            ContextManagerImpl.setKeyPairVerified(null)
         }
 
         // Perform the login
@@ -119,6 +119,6 @@ internal object HelperClient {
 
         // Add the key pair to the context manager
         ContextManagerImpl.setKeyPair(keyPair.public, keyPair.private)
-        ContextManagerImpl.setKeyPairVerified(true)
+        ContextManagerImpl.setKeyPairVerified(keyPair.public)
     }
 }

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/clients/HelperClient.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/clients/HelperClient.kt
@@ -56,7 +56,7 @@ internal object HelperClient {
 
         // Add the new key pair to the context manager
         if (currentKeyPair == null) {
-            ContextManagerImpl.setKeyPair(keyPair.public, keyPair.private)
+            ContextManagerImpl.setKeyPair(publicKey = keyPair.public, privateKey = keyPair.private)
             ContextManagerImpl.setKeyPairVerified(null)
         }
 
@@ -118,7 +118,7 @@ internal object HelperClient {
         AccountlessClient.registrationRequest(email, password, displayName, force, keyPair.public)
 
         // Add the key pair to the context manager
-        ContextManagerImpl.setKeyPair(keyPair.public, keyPair.private)
+        ContextManagerImpl.setKeyPair(publicKey = keyPair.public, privateKey = keyPair.private)
         ContextManagerImpl.setKeyPairVerified(keyPair.public)
     }
 }

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManager.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManager.kt
@@ -1,5 +1,6 @@
 package com.doordeck.multiplatform.sdk.context
 
+import com.doordeck.multiplatform.sdk.model.common.ContextState
 import com.doordeck.multiplatform.sdk.model.data.ApiEnvironment
 import com.doordeck.multiplatform.sdk.model.data.Crypto
 import kotlin.js.JsExport
@@ -160,6 +161,12 @@ interface ContextManager {
      */
     @CName("setOperationContextJson")
     fun setOperationContextJson(data: String)
+
+    /**
+     * Checks the context and returns a [ContextState] representing its state.
+     */
+    @CName("getContextState")
+    fun getContextState(): ContextState
 
     /**
      * Clears all the values stored in secure storage.

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManager.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManager.kt
@@ -136,7 +136,7 @@ interface ContextManager {
     /**
      * Sets the key pair verification status, the provided values will be automatically stored in secure storage.
      */
-    fun setKeyPairVerified(verified: Boolean)
+    fun setKeyPairVerified(publicKey: ByteArray?)
 
     /**
      * Retrieves the key pair verification status.

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManager.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManager.kt
@@ -134,7 +134,7 @@ interface ContextManager {
     fun getKeyPair(): Crypto.KeyPair?
 
     /**
-     * Sets the key pair verification status, the provided values will be automatically stored in secure storage.
+     * Sets the public key that has been verified via two-factor authentication. The provided value will be automatically stored in secure storage.
      */
     fun setKeyPairVerified(publicKey: ByteArray?)
 

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManager.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManager.kt
@@ -153,7 +153,7 @@ interface ContextManager {
     /**
      * Sets all necessary fields to perform secure operations, the provided values will be automatically stored in secure storage.
      */
-    fun setOperationContext(userId: String, certificateChain: List<String>, publicKey: ByteArray, privateKey: ByteArray)
+    fun setOperationContext(userId: String, certificateChain: List<String>, publicKey: ByteArray, privateKey: ByteArray, isKeyPairVerified: Boolean = true)
 
     /**
      * Sets all necessary fields to perform secure operations in JSON format, the provided values will be automatically stored in secure storage.

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerImpl.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerImpl.kt
@@ -115,12 +115,25 @@ internal object ContextManagerImpl : ContextManager {
         } else null
     }
 
-    override fun setKeyPairVerified(verified: Boolean) {
-        secureStorage.setKeyPairVerified(verified)
+    internal fun setPublicKey(publicKey: ByteArray) {
+        secureStorage.addPublicKey(publicKey)
+    }
+
+    internal fun setPrivateKey(privateKey: ByteArray) {
+        secureStorage.addPrivateKey(privateKey)
+    }
+
+    override fun setKeyPairVerified(publicKey: ByteArray?) {
+        secureStorage.setKeyPairVerified(publicKey)
     }
 
     override fun isKeyPairVerified(): Boolean {
-        return secureStorage.getKeyPairVerified() ?: false
+        val verified = secureStorage.getKeyPairVerified()
+        val publicKey = secureStorage.getPublicKey()
+        if (verified == null || publicKey == null) {
+            return false
+        }
+        return verified.contentEquals(publicKey)
     }
 
     internal fun getPublicKey(): ByteArray? {

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerImpl.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerImpl.kt
@@ -172,14 +172,17 @@ internal object ContextManagerImpl : ContextManager {
     override fun setOperationContext(userId: String, certificateChain: List<String>, publicKey: ByteArray, privateKey: ByteArray) {
         setUserId(userId)
         setCertificateChain(certificateChain)
-        setKeyPair(publicKey, privateKey)
+        setKeyPair(publicKey = publicKey, privateKey = privateKey)
     }
 
     override fun setOperationContextJson(data: String) {
         val operationContextData = data.fromJson<Context.OperationContextData>()
         setUserId(operationContextData.userId)
         setCertificateChain(operationContextData.userCertificateChain.stringToCertificateChain())
-        setKeyPair(operationContextData.userPublicKey.decodeBase64ToByteArray(), operationContextData.userPrivateKey.decodeBase64ToByteArray())
+        setKeyPair(
+            publicKey = operationContextData.userPublicKey.decodeBase64ToByteArray(),
+            privateKey = operationContextData.userPrivateKey.decodeBase64ToByteArray()
+        )
     }
 
     internal fun setSecureStorageImpl(secureStorage: SecureStorage) {

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerImpl.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerImpl.kt
@@ -126,14 +126,6 @@ internal object ContextManagerImpl : ContextManager {
         return verified.contentEquals(publicKey)
     }
 
-    internal fun setTempPublicKey(publicKey: ByteArray?) {
-        secureStorage.addTempPublicKey(publicKey)
-    }
-
-    internal fun getTempPublicKey(): ByteArray? {
-        return secureStorage.getTempPublicKey()
-    }
-
     internal fun getPublicKey(): ByteArray? {
         return secureStorage.getPublicKey()
     }

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerImpl.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerImpl.kt
@@ -4,6 +4,7 @@ import com.doordeck.multiplatform.sdk.Constants.DEFAULT_FUSION_HOST
 import com.doordeck.multiplatform.sdk.cache.CapabilityCache
 import com.doordeck.multiplatform.sdk.crypto.CryptoManager
 import com.doordeck.multiplatform.sdk.logger.SdkLogger
+import com.doordeck.multiplatform.sdk.model.common.ContextState
 import com.doordeck.multiplatform.sdk.model.data.ApiEnvironment
 import com.doordeck.multiplatform.sdk.model.data.Context
 import com.doordeck.multiplatform.sdk.model.data.Crypto
@@ -165,6 +166,14 @@ internal object ContextManagerImpl : ContextManager {
             privateKey = operationContextData.userPrivateKey.decodeBase64ToByteArray(),
             isKeyPairVerified = operationContextData.isKeyPairVerified
         )
+    }
+
+    override fun getContextState(): ContextState {
+        if (isCloudAuthTokenInvalidOrExpired()) { return ContextState.CLOUD_TOKEN_IS_INVALID_OR_EXPIRED }
+        if (!isKeyPairValid()) { return ContextState.KEY_PAIR_IS_INVALID }
+        if (!isKeyPairVerified()) { return ContextState.KEY_PAIR_IS_NOT_VERIFIED }
+        if (isCertificateChainInvalidOrExpired()) { return ContextState.CERTIFICATE_CHAIN_IS_INVALID_OR_EXPIRED }
+        return ContextState.READY
     }
 
     internal fun setSecureStorageImpl(secureStorage: SecureStorage) {

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerImpl.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerImpl.kt
@@ -169,19 +169,22 @@ internal object ContextManagerImpl : ContextManager {
         clearContext()
     }
 
-    override fun setOperationContext(userId: String, certificateChain: List<String>, publicKey: ByteArray, privateKey: ByteArray) {
+    override fun setOperationContext(userId: String, certificateChain: List<String>, publicKey: ByteArray,
+                                     privateKey: ByteArray, isKeyPairVerified: Boolean) {
         setUserId(userId)
         setCertificateChain(certificateChain)
         setKeyPair(publicKey = publicKey, privateKey = privateKey)
+        setKeyPairVerified(if (isKeyPairVerified) publicKey else null)
     }
 
     override fun setOperationContextJson(data: String) {
         val operationContextData = data.fromJson<Context.OperationContextData>()
-        setUserId(operationContextData.userId)
-        setCertificateChain(operationContextData.userCertificateChain.stringToCertificateChain())
-        setKeyPair(
+        setOperationContext(
+            userId = operationContextData.userId,
+            certificateChain = operationContextData.userCertificateChain.stringToCertificateChain(),
             publicKey = operationContextData.userPublicKey.decodeBase64ToByteArray(),
-            privateKey = operationContextData.userPrivateKey.decodeBase64ToByteArray()
+            privateKey = operationContextData.userPrivateKey.decodeBase64ToByteArray(),
+            isKeyPairVerified = operationContextData.isKeyPairVerified
         )
     }
 

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/common/ContextState.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/common/ContextState.kt
@@ -1,0 +1,32 @@
+package com.doordeck.multiplatform.sdk.model.common
+
+import kotlin.js.JsExport
+
+@JsExport
+enum class ContextState {
+    /**
+     * Logging in or providing valid authentication tokens in the context is required.
+     */
+    CLOUD_TOKEN_IS_INVALID_OR_EXPIRED,
+
+    /**
+     * Registering an ephemeral key or providing a valid key pair in the context is required.
+     */
+    KEY_PAIR_IS_INVALID,
+
+    /**
+     * Registering an ephemeral key with two-factor authentication or providing a verified public key in the context is required.
+     */
+    KEY_PAIR_IS_NOT_VERIFIED,
+
+    /**
+     * Registering an ephemeral key (to receive a fresh certificate chain from the backend)
+     * or providing a valid existing certificate chain in the context is required.
+     */
+    CERTIFICATE_CHAIN_IS_INVALID_OR_EXPIRED,
+
+    /**
+     * Everything is ready - nothing further is required.
+     */
+    READY
+}

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/data/Context.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/data/Context.kt
@@ -9,6 +9,7 @@ object Context {
         val userId: String,
         val userCertificateChain: String,
         val userPublicKey: String,
-        val userPrivateKey: String
+        val userPrivateKey: String,
+        val isKeyPairVerified: Boolean = true
     )
 }

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/DefaultSecureStorage.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/DefaultSecureStorage.kt
@@ -24,7 +24,6 @@ internal class DefaultSecureStorage(
     private val cloudRefreshTokenKey = "CLOUD_REFRESH_TOKEN_KEY"
     private val fusionHostKey = "FUSION_HOST_KEY"
     private val fusionAuthTokenKey = "FUSION_AUTH_TOKEN_KEY"
-    private val tempPublicKeyKey = "TEMP_PUBLIC_KEY_KEY"
     private val publicKeyKey = "PUBLIC_KEY_KEY"
     private val privateKeyKey = "PRIVATE_KEY_KEY"
     private val keyPairVerifiedKey = "VERIFIED_KEY_PAIR_KEY"
@@ -83,14 +82,6 @@ internal class DefaultSecureStorage(
 
     override fun getFusionAuthToken(): String? {
         return retrieveStringValue(fusionAuthTokenKey, true)
-    }
-
-    override fun addTempPublicKey(publicKey: ByteArray?) {
-        storeStringValue(tempPublicKeyKey, publicKey?.encodeByteArrayToBase64(), true)
-    }
-
-    override fun getTempPublicKey(): ByteArray? {
-        return retrieveStringValue(tempPublicKeyKey, true)?.decodeBase64ToByteArray()
     }
 
     override fun addPublicKey(publicKey: ByteArray) {

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/DefaultSecureStorage.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/DefaultSecureStorage.kt
@@ -26,7 +26,7 @@ internal class DefaultSecureStorage(
     private val fusionAuthTokenKey = "FUSION_AUTH_TOKEN_KEY"
     private val publicKeyKey = "PUBLIC_KEY_KEY"
     private val privateKeyKey = "PRIVATE_KEY_KEY"
-    private val keyPairVerifiedKey = "KEY_PAIR_VERIFIED_KEY"
+    private val keyPairVerifiedKey = "VERIFIED_KEY_PAIR_KEY"
     private val userIdKey = "USER_ID_KEY"
     private val userEmailKey = "USER_EMAIL_KEY"
     private val certificateChainKey = "CERTIFICATE_CHAIN_KEY"

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/DefaultSecureStorage.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/DefaultSecureStorage.kt
@@ -100,12 +100,12 @@ internal class DefaultSecureStorage(
         return retrieveStringValue(privateKeyKey, true)?.decodeBase64ToByteArray()
     }
 
-    override fun setKeyPairVerified(verified: Boolean) {
-        storeBooleanValue(keyPairVerifiedKey, verified)
+    override fun setKeyPairVerified(publicKey: ByteArray?) {
+        storeStringValue(keyPairVerifiedKey, publicKey?.encodeByteArrayToBase64(), true)
     }
 
-    override fun getKeyPairVerified(): Boolean? {
-        return retrieveBooleanValue(keyPairVerifiedKey)
+    override fun getKeyPairVerified(): ByteArray? {
+        return retrieveStringValue(keyPairVerifiedKey, true)?.decodeBase64ToByteArray()
     }
 
     override fun addUserId(userId: String) {
@@ -154,9 +154,14 @@ internal class DefaultSecureStorage(
         }
     }
 
-    private fun storeStringValue(key: String, value: String, maskValue: Boolean = false) {
-        settings.putString(key, value)
-        SdkLogger.d("Stored value: ${if (maskValue) value.mask() else value} for key: $key")
+    private fun storeStringValue(key: String, value: String?, maskValue: Boolean = false) {
+        if (value == null) {
+            settings.remove(key)
+            SdkLogger.d { "Removed key $key" }
+        } else {
+            settings.putString(key, value)
+            SdkLogger.d("Stored value: ${if (maskValue) value.mask() else value} for key: $key")
+        }
     }
 
     private fun retrieveStringValue(key: String, maskValue: Boolean = false): String? {

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/DefaultSecureStorage.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/DefaultSecureStorage.kt
@@ -24,6 +24,7 @@ internal class DefaultSecureStorage(
     private val cloudRefreshTokenKey = "CLOUD_REFRESH_TOKEN_KEY"
     private val fusionHostKey = "FUSION_HOST_KEY"
     private val fusionAuthTokenKey = "FUSION_AUTH_TOKEN_KEY"
+    private val tempPublicKeyKey = "TEMP_PUBLIC_KEY_KEY"
     private val publicKeyKey = "PUBLIC_KEY_KEY"
     private val privateKeyKey = "PRIVATE_KEY_KEY"
     private val keyPairVerifiedKey = "VERIFIED_KEY_PAIR_KEY"
@@ -84,16 +85,24 @@ internal class DefaultSecureStorage(
         return retrieveStringValue(fusionAuthTokenKey, true)
     }
 
-    override fun addPublicKey(byteArray: ByteArray) {
-        storeStringValue(publicKeyKey, byteArray.encodeByteArrayToBase64(), true)
+    override fun addTempPublicKey(publicKey: ByteArray?) {
+        storeStringValue(tempPublicKeyKey, publicKey?.encodeByteArrayToBase64(), true)
+    }
+
+    override fun getTempPublicKey(): ByteArray? {
+        return retrieveStringValue(tempPublicKeyKey, true)?.decodeBase64ToByteArray()
+    }
+
+    override fun addPublicKey(publicKey: ByteArray) {
+        storeStringValue(publicKeyKey, publicKey.encodeByteArrayToBase64(), true)
     }
 
     override fun getPublicKey(): ByteArray? {
         return retrieveStringValue(publicKeyKey, true)?.decodeBase64ToByteArray()
     }
 
-    override fun addPrivateKey(byteArray: ByteArray) {
-        storeStringValue(privateKeyKey, byteArray.encodeByteArrayToBase64(), true)
+    override fun addPrivateKey(privateKey: ByteArray) {
+        storeStringValue(privateKeyKey, privateKey.encodeByteArrayToBase64(), true)
     }
 
     override fun getPrivateKey(): ByteArray? {
@@ -167,19 +176,6 @@ internal class DefaultSecureStorage(
     private fun retrieveStringValue(key: String, maskValue: Boolean = false): String? {
         val value = settings.getStringOrNull(key)
         SdkLogger.d("Retrieved value: ${if (maskValue) value?.mask() else value} for key: $key")
-        return value
-    }
-
-    @Suppress("SameParameterValue")
-    private fun storeBooleanValue(key: String, value: Boolean) {
-        settings.putBoolean(key, value)
-        SdkLogger.d("Stored value: $value for key: $key")
-    }
-
-    @Suppress("SameParameterValue")
-    private fun retrieveBooleanValue(key: String): Boolean? {
-        val value = settings.getBooleanOrNull(key)
-        SdkLogger.d("Retrieved value: $value for key: $key")
         return value
     }
 

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.kt
@@ -79,18 +79,6 @@ interface SecureStorage {
     fun getFusionAuthToken(): String?
 
     /**
-     * Stores the temporary public key.
-     *
-     * @param publicKey The public key as a byte array.
-     */
-    fun addTempPublicKey(publicKey: ByteArray?)
-
-    /**
-     * Retrieves the temporary public key.
-     */
-    fun getTempPublicKey(): ByteArray?
-
-    /**
      * Stores the public key.
      *
      * @param publicKey The public key as a byte array.

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.kt
@@ -11,7 +11,8 @@ import kotlin.js.JsExport
 interface SecureStorage {
 
     /**
-     * Stores the API environment on which the SDK will operate
+     * Stores the API environment on which the SDK will operate.
+     *
      * @param apiEnvironment The api environment to be stored.
      */
     fun setApiEnvironment(apiEnvironment: ApiEnvironment)
@@ -23,120 +24,141 @@ interface SecureStorage {
 
     /**
      * Stores the cloud authentication token.
+     *
      * @param token The cloud authentication token to be stored.
      */
     fun addCloudAuthToken(token: String)
 
     /**
      * Retrieves the cloud authentication token.
+     *
      * @return The stored cloud authentication token, or null if not found.
      */
     fun getCloudAuthToken(): String?
 
     /**
      * Stores the cloud refresh token.
+     *
      * @param token The cloud refresh token to be stored.
      */
     fun addCloudRefreshToken(token: String)
 
     /**
      * Retrieves the cloud refresh token.
+     *
      * @return The stored cloud refresh token, or null if not found.
      */
     fun getCloudRefreshToken(): String?
 
     /**
      * Stores the fusion host.
+     *
      * @param host The fusion host to be stored.
      */
     fun setFusionHost(host: String)
 
     /**
      * Retrieves the fusion host.
+     *
      * @return The stored fusion host, or null if not found.
      */
     fun getFusionHost(): String?
 
     /**
      * Stores the Fusion authentication token.
+     *
      * @param token The Fusion authentication token to be stored.
      */
     fun addFusionAuthToken(token: String)
 
     /**
      * Retrieves the Fusion authentication token.
+     *
      * @return The stored Fusion authentication token, or null if not found.
      */
     fun getFusionAuthToken(): String?
 
     /**
      * Stores the public key.
+     *
      * @param byteArray The public key as a byte array.
      */
     fun addPublicKey(byteArray: ByteArray)
 
     /**
      * Retrieves the public key.
+     *
      * @return The stored public key as a byte array, or null if not found.
      */
     fun getPublicKey(): ByteArray?
 
     /**
      * Stores the private key.
+     *
      * @param byteArray The private key as a byte array.
      */
     fun addPrivateKey(byteArray: ByteArray)
 
     /**
      * Retrieves the private key.
+     *
      * @return The stored private key as a byte array, or null if not found.
      */
     fun getPrivateKey(): ByteArray?
 
     /**
-     * Stores the key pair verification status.
+     * Stores the public key that has been verified via two-factor authentication.
+     *
      * @param publicKey The key pair verification status
      */
     fun setKeyPairVerified(publicKey: ByteArray?)
 
     /**
-     * Retrieves the key pair verification status
+     * Retrieves the verified public key and compares it against the stored public key.
+     * Returns true if they match exactly, or false if either value is null or the keys don't match.
+     *
      * @return The stored key pair verification status a boolean, or null if not found.
      */
     fun getKeyPairVerified(): ByteArray?
 
     /**
      * Stores the user ID.
+     *
      * @param userId The user ID to be stored.
      */
     fun addUserId(userId: String)
 
     /**
      * Retrieves the user ID.
+     *
      * @return The stored user ID, or null if not found.
      */
     fun getUserId(): String?
 
     /**
      * Stores the user email.
+     *
      * @param email The user email to be stored.
      */
     fun addUserEmail(email: String)
 
     /**
      * Retrieves the user email.
+     *
      * @return The stored user email, or null if not found.
      */
     fun getUserEmail(): String?
 
     /**
      * Stores the certificate chain.
+     *
      * @param certificateChain The certificate chain as a list of strings.
      */
     fun addCertificateChain(certificateChain: List<String>)
 
     /**
      * Retrieves the certificate chain.
+     *
      * @return The stored certificate chain as a list of strings, or null if not found.
      */
     fun getCertificateChain(): List<String>?

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.kt
@@ -95,15 +95,15 @@ interface SecureStorage {
 
     /**
      * Stores the key pair verification status.
-     * @param verified The key pair verification status
+     * @param publicKey The key pair verification status
      */
-    fun setKeyPairVerified(verified: Boolean)
+    fun setKeyPairVerified(publicKey: ByteArray?)
 
     /**
      * Retrieves the key pair verification status
      * @return The stored key pair verification status a boolean, or null if not found.
      */
-    fun getKeyPairVerified(): Boolean?
+    fun getKeyPairVerified(): ByteArray?
 
     /**
      * Stores the user ID.

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.kt
@@ -79,11 +79,23 @@ interface SecureStorage {
     fun getFusionAuthToken(): String?
 
     /**
+     * Stores the temporary public key.
+     *
+     * @param publicKey The public key as a byte array.
+     */
+    fun addTempPublicKey(publicKey: ByteArray?)
+
+    /**
+     * Retrieves the temporary public key.
+     */
+    fun getTempPublicKey(): ByteArray?
+
+    /**
      * Stores the public key.
      *
-     * @param byteArray The public key as a byte array.
+     * @param publicKey The public key as a byte array.
      */
-    fun addPublicKey(byteArray: ByteArray)
+    fun addPublicKey(publicKey: ByteArray)
 
     /**
      * Retrieves the public key.
@@ -95,9 +107,9 @@ interface SecureStorage {
     /**
      * Stores the private key.
      *
-     * @param byteArray The private key as a byte array.
+     * @param privateKey The private key as a byte array.
      */
-    fun addPrivateKey(byteArray: ByteArray)
+    fun addPrivateKey(privateKey: ByteArray)
 
     /**
      * Retrieves the private key.

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/migrations/Migrate1To2.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/migrations/Migrate1To2.kt
@@ -1,0 +1,30 @@
+package com.doordeck.multiplatform.sdk.storage.migrations
+
+import com.russhwolf.settings.Settings
+import com.russhwolf.settings.contains
+
+/**
+ * Removes KEY_PAIR_VERIFIED_KEY and adds VERIFIED_KEY_PAIR_KEY with the public key as its value.
+ */
+internal object Migrate1To2 : StorageMigration {
+
+    override val fromVersion: Int = 1
+    override val toVersion: Int = 2
+
+    private const val KEY_PAIR_VERIFIED_KEY = "KEY_PAIR_VERIFIED_KEY"
+    private const val VERIFIED_KEY_PAIR_KEY = "VERIFIED_KEY_PAIR_KEY"
+    private const val PUBLIC_KEY_KEY = "PUBLIC_KEY_KEY"
+
+    override fun migrate(settings: Settings) {
+        val keyPairVerified = settings.getBooleanOrNull(KEY_PAIR_VERIFIED_KEY)
+        if (keyPairVerified != null) {
+            settings.remove(KEY_PAIR_VERIFIED_KEY)
+        }
+        if (!settings.contains(VERIFIED_KEY_PAIR_KEY) && keyPairVerified == true) {
+            val publicKey = settings.getStringOrNull(PUBLIC_KEY_KEY)
+            if (publicKey != null) {
+                settings.putString(VERIFIED_KEY_PAIR_KEY, publicKey)
+            }
+        }
+    }
+}

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/migrations/Migrations.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/migrations/Migrations.kt
@@ -3,13 +3,14 @@ package com.doordeck.multiplatform.sdk.storage.migrations
 /**
  * This value should be updated to match the highest version (toVersion) from the migrations.
  */
-internal const val CURRENT_STORAGE_VERSION = 1
+internal const val CURRENT_STORAGE_VERSION = 2
 
 /**
  * Simple object that holds the list of migrations.
  */
 internal object Migrations {
     val migrations = listOf(
-        Migrate0To1
+        Migrate0To1,
+        Migrate1To2
     )
 }

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/migrations/Migrations.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/migrations/Migrations.kt
@@ -9,8 +9,18 @@ internal const val CURRENT_STORAGE_VERSION = 2
  * Simple object that holds the list of migrations.
  */
 internal object Migrations {
-    val migrations = listOf(
+    private var _migrations: List<StorageMigration> = listOf(
         Migrate0To1,
         Migrate1To2
     )
+
+    val migrations: List<StorageMigration>
+        get() = _migrations
+
+    /**
+     * Internal function used in tests to override the default migration list
+     */
+    internal fun overrideMigrations(list: List<StorageMigration>) {
+        _migrations = list
+    }
 }

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/migrations/Migrations.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/migrations/Migrations.kt
@@ -18,7 +18,7 @@ internal object Migrations {
         get() = _migrations
 
     /**
-     * Internal function used in tests to override the default migration list
+     * Internal function used in testing to override the migration list.
      */
     internal fun overrideMigrations(list: List<StorageMigration>) {
         _migrations = list

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.kt
@@ -128,7 +128,10 @@ internal fun HttpClientConfig<*>.installAuth() {
                         }
                         markAsRefreshTokenRequest()
                     }.body()
-                    ContextManagerImpl.setTokens(refreshTokens.authToken, refreshTokens.refreshToken)
+                    ContextManagerImpl.also { context ->
+                        context.setCloudAuthToken(refreshTokens.authToken)
+                        context.setCloudRefreshToken(refreshTokens.refreshToken)
+                    }
                     BearerTokens(refreshTokens.authToken, refreshTokens.refreshToken)
                 }
             }

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/util/KeyPairUtils.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/util/KeyPairUtils.kt
@@ -1,0 +1,21 @@
+package com.doordeck.multiplatform.sdk.util
+
+import com.doordeck.multiplatform.sdk.crypto.CryptoManager.signWithPrivateKey
+import com.doordeck.multiplatform.sdk.crypto.CryptoManager.verifySignature
+import kotlin.uuid.Uuid
+
+internal object KeyPairUtils {
+
+    /**
+     * Checks whether the provided key pair is valid by signing a small piece of text and verifying it.
+     */
+    fun isKeyPairValid(publicKey: ByteArray, privateKey: ByteArray): Boolean {
+        val text = Uuid.random().toString()
+        val signature = try {
+            text.signWithPrivateKey(privateKey)
+        } catch (_: Exception) {
+            return false
+        }
+        return signature.verifySignature(publicKey, text)
+    }
+}

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/clients/AccountClientTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/clients/AccountClientTest.kt
@@ -11,6 +11,7 @@ import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -56,12 +57,14 @@ class AccountClientTest : IntegrationTest() {
         val result = AccountClient.registerEphemeralKeyRequest(publicKey, privateKey)
 
         // Then
+        println("isCertificateChainInvalidOrExpired: ${ContextManagerImpl.isCertificateChainInvalidOrExpired()}")
+        println("isKeyPairVerified: ${ContextManagerImpl.isKeyPairVerified()}")
         assertTrue { result.certificateChain.isNotEmpty() }
         assertEquals(TEST_MAIN_USER_ID, result.userId)
         assertEquals(result.userId, ContextManagerImpl.getUserId())
         assertEquals(result.certificateChain, ContextManagerImpl.getCertificateChain())
-        assertEquals(publicKey, ContextManagerImpl.getPublicKey())
-        assertEquals(privateKey, ContextManagerImpl.getPrivateKey())
+        assertContentEquals(publicKey, ContextManagerImpl.getPublicKey())
+        assertContentEquals(privateKey, ContextManagerImpl.getPrivateKey())
         assertFalse { ContextManagerImpl.isCertificateChainInvalidOrExpired() }
         assertTrue { ContextManagerImpl.isKeyPairVerified() }
     }

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/clients/AccountClientTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/clients/AccountClientTest.kt
@@ -4,6 +4,7 @@ import com.doordeck.multiplatform.sdk.IntegrationTest
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_EMAIL
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_ID
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_PASSWORD
+import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_PRIVATE_KEY
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_PUBLIC_KEY
 import com.doordeck.multiplatform.sdk.context.ContextManagerImpl
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
@@ -12,7 +13,6 @@ import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -49,16 +49,21 @@ class AccountClientTest : IntegrationTest() {
     fun shouldRegisterEphemeralKey() = runTest {
         // Given
         AccountlessClient.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
-        val key = TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray()
+        val publicKey = TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray()
+        val privateKey = TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()
 
         // When
-        val result = AccountClient.registerEphemeralKeyRequest(key)
+        val result = AccountClient.registerEphemeralKeyRequest(publicKey, privateKey)
 
         // Then
         assertTrue { result.certificateChain.isNotEmpty() }
         assertEquals(TEST_MAIN_USER_ID, result.userId)
-        assertNotNull(ContextManagerImpl.getCertificateChain())
+        assertEquals(result.userId, ContextManagerImpl.getUserId())
+        assertEquals(result.certificateChain, ContextManagerImpl.getCertificateChain())
+        assertEquals(publicKey, ContextManagerImpl.getPublicKey())
+        assertEquals(privateKey, ContextManagerImpl.getPrivateKey())
         assertFalse { ContextManagerImpl.isCertificateChainInvalidOrExpired() }
+        assertTrue { ContextManagerImpl.isKeyPairVerified() }
     }
 
     @Test

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/clients/AccountClientTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/clients/AccountClientTest.kt
@@ -57,8 +57,6 @@ class AccountClientTest : IntegrationTest() {
         val result = AccountClient.registerEphemeralKeyRequest(publicKey, privateKey)
 
         // Then
-        println("isCertificateChainInvalidOrExpired: ${ContextManagerImpl.isCertificateChainInvalidOrExpired()}")
-        println("isKeyPairVerified: ${ContextManagerImpl.isKeyPairVerified()}")
         assertTrue { result.certificateChain.isNotEmpty() }
         assertEquals(TEST_MAIN_USER_ID, result.userId)
         assertEquals(result.userId, ContextManagerImpl.getUserId())

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/clients/LockOperationsClientTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/clients/LockOperationsClientTest.kt
@@ -332,7 +332,10 @@ class LockOperationsClientTest : IntegrationTest() {
     fun shouldUnlock() = runTest {
         // Given
         AccountlessClient.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
-        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray())
+        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(
+            publicKey = TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
+            privateKey = TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()
+        )
             .certificateChain
             .certificateChainToString()
         val baseOperation = LockOperations.BaseOperation(
@@ -350,7 +353,10 @@ class LockOperationsClientTest : IntegrationTest() {
     fun shouldUnlockUsingContext() = runTest {
         // Given
         AccountlessClient.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
-        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray())
+        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(
+            publicKey = TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
+            privateKey = TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()
+        )
             .certificateChain
             .certificateChainToString()
         ContextManagerImpl.setOperationContext(
@@ -368,7 +374,10 @@ class LockOperationsClientTest : IntegrationTest() {
     fun shouldShareAndRevokeLock() = runTest {
         // Given - shouldShareLock
         AccountlessClient.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
-        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray())
+        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(
+            publicKey = TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
+            privateKey = TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()
+        )
             .certificateChain
             .certificateChainToString()
         val shareBaseOperation = LockOperations.BaseOperation(
@@ -417,7 +426,10 @@ class LockOperationsClientTest : IntegrationTest() {
     fun shouldBatchShareAndRevokeLock() = runTest {
         // Given - shouldShareLockUsingContext
         AccountlessClient.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
-        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray())
+        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(
+            publicKey = TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
+            privateKey = TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()
+        )
             .certificateChain
             .certificateChainToString()
         val shareBaseOperation = LockOperations.BaseOperation(
@@ -487,7 +499,10 @@ class LockOperationsClientTest : IntegrationTest() {
     fun shouldShareAndRevokeLockUsingContext() = runTest {
         // Given - shouldShareLockUsingContext
         AccountlessClient.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
-        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray())
+        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(
+            publicKey = TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
+            privateKey = TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()
+        )
             .certificateChain
             .certificateChainToString()
         ContextManagerImpl.setOperationContext(
@@ -530,7 +545,10 @@ class LockOperationsClientTest : IntegrationTest() {
     fun shouldBatchShareAndRevokeLockUsingContext() = runTest {
         // Given - shouldShareLockUsingContext
         AccountlessClient.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
-        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray())
+        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(
+            publicKey = TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
+            privateKey = TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()
+        )
             .certificateChain
             .certificateChainToString()
         ContextManagerImpl.setOperationContext(
@@ -594,7 +612,10 @@ class LockOperationsClientTest : IntegrationTest() {
     fun shouldUpdateSecureSettingUnlockDuration() = runTest {
         // Given
         AccountlessClient.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
-        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray())
+        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(
+            publicKey = TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
+            privateKey = TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()
+        )
             .certificateChain
             .certificateChainToString()
         val updatedUnlockDuration = Random.nextInt(30, 60)
@@ -621,7 +642,10 @@ class LockOperationsClientTest : IntegrationTest() {
     fun shouldUpdateSecureSettingUnlockDurationUsingContext() = runTest {
         // Given
         AccountlessClient.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
-        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray())
+        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(
+            publicKey = TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
+            privateKey = TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()
+        )
             .certificateChain
             .certificateChainToString()
         val updatedUnlockDuration = 1
@@ -649,7 +673,10 @@ class LockOperationsClientTest : IntegrationTest() {
     fun shouldUpdateAndRemoveSecureSettingUnlockBetween() = runTest {
         // Given
         AccountlessClient.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
-        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray())
+        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(
+            publicKey = TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
+            privateKey = TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()
+        )
             .certificateChain
             .certificateChainToString()
         val now = Clock.System.now()
@@ -708,7 +735,10 @@ class LockOperationsClientTest : IntegrationTest() {
     fun shouldUpdateAndRemoveSecureSettingUnlockBetweenUsingContext() = runTest {
         // Given
         AccountlessClient.loginRequest(TEST_MAIN_USER_EMAIL, TEST_MAIN_USER_PASSWORD)
-        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray())
+        val TEST_MAIN_USER_CERTIFICATE_CHAIN = AccountClient.registerEphemeralKeyRequest(
+            publicKey = TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
+            privateKey = TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()
+        )
             .certificateChain
             .certificateChainToString()
         val now = Clock.System.now()

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/clients/PlatformClientTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/clients/PlatformClientTest.kt
@@ -145,7 +145,7 @@ class PlatformClientTest : IntegrationTest() {
         assertEquals(updatedApplicationLogoUrl, application.logoUrl)
 
         // Given - shouldAddAuthIssuer
-        val addedApplicationAuthIssuer = "https://test.com"
+        val addedApplicationAuthIssuer = "https://${Uuid.random()}.com"
 
         // When
         PlatformClient.addAuthIssuerRequest(application.applicationId, addedApplicationAuthIssuer)
@@ -167,7 +167,7 @@ class PlatformClientTest : IntegrationTest() {
         assertFalse { application!!.authDomains!!.any { it.equals(removedApplicationAuthIssuer, true) } }
 
         // Given - shouldAddCorsDomain
-        val addedApplicationCorsDomain = "https://test.com"
+        val addedApplicationCorsDomain = "https://${Uuid.random()}.com"
 
         // When
         PlatformClient.addCorsDomainRequest(application.applicationId, addedApplicationCorsDomain)

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerTest.kt
@@ -33,7 +33,7 @@ class ContextManagerTest : IntegrationTest() {
         val certificateChain = (1..3).map { Uuid.random().toString() }
         val publicKey = Uuid.random().toString().encodeToByteArray()
         val privateKey = Uuid.random().toString().encodeToByteArray()
-        val keyPairVerified = randomBoolean()
+        val keyPairVerified = publicKey
         val settings = DefaultSecureStorage(MemorySettings())
         ContextManagerImpl.apply {
             setSecureStorageImpl(settings)
@@ -62,7 +62,7 @@ class ContextManagerTest : IntegrationTest() {
         assertContentEquals(privateKey, ContextManagerImpl.getPrivateKey())
         assertContentEquals(publicKey, ContextManagerImpl.getKeyPair()?.public)
         assertContentEquals(privateKey, ContextManagerImpl.getKeyPair()?.private)
-        assertEquals(keyPairVerified, ContextManagerImpl.isKeyPairVerified())
+        assertTrue { ContextManagerImpl.isKeyPairVerified() }
         assertEquals(cloudAuthToken, ContextManagerImpl.getCloudAuthToken())
         assertEquals(cloudRefreshToken, ContextManagerImpl.getCloudRefreshToken())
         assertEquals(fusionAuthToken, ContextManagerImpl.getFusionAuthToken())
@@ -80,7 +80,7 @@ class ContextManagerTest : IntegrationTest() {
         val certificateChain = (1..3).map { Uuid.random().toString() }
         val publicKey = Uuid.random().toString().encodeToByteArray()
         val privateKey = Uuid.random().toString().encodeToByteArray()
-        val keyPairVerified = randomBoolean()
+        val keyPairVerified = publicKey
         ContextManagerImpl.apply {
             setApiEnvironment(apiEnvironment)
             setCloudAuthToken(cloudAuthToken)

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerTest.kt
@@ -1,10 +1,12 @@
 package com.doordeck.multiplatform.sdk.context
 
+import com.doordeck.multiplatform.sdk.Constants.DEFAULT_FUSION_HOST
 import com.doordeck.multiplatform.sdk.IntegrationTest
 import com.doordeck.multiplatform.sdk.crypto.CryptoManager
+import com.doordeck.multiplatform.sdk.model.common.ContextState
 import com.doordeck.multiplatform.sdk.model.data.ApiEnvironment
 import com.doordeck.multiplatform.sdk.model.data.Context
-import com.doordeck.multiplatform.sdk.randomBoolean
+import com.doordeck.multiplatform.sdk.randomString
 import com.doordeck.multiplatform.sdk.storage.DefaultSecureStorage
 import com.doordeck.multiplatform.sdk.storage.MemorySettings
 import com.doordeck.multiplatform.sdk.util.Utils.certificateChainToString
@@ -25,6 +27,7 @@ class ContextManagerTest : IntegrationTest() {
     fun shouldStoreAndLoadContext() = runTest {
         // Given
         val apiEnvironment = ApiEnvironment.entries.random()
+        val fusionHost = "https://${Uuid.random()}.com"
         val cloudAuthToken = Uuid.random().toString()
         val cloudRefreshToken = Uuid.random().toString()
         val fusionAuthToken = Uuid.random().toString()
@@ -40,6 +43,7 @@ class ContextManagerTest : IntegrationTest() {
             setApiEnvironment(apiEnvironment)
             setCloudAuthToken(cloudAuthToken)
             setCloudRefreshToken(cloudRefreshToken)
+            setFusionHost(fusionHost)
             setFusionAuthToken(fusionAuthToken)
             setUserId(userId)
             setCertificateChain(certificateChain)
@@ -66,12 +70,14 @@ class ContextManagerTest : IntegrationTest() {
         assertEquals(cloudAuthToken, ContextManagerImpl.getCloudAuthToken())
         assertEquals(cloudRefreshToken, ContextManagerImpl.getCloudRefreshToken())
         assertEquals(fusionAuthToken, ContextManagerImpl.getFusionAuthToken())
+        assertEquals(fusionHost, ContextManagerImpl.getFusionHost())
     }
 
     @Test
     fun shouldClearContext() = runTest {
         // Given
         val apiEnvironment = ApiEnvironment.entries.random()
+        val fusionHost = "https://${Uuid.random()}.com"
         val cloudAuthToken = Uuid.random().toString()
         val cloudRefreshToken = Uuid.random().toString()
         val fusionAuthToken = Uuid.random().toString()
@@ -85,6 +91,7 @@ class ContextManagerTest : IntegrationTest() {
             setApiEnvironment(apiEnvironment)
             setCloudAuthToken(cloudAuthToken)
             setCloudRefreshToken(cloudRefreshToken)
+            setFusionHost(fusionHost)
             setFusionAuthToken(fusionAuthToken)
             setUserId(userId)
             setCertificateChain(certificateChain)
@@ -109,6 +116,7 @@ class ContextManagerTest : IntegrationTest() {
         assertNull(ContextManagerImpl.getCloudAuthToken())
         assertNull(ContextManagerImpl.getCloudRefreshToken())
         assertNull(ContextManagerImpl.getFusionAuthToken())
+        assertEquals(DEFAULT_FUSION_HOST, ContextManagerImpl.getFusionHost())
     }
 
     @Test
@@ -199,10 +207,24 @@ class ContextManagerTest : IntegrationTest() {
     }
 
     @Test
-    fun shouldCheckKeyPairInvalidValidity() = runTest {
+    fun shouldCheckKeyPairValidityWithInvalidKeys() = runTest {
         // Given
         val publicKey = Uuid.random().toString().encodeToByteArray()
         val privateKey = Uuid.random().toString().encodeToByteArray()
+        ContextManagerImpl.setKeyPair(publicKey, privateKey)
+
+        // When
+        val result = ContextManagerImpl.isKeyPairValid()
+
+        // Then
+        assertFalse { result }
+    }
+
+    @Test
+    fun shouldCheckKeyPairValidityWithNonMatchingKeys() = runTest {
+        // Given
+        val publicKey = CryptoManager.generateKeyPair().public
+        val privateKey = CryptoManager.generateKeyPair().private
         ContextManagerImpl.setKeyPair(publicKey, privateKey)
 
         // When
@@ -235,5 +257,75 @@ class ContextManagerTest : IntegrationTest() {
 
         // Then
         assertEquals(apiEnvironment, ContextManagerImpl.getApiEnvironment())
+    }
+
+    @Test
+    fun shouldGetContextStateCloudTokenIsInvalid() = runTest {
+        // Given
+        ContextManagerImpl.setCloudAuthToken(randomString())
+
+        // When
+        val result = ContextManagerImpl.getContextState()
+
+        // Then
+        assertEquals(ContextState.CLOUD_TOKEN_IS_INVALID_OR_EXPIRED, result)
+    }
+
+    @Test
+    fun shouldGetContextStateKeyPairIsInvalid() = runTest {
+        // Given
+        ContextManagerImpl.setCloudAuthToken("eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjQwMzhmODE5MmZmMTZiMGQ4N2E3OWYyZjFlOTYyZWIwIn0.eyJleHAiOiIyNTUzNzczMjYxIn0.0O36vfj7QasI-PkE3qEqg4Vm1lF4vGxmmJzso7zLp23qmljOuBd6NaknPG9ZxxIo5WEbaJrgN8zAuRxtA8sYzA")
+
+        // When
+        val result = ContextManagerImpl.getContextState()
+
+        // Then
+        assertEquals(ContextState.KEY_PAIR_IS_INVALID, result)
+    }
+
+    @Test
+    fun shouldGetContextStateKeyPairIsNotVerified() = runTest {
+        // Given
+        val keyPair = CryptoManager.generateKeyPair()
+        ContextManagerImpl.setCloudAuthToken("eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjQwMzhmODE5MmZmMTZiMGQ4N2E3OWYyZjFlOTYyZWIwIn0.eyJleHAiOiIyNTUzNzczMjYxIn0.0O36vfj7QasI-PkE3qEqg4Vm1lF4vGxmmJzso7zLp23qmljOuBd6NaknPG9ZxxIo5WEbaJrgN8zAuRxtA8sYzA")
+        ContextManagerImpl.setKeyPair(keyPair.public, keyPair.private)
+
+        // When
+        val result = ContextManagerImpl.getContextState()
+
+        // Then
+        assertEquals(ContextState.KEY_PAIR_IS_NOT_VERIFIED, result)
+    }
+
+    @Test
+    fun shouldGetContextStateCertificateChainIsInvalid() = runTest {
+        // Given
+        val keyPair = CryptoManager.generateKeyPair()
+        ContextManagerImpl.setCloudAuthToken("eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjQwMzhmODE5MmZmMTZiMGQ4N2E3OWYyZjFlOTYyZWIwIn0.eyJleHAiOiIyNTUzNzczMjYxIn0.0O36vfj7QasI-PkE3qEqg4Vm1lF4vGxmmJzso7zLp23qmljOuBd6NaknPG9ZxxIo5WEbaJrgN8zAuRxtA8sYzA")
+        ContextManagerImpl.setKeyPair(keyPair.public, keyPair.private)
+        ContextManagerImpl.setKeyPairVerified(keyPair.public)
+        ContextManagerImpl.setCertificateChain(listOf(Uuid.random().toString()))
+
+        // When
+        val result = ContextManagerImpl.getContextState()
+
+        // Then
+        assertEquals(ContextState.CERTIFICATE_CHAIN_IS_INVALID_OR_EXPIRED, result)
+    }
+
+    @Test
+    fun shouldGetContextStateReady() = runTest {
+        // Given
+        val keyPair = CryptoManager.generateKeyPair()
+        ContextManagerImpl.setCloudAuthToken("eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjQwMzhmODE5MmZmMTZiMGQ4N2E3OWYyZjFlOTYyZWIwIn0.eyJleHAiOiIyNTUzNzczMjYxIn0.0O36vfj7QasI-PkE3qEqg4Vm1lF4vGxmmJzso7zLp23qmljOuBd6NaknPG9ZxxIo5WEbaJrgN8zAuRxtA8sYzA")
+        ContextManagerImpl.setKeyPair(keyPair.public, keyPair.private)
+        ContextManagerImpl.setKeyPairVerified(keyPair.public)
+        ContextManagerImpl.setCertificateChain(listOf("MIICVDCCAb2gAwIBAgIBADANBgkqhkiG9w0BAQ0FADBHMQswCQYDVQQGEwJlczESMBAGA1UECAwJQmFyY2Vsb25hMREwDwYDVQQKDAhEb29yZGVjazERMA8GA1UEAwwIRG9vcmRlY2swHhcNMjUwNzA4MjA0NzI4WhcNMjcwNzA4MjA0NzI4WjBHMQswCQYDVQQGEwJlczESMBAGA1UECAwJQmFyY2Vsb25hMREwDwYDVQQKDAhEb29yZGVjazERMA8GA1UEAwwIRG9vcmRlY2swgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKG708ApCnAtbuJZzlgfqK8K39JPbb5Mrd1RRkGCJ6B6LV9nDudu53sUCxt8WT/xWIF3KUThbLNOqX3ZDN/agJbJTeh/T62TxiWmWE3LFyrqz2xQ7Jpfg807Hj0KPjJxdfpY6Btg+RP2+rHzjbvYsu950/l2ymfuU3xMYt/OSvUrAgMBAAGjUDBOMB0GA1UdDgQWBBQsomoEUylwegTctRzxee21JVD4xTAfBgNVHSMEGDAWgBQsomoEUylwegTctRzxee21JVD4xTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBDQUAA4GBACrKh/QepnoYS7YVIjmUkoPGyZHsm0Rww5R00cryat5uhpt8Fp3IZ1PTJ83OHl1P6yl6bATZTTls Mc0Tk9GLTLMZl0qh4gXevU8jpGTi2Dv9AqKmTio1m8va5EgQfhkT/efnxQPQfCyvxo/j4xah2uBdGDtlwm2q+XF7ClZyAZBO"))
+
+        // When
+        val result = ContextManagerImpl.getContextState()
+
+        // Then
+        assertEquals(ContextState.READY, result)
     }
 }

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/storage/MigrationTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/storage/MigrationTest.kt
@@ -1,6 +1,8 @@
 package com.doordeck.multiplatform.sdk.storage
 
 import com.doordeck.multiplatform.sdk.randomBoolean
+import com.doordeck.multiplatform.sdk.storage.migrations.Migrate0To1
+import com.doordeck.multiplatform.sdk.storage.migrations.Migrations
 import com.russhwolf.settings.contains
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -13,6 +15,7 @@ class MigrationTest {
     @Test
     fun shouldMigrateStorageTest() = runTest {
         // Given
+        Migrations.overrideMigrations(listOf(Migrate0To1))
         val deprecatedKey = "KEY_PAIR_VERIFIED"
         val newKey = "KEY_PAIR_VERIFIED_KEY"
         val verified = randomBoolean()
@@ -33,6 +36,7 @@ class MigrationTest {
     @Test
     fun shouldNotRunMigrationsTest() = runTest {
         // Given
+        Migrations.overrideMigrations(listOf(Migrate0To1))
         val key = "STORAGE_VERSION_KEY"
         val newKey = "KEY_PAIR_VERIFIED_KEY"
         val settings = MemorySettings().apply {

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/storage/MigrationTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/storage/MigrationTest.kt
@@ -1,8 +1,11 @@
 package com.doordeck.multiplatform.sdk.storage
 
 import com.doordeck.multiplatform.sdk.randomBoolean
+import com.doordeck.multiplatform.sdk.randomByteArray
 import com.doordeck.multiplatform.sdk.storage.migrations.Migrate0To1
+import com.doordeck.multiplatform.sdk.storage.migrations.Migrate1To2
 import com.doordeck.multiplatform.sdk.storage.migrations.Migrations
+import com.doordeck.multiplatform.sdk.util.Utils.encodeByteArrayToBase64
 import com.russhwolf.settings.contains
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -13,7 +16,7 @@ import kotlin.test.assertTrue
 class MigrationTest {
 
     @Test
-    fun shouldMigrateStorageTest() = runTest {
+    fun shouldMigrate0To1Test() = runTest {
         // Given
         Migrations.overrideMigrations(listOf(Migrate0To1))
         val deprecatedKey = "KEY_PAIR_VERIFIED"
@@ -31,6 +34,28 @@ class MigrationTest {
         assertFalse { settings.contains(deprecatedKey) }
         assertTrue { settings.contains(newKey) }
         assertEquals(verified, settings.getBooleanOrNull(newKey))
+    }
+
+    @Test
+    fun shouldMigrate1To2Test() = runTest {
+        // Given
+        Migrations.overrideMigrations(listOf(Migrate1To2))
+        val deprecatedKey = "KEY_PAIR_VERIFIED_KEY"
+        val newKey = "VERIFIED_KEY_PAIR_KEY"
+        val key = randomByteArray().encodeByteArrayToBase64()
+        val settings = MemorySettings().apply {
+            putBoolean(deprecatedKey, true)
+            putString("PUBLIC_KEY_KEY", key)
+        }
+
+        // When
+        val storage = DefaultSecureStorage(settings)
+
+        // Then
+        assertEquals(2, storage.getStorageVersion())
+        assertFalse { settings.contains(deprecatedKey) }
+        assertTrue { settings.contains(newKey) }
+        assertEquals(key, settings.getStringOrNull(newKey))
     }
 
     @Test

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/util/KeyPairUtilsTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/util/KeyPairUtilsTest.kt
@@ -1,0 +1,49 @@
+package com.doordeck.multiplatform.sdk.util
+
+import com.doordeck.multiplatform.sdk.crypto.CryptoManager
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class KeyPairUtilsTest {
+
+    @Test
+    fun shouldCheckValidKeyPair() = runTest {
+        // Given
+        val keyPair = CryptoManager.generateKeyPair()
+
+        // When
+        val result = KeyPairUtils.isKeyPairValid(keyPair.public, keyPair.private)
+
+        // Then
+        assertTrue { result }
+    }
+
+    @Test
+    fun shouldCheckInvalidKeys() = runTest {
+        // Given
+        val publicKey = Uuid.random().toString().encodeToByteArray()
+        val privateKey = Uuid.random().toString().encodeToByteArray()
+
+        // When
+        val result = KeyPairUtils.isKeyPairValid(publicKey, privateKey)
+
+        // Then
+        assertFalse { result }
+    }
+
+    @Test
+    fun shouldCheckInvalidKeyPair() = runTest {
+        // Given
+        val publicKey = CryptoManager.generateKeyPair().public
+        val privateKey = CryptoManager.generateKeyPair().private
+
+        // When
+        val result = KeyPairUtils.isKeyPairValid(publicKey, privateKey)
+
+        // Then
+        assertFalse { result }
+    }
+}

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.js.kt
@@ -47,8 +47,8 @@ actual object AccountApi {
     /**
      * @see AccountClient.verifyEphemeralKeyRegistrationRequest
      */
-    fun verifyEphemeralKeyRegistration(code: String, privateKey: ByteArray? = null): Promise<RegisterEphemeralKeyResponse> {
-        return promise { AccountClient.verifyEphemeralKeyRegistrationRequest(code, privateKey) }
+    fun verifyEphemeralKeyRegistration(code: String, publicKey: ByteArray? = null, privateKey: ByteArray? = null): Promise<RegisterEphemeralKeyResponse> {
+        return promise { AccountClient.verifyEphemeralKeyRegistrationRequest(code, publicKey, privateKey) }
     }
 
     /**

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.js.kt
@@ -33,8 +33,8 @@ actual object AccountApi {
     /**
      * @see AccountClient.registerEphemeralKeyRequest
      */
-    fun registerEphemeralKey(publicKey: ByteArray? = null): Promise<RegisterEphemeralKeyResponse> {
-        return promise { AccountClient.registerEphemeralKeyRequest(publicKey) }
+    fun registerEphemeralKey(publicKey: ByteArray? = null, privateKey: ByteArray? = null): Promise<RegisterEphemeralKeyResponse> {
+        return promise { AccountClient.registerEphemeralKeyRequest(publicKey, privateKey) }
     }
 
     /**

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/api/HelperApi.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/api/HelperApi.js.kt
@@ -28,8 +28,8 @@ actual object HelperApi {
     /**
      * @see HelperClient.assistedRegisterEphemeralKeyRequest
      */
-    fun assistedRegisterEphemeralKey(publicKey: ByteArray? = null): Promise<AssistedRegisterEphemeralKeyResponse> {
-        return promise { HelperClient.assistedRegisterEphemeralKeyRequest(publicKey) }
+    fun assistedRegisterEphemeralKey(publicKey: ByteArray? = null, privateKey: ByteArray? = null): Promise<AssistedRegisterEphemeralKeyResponse> {
+        return promise { HelperClient.assistedRegisterEphemeralKeyRequest(publicKey, privateKey) }
     }
 
     /**

--- a/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.js.kt
+++ b/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.js.kt
@@ -5,6 +5,7 @@ import com.doordeck.multiplatform.sdk.REGISTER_EPHEMERAL_KEY_RESPONSE
 import com.doordeck.multiplatform.sdk.REGISTER_EPHEMERAL_KEY_WITH_SECONDARY_AUTHENTICATION_RESPONSE
 import com.doordeck.multiplatform.sdk.TOKEN_RESPONSE
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_PRIVATE_KEY
+import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_PUBLIC_KEY
 import com.doordeck.multiplatform.sdk.USER_DETAILS_RESPONSE
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
 import kotlinx.coroutines.await
@@ -57,7 +58,7 @@ class AccountApiTest : MockTest() {
 
     @Test
     fun shouldVerifyEphemeralKeyRegistration() = runTest {
-        val response = AccountApi.verifyEphemeralKeyRegistration("", TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()).await()
+        val response = AccountApi.verifyEphemeralKeyRegistration("", TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(), TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()).await()
         assertEquals(REGISTER_EPHEMERAL_KEY_RESPONSE, response)
     }
 

--- a/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.js.kt
+++ b/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.js.kt
@@ -33,7 +33,7 @@ class AccountApiTest : MockTest() {
 
     @Test
     fun shouldRegisterEphemeralKey() = runTest {
-        val response = AccountApi.registerEphemeralKey(byteArrayOf()).await()
+        val response = AccountApi.registerEphemeralKey(byteArrayOf(), byteArrayOf()).await()
         assertEquals(REGISTER_EPHEMERAL_KEY_RESPONSE, response)
     }
 

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.jvm.kt
@@ -83,9 +83,10 @@ actual object AccountApi {
      */
     suspend fun verifyEphemeralKeyRegistration(
         code: String,
+        publicKey: ByteArray? = null,
         privateKey: ByteArray? = null
     ): RegisterEphemeralKeyResponse {
-        return AccountClient.verifyEphemeralKeyRegistrationRequest(code, privateKey)
+        return AccountClient.verifyEphemeralKeyRegistrationRequest(code, publicKey, privateKey)
     }
 
     /**
@@ -93,9 +94,10 @@ actual object AccountApi {
      */
     fun verifyEphemeralKeyRegistrationAsync(
         code: String,
+        publicKey: ByteArray? = null,
         privateKey: ByteArray? = null
     ): CompletableFuture<RegisterEphemeralKeyResponse> {
-        return completableFuture { verifyEphemeralKeyRegistration(code, privateKey) }
+        return completableFuture { verifyEphemeralKeyRegistration(code, publicKey, privateKey) }
     }
 
     /**

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.jvm.kt
@@ -47,15 +47,15 @@ actual object AccountApi {
     /**
      * @see AccountClient.registerEphemeralKeyRequest
      */
-    suspend fun registerEphemeralKey(publicKey: ByteArray? = null): RegisterEphemeralKeyResponse {
-        return AccountClient.registerEphemeralKeyRequest(publicKey)
+    suspend fun registerEphemeralKey(publicKey: ByteArray? = null, privateKey: ByteArray? = null): RegisterEphemeralKeyResponse {
+        return AccountClient.registerEphemeralKeyRequest(publicKey, privateKey)
     }
 
     /**
      * Async variant of [AccountApi.registerEphemeralKey] returning [CompletableFuture].
      */
-    fun registerEphemeralKeyAsync(publicKey: ByteArray? = null): CompletableFuture<RegisterEphemeralKeyResponse> {
-        return completableFuture { registerEphemeralKey(publicKey) }
+    fun registerEphemeralKeyAsync(publicKey: ByteArray? = null, privateKey: ByteArray? = null): CompletableFuture<RegisterEphemeralKeyResponse> {
+        return completableFuture { registerEphemeralKey(publicKey, privateKey) }
     }
 
     /**

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/api/HelperApi.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/api/HelperApi.jvm.kt
@@ -41,15 +41,15 @@ actual object HelperApi {
     /**
      * @see HelperClient.assistedRegisterEphemeralKeyRequest
      */
-    suspend fun assistedRegisterEphemeralKey(publicKey: ByteArray? = null): AssistedRegisterEphemeralKeyResponse {
-        return HelperClient.assistedRegisterEphemeralKeyRequest(publicKey)
+    suspend fun assistedRegisterEphemeralKey(publicKey: ByteArray? = null, privateKey: ByteArray? = null): AssistedRegisterEphemeralKeyResponse {
+        return HelperClient.assistedRegisterEphemeralKeyRequest(publicKey, privateKey)
     }
 
     /**
      * Async variant of [HelperApi.assistedRegisterEphemeralKey] returning [CompletableFuture].
      */
-    fun assistedRegisterEphemeralKeyAsync(publicKey: ByteArray? = null): CompletableFuture<AssistedRegisterEphemeralKeyResponse> {
-        return completableFuture { assistedRegisterEphemeralKey(publicKey) }
+    fun assistedRegisterEphemeralKeyAsync(publicKey: ByteArray? = null, privateKey: ByteArray? = null): CompletableFuture<AssistedRegisterEphemeralKeyResponse> {
+        return completableFuture { assistedRegisterEphemeralKey(publicKey, privateKey) }
     }
 
     /**

--- a/doordeck-sdk/src/jvmTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.jvm.kt
+++ b/doordeck-sdk/src/jvmTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.jvm.kt
@@ -50,13 +50,13 @@ class AccountApiTest : MockTest() {
 
     @Test
     fun shouldRegisterEphemeralKey() = runTest {
-        val response = AccountApi.registerEphemeralKey(byteArrayOf())
+        val response = AccountApi.registerEphemeralKey(byteArrayOf(), byteArrayOf())
         assertEquals(REGISTER_EPHEMERAL_KEY_RESPONSE, response)
     }
 
     @Test
     fun shouldRegisterEphemeralKeyAsync() = runTest {
-        val response = AccountApi.registerEphemeralKeyAsync(byteArrayOf()).await()
+        val response = AccountApi.registerEphemeralKeyAsync(byteArrayOf(), byteArrayOf()).await()
         assertEquals(REGISTER_EPHEMERAL_KEY_RESPONSE, response)
     }
 

--- a/doordeck-sdk/src/jvmTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.jvm.kt
+++ b/doordeck-sdk/src/jvmTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.jvm.kt
@@ -5,6 +5,7 @@ import com.doordeck.multiplatform.sdk.REGISTER_EPHEMERAL_KEY_RESPONSE
 import com.doordeck.multiplatform.sdk.REGISTER_EPHEMERAL_KEY_WITH_SECONDARY_AUTHENTICATION_RESPONSE
 import com.doordeck.multiplatform.sdk.TOKEN_RESPONSE
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_PRIVATE_KEY
+import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_PUBLIC_KEY
 import com.doordeck.multiplatform.sdk.USER_DETAILS_RESPONSE
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
 import kotlinx.coroutines.future.await
@@ -98,13 +99,13 @@ class AccountApiTest : MockTest() {
 
     @Test
     fun shouldVerifyEphemeralKeyRegistration() = runTest {
-        val response = AccountApi.verifyEphemeralKeyRegistration("", TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray())
+        val response = AccountApi.verifyEphemeralKeyRegistration("", TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(), TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray())
         assertEquals(REGISTER_EPHEMERAL_KEY_RESPONSE, response)
     }
 
     @Test
     fun shouldVerifyEphemeralKeyRegistrationAsync() = runTest {
-        val response = AccountApi.verifyEphemeralKeyRegistrationAsync("", TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()).await()
+        val response = AccountApi.verifyEphemeralKeyRegistrationAsync("", TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(), TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray()).await()
         assertEquals(REGISTER_EPHEMERAL_KEY_RESPONSE, response)
     }
 

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.mingw.kt
@@ -94,6 +94,7 @@ actual object AccountApi {
                 val verifyEphemeralKeyRegistrationData = data.fromJson<VerifyEphemeralKeyRegistrationData>()
                 AccountClient.verifyEphemeralKeyRegistrationRequest(
                     code = verifyEphemeralKeyRegistrationData.code,
+                    publicKey = verifyEphemeralKeyRegistrationData.publicKey?.decodeBase64ToByteArray(),
                     privateKey = verifyEphemeralKeyRegistrationData.privateKey?.decodeBase64ToByteArray()
                 )
             },

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/HelperApi.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/HelperApi.mingw.kt
@@ -45,7 +45,10 @@ actual object HelperApi {
         callback(
             block = {
                 val assistedRegisterEphemeralKeyData = data?.fromJson<AssistedRegisterEphemeralKeyData>()
-                HelperClient.assistedRegisterEphemeralKeyRequest(assistedRegisterEphemeralKeyData?.publicKey?.decodeBase64ToByteArray())
+                HelperClient.assistedRegisterEphemeralKeyRequest(
+                    publicKey = assistedRegisterEphemeralKeyData?.publicKey?.decodeBase64ToByteArray(),
+                    privateKey = assistedRegisterEphemeralKeyData?.privateKey?.decodeBase64ToByteArray()
+                )
             },
             callback = callback
         )

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/model/data/AccountData.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/model/data/AccountData.mingw.kt
@@ -22,6 +22,7 @@ data class RegisterEphemeralKeyWithSecondaryAuthenticationData(
 @Serializable
 data class VerifyEphemeralKeyRegistrationData(
     val code: String,
+    val publicKey: String? = null,
     val privateKey: String? = null
 )
 

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/model/data/HelperData.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/model/data/HelperData.mingw.kt
@@ -17,7 +17,8 @@ data class AssistedLoginData(
 
 @Serializable
 data class AssistedRegisterEphemeralKeyData(
-    val publicKey: String
+    val publicKey: String,
+    val privateKey: String
 )
 
 @Serializable

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.mingw.kt
@@ -45,6 +45,8 @@ fun createMingwSecureStorage(
     getFusionHostCp: getStringCallback,
     addFusionAuthTokenCp: setStringCallback,
     getFusionAuthTokenCp: getStringCallback,
+    addTempPublicKeyCp: setNullableStringCallback,
+    getTempPublicKeyCp: getStringCallback,
     addPublicKeyCp: setStringCallback,
     getPublicKeyCp: getStringCallback,
     addPrivateKeyCp: setStringCallback,
@@ -70,6 +72,8 @@ fun createMingwSecureStorage(
         getFusionHostCp = getFusionHostCp,
         addFusionAuthTokenCp = addFusionAuthTokenCp,
         getFusionAuthTokenCp = getFusionAuthTokenCp,
+        addTempPublicKeyCp = addTempPublicKeyCp,
+        getTempPublicKeyCp = getTempPublicKeyCp,
         addPublicKeyCp = addPublicKeyCp,
         getPublicKeyCp = getPublicKeyCp,
         addPrivateKeyCp = addPrivateKeyCp,
@@ -97,6 +101,8 @@ class MingwSecureStorage(
     private val getFusionHostCp: getStringCallback,
     private val addFusionAuthTokenCp: setStringCallback,
     private val getFusionAuthTokenCp: getStringCallback,
+    private val addTempPublicKeyCp: setNullableStringCallback,
+    private val getTempPublicKeyCp: getStringCallback,
     private val addPublicKeyCp: setStringCallback,
     private val getPublicKeyCp: getStringCallback,
     private val addPrivateKeyCp: setStringCallback,
@@ -154,16 +160,24 @@ class MingwSecureStorage(
         return getFusionAuthTokenCp()?.toKString()
     }
 
-    override fun addPublicKey(byteArray: ByteArray) {
-        addPublicKeyCp.invokeStringCallback(byteArray.encodeByteArrayToBase64())
+    override fun addTempPublicKey(publicKey: ByteArray?) {
+        addTempPublicKeyCp.invokeNullableStringCallback(publicKey?.encodeByteArrayToBase64())
+    }
+
+    override fun getTempPublicKey(): ByteArray? {
+        return getTempPublicKeyCp()?.toKString()?.decodeBase64ToByteArray()
+    }
+
+    override fun addPublicKey(publicKey: ByteArray) {
+        addPublicKeyCp.invokeStringCallback(publicKey.encodeByteArrayToBase64())
     }
 
     override fun getPublicKey(): ByteArray? {
         return getPublicKeyCp()?.toKString()?.decodeBase64ToByteArray()
     }
 
-    override fun addPrivateKey(byteArray: ByteArray) {
-        addPrivateKeyCp.invokeStringCallback(byteArray.encodeByteArrayToBase64())
+    override fun addPrivateKey(privateKey: ByteArray) {
+        addPrivateKeyCp.invokeStringCallback(privateKey.encodeByteArrayToBase64())
     }
 
     override fun getPrivateKey(): ByteArray? {

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.mingw.kt
@@ -45,8 +45,6 @@ fun createMingwSecureStorage(
     getFusionHostCp: getStringCallback,
     addFusionAuthTokenCp: setStringCallback,
     getFusionAuthTokenCp: getStringCallback,
-    addTempPublicKeyCp: setNullableStringCallback,
-    getTempPublicKeyCp: getStringCallback,
     addPublicKeyCp: setStringCallback,
     getPublicKeyCp: getStringCallback,
     addPrivateKeyCp: setStringCallback,
@@ -72,8 +70,6 @@ fun createMingwSecureStorage(
         getFusionHostCp = getFusionHostCp,
         addFusionAuthTokenCp = addFusionAuthTokenCp,
         getFusionAuthTokenCp = getFusionAuthTokenCp,
-        addTempPublicKeyCp = addTempPublicKeyCp,
-        getTempPublicKeyCp = getTempPublicKeyCp,
         addPublicKeyCp = addPublicKeyCp,
         getPublicKeyCp = getPublicKeyCp,
         addPrivateKeyCp = addPrivateKeyCp,
@@ -101,8 +97,6 @@ class MingwSecureStorage(
     private val getFusionHostCp: getStringCallback,
     private val addFusionAuthTokenCp: setStringCallback,
     private val getFusionAuthTokenCp: getStringCallback,
-    private val addTempPublicKeyCp: setNullableStringCallback,
-    private val getTempPublicKeyCp: getStringCallback,
     private val addPublicKeyCp: setStringCallback,
     private val getPublicKeyCp: getStringCallback,
     private val addPrivateKeyCp: setStringCallback,
@@ -158,14 +152,6 @@ class MingwSecureStorage(
 
     override fun getFusionAuthToken(): String? {
         return getFusionAuthTokenCp()?.toKString()
-    }
-
-    override fun addTempPublicKey(publicKey: ByteArray?) {
-        addTempPublicKeyCp.invokeNullableStringCallback(publicKey?.encodeByteArrayToBase64())
-    }
-
-    override fun getTempPublicKey(): ByteArray? {
-        return getTempPublicKeyCp()?.toKString()?.decodeBase64ToByteArray()
     }
 
     override fun addPublicKey(publicKey: ByteArray) {

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/storage/SecureStorage.mingw.kt
@@ -19,11 +19,17 @@ internal actual fun createSecureStorage(applicationContext: ApplicationContext?)
 }
 
 internal typealias setStringCallback = CPointer<CFunction<(CPointer<ByteVar>) -> Unit>>
+internal typealias setNullableStringCallback = CPointer<CFunction<(CPointer<ByteVar>?) -> Unit>>
 internal typealias getStringCallback = CPointer<CFunction<() -> CPointer<ByteVar>?>>
 internal typealias emptyCallback = CPointer<CFunction<() -> Unit>>
 
 internal fun setStringCallback.invokeStringCallback(string: String) = memScoped {
     val cString = string.cstr.ptr
+    invoke(cString)
+}
+
+internal fun setNullableStringCallback.invokeNullableStringCallback(string: String?) = memScoped {
+    val cString = string?.cstr?.ptr
     invoke(cString)
 }
 
@@ -43,7 +49,7 @@ fun createMingwSecureStorage(
     getPublicKeyCp: getStringCallback,
     addPrivateKeyCp: setStringCallback,
     getPrivateKeyCp: getStringCallback,
-    setKeyPairVerifiedCp: setStringCallback,
+    setKeyPairVerifiedCp: setNullableStringCallback,
     getKeyPairVerifiedCp: getStringCallback,
     addUserIdCp: setStringCallback,
     getUserIdCp: getStringCallback,
@@ -95,7 +101,7 @@ class MingwSecureStorage(
     private val getPublicKeyCp: getStringCallback,
     private val addPrivateKeyCp: setStringCallback,
     private val getPrivateKeyCp: getStringCallback,
-    private val setKeyPairVerifiedCp: setStringCallback,
+    private val setKeyPairVerifiedCp: setNullableStringCallback,
     private val getKeyPairVerifiedCp: getStringCallback,
     private val addUserIdCp: setStringCallback,
     private val getUserIdCp: getStringCallback,
@@ -164,12 +170,12 @@ class MingwSecureStorage(
         return getPrivateKeyCp()?.toKString()?.decodeBase64ToByteArray()
     }
 
-    override fun setKeyPairVerified(verified: Boolean) {
-        setKeyPairVerifiedCp.invokeStringCallback(verified.toString())
+    override fun setKeyPairVerified(publicKey: ByteArray?) {
+        setKeyPairVerifiedCp.invokeNullableStringCallback(publicKey?.toString())
     }
 
-    override fun getKeyPairVerified(): Boolean? {
-        return getKeyPairVerifiedCp()?.toKString()?.toBoolean()
+    override fun getKeyPairVerified(): ByteArray? {
+        return getKeyPairVerifiedCp()?.toKString()?.decodeBase64ToByteArray()
     }
 
     override fun addUserId(userId: String) {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/HelperResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/HelperResponses.cs
@@ -3,11 +3,11 @@ namespace Doordeck.Headless.Sdk.Model.Responses;
 public class AssistedLoginResponse
 {
     public bool RequiresVerification { get; set; }
-    public bool RequiresRetry { get; set; };
+    public bool RequiresRetry { get; set; }
 }
 
 public class AssistedRegisterEphemeralKeyResponse
 {
-    public bool RequiresVerification { get; set; };
-    public bool RequiresRetry { get; set; };
+    public bool RequiresVerification { get; set; }
+    public bool RequiresRetry { get; set; }
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/HelperResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/HelperResponses.cs
@@ -3,9 +3,11 @@ namespace Doordeck.Headless.Sdk.Model.Responses;
 public class AssistedLoginResponse
 {
     public bool RequiresVerification { get; set; }
+    public bool RequiresRetry { get; set; };
 }
 
 public class AssistedRegisterEphemeralKeyResponse
 {
-    public bool RequiresVerification { get; set; }
+    public bool RequiresVerification { get; set; };
+    public bool RequiresRetry { get; set; };
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Account.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Account.cs
@@ -14,8 +14,8 @@ public class Account(
     public unsafe Task<object> Logout() =>
         Process<object>(null, accountApi.logout_, null);
 
-    public unsafe Task<RegisterEphemeralKeyResponse> RegisterEphemeralKey(string? publicKey = null) =>
-        Process<RegisterEphemeralKeyResponse>(accountApi.registerEphemeralKey_, null, new { publicKey });
+    public unsafe Task<RegisterEphemeralKeyResponse> RegisterEphemeralKey(string? publicKey = null, string? privateKey = null) =>
+        Process<RegisterEphemeralKeyResponse>(accountApi.registerEphemeralKey_, null, new { publicKey, privateKey });
 
     public unsafe Task<RegisterEphemeralKeyWithSecondaryAuthenticationResponse> RegisterEphemeralKeyWithSecondaryAuthentication(string? publicKey = null, TwoFactorMethod? method = null) =>
         Process<RegisterEphemeralKeyWithSecondaryAuthenticationResponse>(accountApi.registerEphemeralKeyWithSecondaryAuthentication_, null, new { publicKey, method });

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Account.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Account.cs
@@ -20,8 +20,8 @@ public class Account(
     public unsafe Task<RegisterEphemeralKeyWithSecondaryAuthenticationResponse> RegisterEphemeralKeyWithSecondaryAuthentication(string? publicKey = null, TwoFactorMethod? method = null) =>
         Process<RegisterEphemeralKeyWithSecondaryAuthenticationResponse>(accountApi.registerEphemeralKeyWithSecondaryAuthentication_, null, new { publicKey, method });
 
-    public unsafe Task<RegisterEphemeralKeyResponse> VerifyEphemeralKeyRegistration(string code, string? privateKey = null) =>
-        Process<RegisterEphemeralKeyResponse>(accountApi.verifyEphemeralKeyRegistration_, null, new { code, privateKey });
+    public unsafe Task<RegisterEphemeralKeyResponse> VerifyEphemeralKeyRegistration(string code, string? publicKey = null, string? privateKey = null) =>
+        Process<RegisterEphemeralKeyResponse>(accountApi.verifyEphemeralKeyRegistration_, null, new { code, publicKey, privateKey });
 
     public unsafe Task<object> ReverifyEmail() =>
         Process<object>(null, accountApi.reverifyEmail_, null);

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
@@ -220,10 +220,7 @@ public unsafe class ContextManager(
 
     // GetKeyPair
 
-    public void SetKeyPairVerified(bool verified)
-    {
-        contextManager.setKeyPairVerified(context, Convert.ToByte(verified));
-    }
+    // SetKeyPairVerified
 
     public bool IsKeyPairVerified()
     {
@@ -235,9 +232,9 @@ public unsafe class ContextManager(
         return contextManager.isKeyPairValid_(context).ToBoolean();
     }
 
-    public void SetOperationContext(string userId, string userCertificateChain, string userPublicKey, string userPrivateKey)
+    public void SetOperationContext(string userId, string userCertificateChain, string userPublicKey, string userPrivateKey, bool isKeyPairVerified)
     {
-        var sData = new { userId, userCertificateChain, userPublicKey, userPrivateKey }.ToData();
+        var sData = new { userId, userCertificateChain, userPublicKey, userPrivateKey, isKeyPairVerified }.ToData();
         try
         {
             contextManager.setOperationContextJson_(context, sData);

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Helper.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Helper.cs
@@ -13,8 +13,8 @@ public class Helper(
     public unsafe Task<AssistedLoginResponse> AssistedLogin(string email, string password) =>
         Process<AssistedLoginResponse>(helperApi.assistedLogin_, null, new { email, password });
 
-    public unsafe Task<AssistedRegisterEphemeralKeyResponse> AssistedRegisterEphemeralKey(string? publicKey = null) =>
-        Process<AssistedRegisterEphemeralKeyResponse>(helperApi.assistedRegisterEphemeralKey_, null, new { publicKey });
+    public unsafe Task<AssistedRegisterEphemeralKeyResponse> AssistedRegisterEphemeralKey(string? publicKey = null, string? privateKey = null) =>
+        Process<AssistedRegisterEphemeralKeyResponse>(helperApi.assistedRegisterEphemeralKey_, null, new { publicKey, privateKey });
 
     public unsafe Task<object> AssistedRegister(string email, string password, string? displayName = null, bool force = false) =>
         Process<object>(helperApi.assistedRegister_, null, new { email, password, displayName, force });

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ISecureStorage.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ISecureStorage.cs
@@ -32,7 +32,7 @@ public interface ISecureStorage
 
     public byte[]? GetPrivateKey();
 
-    public void SetKeyPairVerified(bool isKeyVerified);
+    public void SetKeyPairVerified(byte[]? publicKey);
 
     public bool? GetKeyPairVerified();
 

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ISecureStorage.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ISecureStorage.cs
@@ -34,7 +34,7 @@ public interface ISecureStorage
 
     public void SetKeyPairVerified(byte[]? publicKey);
 
-    public bool? GetKeyPairVerified();
+    public byte[]? GetKeyPairVerified();
 
     public void AddUserId(string userId);
 

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/SecureStorage.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/SecureStorage.cs
@@ -159,10 +159,8 @@ internal static class SecureStorage
     
     public static void SetKeyPairVerified(IntPtr c)
     {
-        if (GetStringFromPtr(c) is {} result)
-        {
-            Implementation?.SetKeyPairVerified(bool.Parse(result));
-        }
+        var result = GetStringFromPtr(c);
+        Implementation?.SetKeyPairVerified(result?.DecodeBase64ToByteArray());
     }
     
     public static IntPtr GetKeyPairVerified() =>

--- a/doordeck-sdk/src/mingwMain/resources/python/wrapper/account.i
+++ b/doordeck-sdk/src/mingwMain/resources/python/wrapper/account.i
@@ -17,8 +17,8 @@ class Account(object):
             [self.resource]
         )
 
-    async def register_ephemeral_key(self, publicKey: str):
-        data = { "publicKey": publicKey }
+    async def register_ephemeral_key(self, publicKey: str, privateKey: str):
+        data = { "publicKey": publicKey, "privateKey": privateKey }
         return await execute_async(
             _doordeck_headless_sdk.registerEphemeralKey,
             [self.resource, json.dumps(data)]

--- a/doordeck-sdk/src/mingwMain/resources/python/wrapper/account.i
+++ b/doordeck-sdk/src/mingwMain/resources/python/wrapper/account.i
@@ -34,9 +34,10 @@ class Account(object):
             [self.resource, json.dumps(data)]
         )
 
-    async def verify_ephemeral_key_registration(self, code: str, privateKey: typing.Optional[str] = None):
+    async def verify_ephemeral_key_registration(self, code: str, publicKey: typing.Optional[str] = None, privateKey: typing.Optional[str] = None):
         data = {
             "code": code,
+            "publicKey": publicKey,
             "privateKey": privateKey
         }
         return await execute_async(

--- a/doordeck-sdk/src/mingwMain/resources/python/wrapper/helper.i
+++ b/doordeck-sdk/src/mingwMain/resources/python/wrapper/helper.i
@@ -25,8 +25,8 @@ class Helper(object):
             [self.resource, json.dumps(data)]
         )
 
-    async def assisted_register_ephemeral_key(self, publicKey: str):
-        data = { "publicKey": publicKey }
+    async def assisted_register_ephemeral_key(self, publicKey: str, privateKey: str):
+        data = { "publicKey": publicKey, "privateKey": privateKey }
         return await execute_async(
             _doordeck_headless_sdk.assistedRegisterEphemeralKey,
             [self.resource, json.dumps(data)]

--- a/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.mingw.kt
+++ b/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.mingw.kt
@@ -5,6 +5,7 @@ import com.doordeck.multiplatform.sdk.REGISTER_EPHEMERAL_KEY_RESPONSE
 import com.doordeck.multiplatform.sdk.REGISTER_EPHEMERAL_KEY_WITH_SECONDARY_AUTHENTICATION_RESPONSE
 import com.doordeck.multiplatform.sdk.TOKEN_RESPONSE
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_PRIVATE_KEY
+import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_PUBLIC_KEY
 import com.doordeck.multiplatform.sdk.USER_DETAILS_RESPONSE
 import com.doordeck.multiplatform.sdk.model.data.ChangePasswordData
 import com.doordeck.multiplatform.sdk.model.data.RefreshTokenData
@@ -108,7 +109,7 @@ class AccountApiTest : CallbackTest() {
         callbackTest(
             apiCall = {
                 AccountApi.verifyEphemeralKeyRegistration(
-                    data = VerifyEphemeralKeyRegistrationData("", TEST_MAIN_USER_PRIVATE_KEY).toJson(),
+                    data = VerifyEphemeralKeyRegistrationData("", TEST_MAIN_USER_PUBLIC_KEY,TEST_MAIN_USER_PRIVATE_KEY).toJson(),
                     callback = staticCFunction(::testCallback)
                 )
             },


### PR DESCRIPTION
Previously, we only stored a boolean flag when either `register ephemeral key` or `register ephemeral key with secondary auth` was successfully used to indicate that "two-factor authentication" had been completed for the existing key. However, since this boolean was never reset to false, the logic remained overly simplistic.

Now, upon successful registration or verification, we will store the public key in a separate storage key. The SDK will then compare this public key against the previously stored one to verify the key pair's authentication status (for successful verification, both keys must match).