### PR TITLE
Support for watch os device arm 64 target

### DIFF
--- a/doordeck-sdk/build.gradle.kts
+++ b/doordeck-sdk/build.gradle.kts
@@ -76,7 +76,7 @@ kotlin {
     val appleTargets = listOf(
         iosX64(), iosArm64(), iosSimulatorArm64(),                                      // iOS
         macosArm64(),                                                                   // macOS
-        watchosX64(), watchosArm64(), watchosSimulatorArm64()                           // watchOS
+        watchosX64(), watchosArm64(), watchosDeviceArm64(), watchosSimulatorArm64()     // watchOS
     )
 
     appleTargets.forEach {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ libsodium = "0.9.2"
 security-crypto = "1.1.0-alpha07"
 kotlinx-datetime = "0.6.2" # Do not update to 0.7.0 unless the other dependencies that rely on kotlinx-datetime are also using the same version.
 kotlin-coroutines-test = "1.10.2"
-swift-klib = "0.6.4"
+swift-klib = "1.1.0"
 asn1js = "3.0.6"
 pkijs = "3.2.5"
 kermit = "2.0.6"
@@ -52,4 +52,4 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
-swift-klib = { id = "io.github.ttypic.swiftklib", version.ref = "swift-klib" }
+swift-klib = { id = "io.github.bernatcarbo.swiftklibfork", version.ref = "swift-klib" }


### PR DESCRIPTION
That is a bit weird, but so far, it's the best solution I've found. It looks like we need the `watchOsDeviceArm64` target ASAP, but the Gradle plugin we use to bridge KMP with Swift code doesn’t support it yet. I sent them a PR a week ago with the changes, but they’re likely ignoring it, so I [forked](https://github.com/BernatCarbo/swift-klib-plugin-fork) it with the necessary modifications. I believe this will be a _temporary_ solution to unblock us.