### PR TITLE
Increase maven timeouts [skip actions]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.time.Duration
+
 plugins {
     alias(libs.plugins.android.library).apply(false)
     alias(libs.plugins.kotlin.multiplatform).apply(false)
@@ -19,6 +21,10 @@ nexusPublishing {
             password = System.getenv("MAVEN_TOKEN")
         }
     }
+
+    // Increase timeouts
+    connectTimeout.set(Duration.ofMinutes(10))
+    clientTimeout.set(Duration.ofMinutes(10))
 }
 
 // Force some JS dependencies to use specific versions (yarn.lock)

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\=
 org.gradle.caching=false
 org.gradle.configuration-cache=false
 #Increase timeouts
-systemProp.org.gradle.internal.http.connectionTimeout=180000
-systemProp.org.gradle.internal.http.socketTimeout=180000
+systemProp.org.gradle.internal.http.connectionTimeout=600000
+systemProp.org.gradle.internal.http.socketTimeout=600000
 #Kotlin
 kotlin.code.style=official
 #MPP


### PR DESCRIPTION
Apparently, the issue is still present, so let's try to increase the timeouts and set them specifically for the Nexus plugin