### PR TITLE
Remove generateEncodedKeyPair from non-Windows platforms

### DIFF
--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.android.kt
@@ -42,16 +42,6 @@ actual object CryptoManager {
     }
 
     /**
-     * This method is not implemented and will throw [NotImplementedError]. Use [generateKeyPair] instead.
-     *
-     * @throws [NotImplementedError].
-     */
-    @Suppress("UNUSED")
-    actual fun generateEncodedKeyPair(): String {
-        throw NotImplementedError("Use generateKeyPair() instead")
-    }
-
-    /**
      * @see [CryptoManager.isCertificateInvalidOrExpired]
      */
     actual fun isCertificateInvalidOrExpired(base64Certificate: String): Boolean {

--- a/doordeck-sdk/src/appleMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.apple.kt
+++ b/doordeck-sdk/src/appleMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.apple.kt
@@ -33,14 +33,6 @@ actual object CryptoManager {
     }
 
     /**
-     * This method is not implemented and will throw [NotImplementedError]. Use [generateKeyPair] instead.
-     * @throws [NotImplementedError].
-     */
-    actual fun generateEncodedKeyPair(): String {
-        throw NotImplementedError("Use generateKeyPair() instead")
-    }
-
-    /**
      * @see [CryptoManager.isCertificateInvalidOrExpired]
      */
     actual fun isCertificateInvalidOrExpired(base64Certificate: String): Boolean {

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.kt
@@ -86,13 +86,6 @@ expect object CryptoManager {
     fun generateKeyPair(): Crypto.KeyPair
 
     /**
-     * Generates a new Ed25519 key pair and returns it as a JSON-encoded string.
-     *
-     * @return JSON string representation of the generated key pair.
-     */
-    fun generateEncodedKeyPair(): String
-
-    /**
      * Checks if a certificate is invalid (e.g., null, malformed) or expired.
      * (we consider it expired if it will expire within the next [MIN_CERTIFICATE_LIFETIME_DAYS] days).
      *

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManagerTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManagerTest.kt
@@ -1,13 +1,10 @@
 package com.doordeck.multiplatform.sdk.crypto
 
-import com.doordeck.multiplatform.sdk.PlatformType
 import com.doordeck.multiplatform.sdk.crypto.CryptoManager.signWithPrivateKey
 import com.doordeck.multiplatform.sdk.crypto.CryptoManager.verifySignature
-import com.doordeck.multiplatform.sdk.platformType
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -28,26 +25,6 @@ class CryptoManagerTest {
     @Test
     fun shouldGenerateCryptoKeyPair() = runTest {
         CryptoManager.generateKeyPair()
-    }
-
-    @Test
-    fun shouldGenerateEncodedCryptoKeyPair() = runTest {
-        when (platformType) {
-            PlatformType.JVM,
-            PlatformType.JS_BROWSER,
-            PlatformType.JS_NODE,
-            PlatformType.ANDROID,
-            PlatformType.APPLE_WATCH,
-            PlatformType.APPLE_IOS,
-            PlatformType.APPLE_MAC -> {
-                val exception = assertFails {
-                    CryptoManager.generateEncodedKeyPair()
-                }
-                assertTrue { exception is NotImplementedError }
-            } else -> {
-                CryptoManager.generateEncodedKeyPair()
-            }
-        }
     }
 
     @Test

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.js.kt
@@ -41,14 +41,6 @@ actual object CryptoManager {
     }
 
     /**
-     * This method is not implemented and will throw [NotImplementedError]. Use [generateKeyPair] instead.
-     * @throws [NotImplementedError].
-     */
-    actual fun generateEncodedKeyPair(): String {
-        throw NotImplementedError("Use generateKeyPair() instead")
-    }
-
-    /**
      * @see [CryptoManager.isCertificateInvalidOrExpired]
      */
     actual fun isCertificateInvalidOrExpired(base64Certificate: String): Boolean = try {

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.jvm.kt
@@ -35,14 +35,6 @@ actual object CryptoManager {
     }
 
     /**
-     * This method is not implemented and will throw [NotImplementedError]. Use [generateKeyPair] instead.
-     * @throws [NotImplementedError].
-     */
-    actual fun generateEncodedKeyPair(): String {
-        throw NotImplementedError("Use generateKeyPair() instead")
-    }
-
-    /**
      * @see [CryptoManager.isCertificateInvalidOrExpired]
      */
     actual fun isCertificateInvalidOrExpired(base64Certificate: String): Boolean {

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.mingw.kt
@@ -36,10 +36,12 @@ actual object CryptoManager {
     }
 
     /**
-     * @see [CryptoManager.generateEncodedKeyPair]
+     * Generates a new Ed25519 key pair and returns it as a JSON-encoded string.
+     *
+     * @return JSON string representation of the generated key pair.
      */
     @CName("generateEncodedKeyPair")
-    actual fun generateEncodedKeyPair(): String {
+    fun generateEncodedKeyPair(): String {
         val keyPair = generateKeyPair()
         return Crypto.EncodedKeyPair(
             private = keyPair.private.encodeByteArrayToBase64(),

--- a/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/crypto/MingwCryptoManagerTest.kt
+++ b/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/crypto/MingwCryptoManagerTest.kt
@@ -3,6 +3,7 @@ package com.doordeck.multiplatform.sdk.crypto
 import com.ionspin.kotlin.crypto.LibsodiumInitializer
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class MingwCryptoManagerTest {
@@ -17,5 +18,17 @@ class MingwCryptoManagerTest {
 
         // Then
         assertTrue { result }
+    }
+
+    @Test
+    fun shouldGenerateEncodedCryptoKeyPair() = runTest {
+        // Given
+        val cryptoManager = CryptoManager // Initialize
+
+        // When
+        val result = cryptoManager.generateEncodedKeyPair()
+
+        // Then
+        assertFalse(result.isEmpty())
     }
 }


### PR DESCRIPTION
`generateEncodedKeyPair` is only needed on Windows, so we can remove it from other platforms.