### PR TITLE
Replace Set with JsSet @ JS platform

### DIFF
--- a/.github/actions/csharp-bindings-action/action.yml
+++ b/.github/actions/csharp-bindings-action/action.yml
@@ -10,7 +10,7 @@ runs:
 
     - name: Setup ClangSharpPInvokeGenerator
       shell: bash
-      run: dotnet tool install --global ClangSharpPInvokeGenerator
+      run: dotnet tool install --global ClangSharpPInvokeGenerator --version 20.1.2.1
 
     - name: Adjust header
       shell: bash

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperations.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperations.js.kt
@@ -8,7 +8,9 @@ import com.doordeck.multiplatform.sdk.util.validateLongitude
 import com.doordeck.multiplatform.sdk.util.validateRadius
 import kotlin.time.Clock
 import kotlin.js.collections.JsArray
+import kotlin.js.collections.JsSet
 import kotlin.js.collections.toList
+import kotlin.js.collections.toSet
 import kotlin.time.Duration.Companion.minutes
 import kotlin.uuid.Uuid
 
@@ -19,18 +21,18 @@ object LockOperations {
         val start: String, // HH:mm
         val end: String, // HH:mm
         val timezone: String,
-        val days: Set<DayOfWeek>
+        val days: JsSet<DayOfWeek>
     ) {
         class Builder {
             private var start: String? = null
             private var end: String? = null
             private var timezone: String? = null
-            private var days: Set<DayOfWeek>? = null
+            private var days: JsSet<DayOfWeek>? = null
 
             fun setStart(start: String): Builder = apply { this.start = start }
             fun setEnd(end: String): Builder = apply { this.end = end }
             fun setTimezone(timezone: String) = apply { this.timezone = timezone }
-            fun setDays(days: Set<DayOfWeek>) = apply { this.days = days }
+            fun setDays(days: JsSet<DayOfWeek>) = apply { this.days = days }
 
             fun build(): TimeRequirement {
                 return TimeRequirement(
@@ -86,20 +88,20 @@ object LockOperations {
         val start: String, // HH:mm
         val end: String, // HH:mm
         val timezone: String,
-        val days: Set<DayOfWeek>,
+        val days: JsSet<DayOfWeek>,
         val exceptions: JsArray<String>? = null
     ) {
         class Builder {
             private var start: String? = null
             private var end: String? = null
             private var timezone: String? = null
-            private var days: Set<DayOfWeek>? = null
+            private var days: JsSet<DayOfWeek>? = null
             private var exceptions: JsArray<String>? = null
 
             fun setStart(start: String): Builder = apply { this.start = start }
             fun setEnd(end: String): Builder = apply { this.end = end }
             fun setTimezone(timezone: String): Builder = apply { this.timezone = timezone }
-            fun setDays(days: Set<DayOfWeek>): Builder = apply { this.days = days }
+            fun setDays(days: JsSet<DayOfWeek>): Builder = apply { this.days = days }
             fun setExceptions(exceptions: JsArray<String>?): Builder = apply { this.exceptions = exceptions }
 
             fun build(): UnlockBetween {
@@ -318,7 +320,7 @@ internal fun JsArray<LockOperations.TimeRequirement>.toBasicTimeRequirement(): L
         start = requirement.start,
         end = requirement.end,
         timezone = requirement.timezone,
-        days = requirement.days
+        days = requirement.days.toSet()
     )
 }
 
@@ -337,7 +339,7 @@ internal fun LockOperations.UnlockBetween.toBasicUnlockBetween(): BasicUnlockBet
         start = start,
         end = end,
         timezone = timezone,
-        days = days,
+        days = days.toSet(),
         exceptions = exceptions?.toList()
     )
 }

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/LockResponses.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/LockResponses.js.kt
@@ -7,7 +7,9 @@ import com.doordeck.multiplatform.sdk.model.common.DayOfWeek
 import com.doordeck.multiplatform.sdk.model.common.UserRole
 import com.doordeck.multiplatform.sdk.util.emptyJsArray
 import com.doordeck.multiplatform.sdk.util.toJsArray
+import com.doordeck.multiplatform.sdk.util.toJsSet
 import kotlin.js.collections.JsArray
+import kotlin.js.collections.JsSet
 
 @JsExport
 data class LockResponse(
@@ -45,7 +47,7 @@ data class TimeRequirementResponse(
     val start: String,
     val end: String,
     val timezone: String,
-    val days: Set<DayOfWeek>
+    val days: JsSet<DayOfWeek>
 )
 
 @JsExport
@@ -62,7 +64,7 @@ data class UnlockBetweenSettingResponse(
     val start: String,
     val end: String,
     val timezone: String,
-    val days: Set<DayOfWeek>,
+    val days: JsSet<DayOfWeek>,
     val exceptions: JsArray<String> = emptyJsArray()
 )
 
@@ -181,7 +183,7 @@ internal fun BasicTimeRequirementResponse.toTimeRequirementResponse(): TimeRequi
     start = start,
     end = end,
     timezone = timezone,
-    days = days
+    days = days.toJsSet()
 )
 
 internal fun BasicLocationRequirementResponse.toLocationRequirementResponse(): LocationRequirementResponse = LocationRequirementResponse(
@@ -196,7 +198,7 @@ internal fun BasicUnlockBetweenSettingResponse.toUnlockBetweenSettingResponse():
     start = start,
     end = end,
     timezone = timezone,
-    days = days,
+    days = days.toJsSet(),
     exceptions = exceptions.toJsArray()
 )
 

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.js.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.promise
 import kotlin.js.Promise
 import kotlin.js.collections.JsArray
+import kotlin.js.collections.JsSet
 
 internal actual fun HttpClientConfig<*>.installCertificatePinner() {
     // Certificate pinner is not supported on the JS engine
@@ -13,6 +14,8 @@ internal actual fun HttpClientConfig<*>.installCertificatePinner() {
 internal inline fun <reified T>emptyJsArray(): JsArray<T> = emptyList<T>().toMutableList().asJsArrayView()
 
 internal inline fun <reified T>List<T>.toJsArray(): JsArray<T> = toMutableList().asJsArrayView()
+
+internal inline fun <reified T>Set<T>.toJsSet(): JsSet<T> = toMutableSet().asJsSetView()
 
 /**
  * Creates a `Promise` from a suspendable function.

--- a/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/Platform.test.js.kt
+++ b/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/Platform.test.js.kt
@@ -1,8 +1,11 @@
 package com.doordeck.multiplatform.sdk
 
 import com.doordeck.multiplatform.sdk.util.toJsArray
+import com.doordeck.multiplatform.sdk.util.toJsSet
 import kotlin.js.collections.JsArray
+import kotlin.js.collections.JsSet
 import kotlin.js.collections.toList
+import kotlin.js.collections.toSet
 
 actual fun getEnvironmentVariable(name: String): String? =
     js("process.env[name]").unsafeCast<String?>()
@@ -11,6 +14,8 @@ internal inline fun <reified T>JsArray<T>.isEmpty(): Boolean = toList().isEmpty(
 internal inline fun <reified T>JsArray<T>.isNotEmpty(): Boolean = !isEmpty()
 internal inline fun <reified T>JsArray<T>.first(): T = toList().first()
 internal inline fun <reified T>JsArray<T>.contains(element: T): Boolean = toList().contains(element)
+internal inline fun <reified T>jsSetOf(element: T) = setOf(element).toJsSet()
+internal inline fun <reified T>JsSet<T>.first(): T = toSet().first()
 internal inline fun <reified T>jsArrayOf(element: T) = listOf(element).toJsArray()
 internal inline fun <reified T>jsArrayOf(vararg elements: T) = elements.asList().toJsArray()
 internal inline fun <reified T>JsArray<T>.any(predicate: (T) -> Boolean) = toList().any {
@@ -22,3 +27,4 @@ internal inline fun <reified T>JsArray<T>.firstOrNull(predicate: (T) -> Boolean)
 }
 
 internal inline fun <reified T>JsArray<T>.size() = toList().size
+internal inline fun <reified T>emptyJsSet(): JsSet<T> = emptySet<T>().toMutableSet().asJsSetView()

--- a/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.js.kt
+++ b/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.js.kt
@@ -8,6 +8,7 @@ import com.doordeck.multiplatform.sdk.model.data.LockOperations
 import com.doordeck.multiplatform.sdk.model.data.LockOperations.ShareLock
 import com.doordeck.multiplatform.sdk.model.data.PlatformOperations
 import com.doordeck.multiplatform.sdk.util.toJsArray
+import com.doordeck.multiplatform.sdk.util.toJsSet
 
 internal fun randomBaseOperation() = LockOperations.BaseOperation(
     userId = randomNullable { randomUuidString() },
@@ -24,7 +25,7 @@ internal fun randomTimeRequirement() = LockOperations.TimeRequirement(
     start = randomString(),
     end = randomString(),
     timezone = randomString(),
-    days = DayOfWeek.entries.shuffled().take(3).toSet()
+    days = DayOfWeek.entries.shuffled().take(3).toSet().toJsSet()
 )
 
 internal fun randomLocationRequirement() = LockOperations.LocationRequirement(
@@ -39,7 +40,7 @@ internal fun randomUnlockBetween() = LockOperations.UnlockBetween(
     start = randomString(),
     end = randomString(),
     timezone = randomString(),
-    days = DayOfWeek.entries.shuffled().take(3).toSet(),
+    days = DayOfWeek.entries.shuffled().take(3).toSet().toJsSet(),
     exceptions = (1..3).map { randomString() }.toJsArray()
 )
 

--- a/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsApiTest.js.kt
+++ b/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsApiTest.js.kt
@@ -17,12 +17,14 @@ import com.doordeck.multiplatform.sdk.TestConstants.TEST_SUPPLEMENTARY_USER_ID
 import com.doordeck.multiplatform.sdk.any
 import com.doordeck.multiplatform.sdk.context.ContextManager
 import com.doordeck.multiplatform.sdk.crypto.CryptoManager
+import com.doordeck.multiplatform.sdk.emptyJsSet
 import com.doordeck.multiplatform.sdk.exceptions.MissingContextFieldException
 import com.doordeck.multiplatform.sdk.first
 import com.doordeck.multiplatform.sdk.firstOrNull
 import com.doordeck.multiplatform.sdk.isEmpty
 import com.doordeck.multiplatform.sdk.isNotEmpty
 import com.doordeck.multiplatform.sdk.jsArrayOf
+import com.doordeck.multiplatform.sdk.jsSetOf
 import com.doordeck.multiplatform.sdk.model.common.DayOfWeek
 import com.doordeck.multiplatform.sdk.model.common.UserRole
 import com.doordeck.multiplatform.sdk.model.data.LockOperations
@@ -36,6 +38,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.js.collections.toList
+import kotlin.js.collections.toSet
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -154,7 +157,7 @@ class LockOperationsApiTest : IntegrationTest() {
             start = "${min.hour.toString().padStart(2, '0')}:${min.minute.toString().padStart(2, '0')}",
             end = "${max.hour.toString().padStart(2, '0')}:${max.minute.toString().padStart(2, '0')}",
             timezone = TimeZone.UTC.id,
-            days = setOf(DayOfWeek.entries.random())
+            days = jsSetOf(DayOfWeek.entries.random())
         )
 
         // When
@@ -167,7 +170,7 @@ class LockOperationsApiTest : IntegrationTest() {
         assertEquals(addedTimeRestriction.start, actualTime.start)
         assertEquals(addedTimeRestriction.end, actualTime.end)
         assertEquals(addedTimeRestriction.timezone, actualTime.timezone)
-        assertContains(actualTime.days, addedTimeRestriction.days.first())
+        assertContains(actualTime.days.toSet(), addedTimeRestriction.days.first())
 
         // Given - shouldRemoveLockSettingTimeRestrictions
         val removedTimeRestriction = emptyJsArray<LockOperations.TimeRequirement>()
@@ -688,7 +691,7 @@ class LockOperationsApiTest : IntegrationTest() {
             start = "${min.hour.toString().padStart(2, '0')}:${min.minute.toString().padStart(2, '0')}",
             end = "${max.hour.toString().padStart(2, '0')}:${max.minute.toString().padStart(2, '0')}",
             timezone = TimeZone.UTC.id,
-            days = setOf(DayOfWeek.entries.random()),
+            days = jsSetOf(DayOfWeek.entries.random()),
             exceptions = emptyJsArray()
         )
         val addBaseOperation = LockOperations.BaseOperation(
@@ -750,7 +753,7 @@ class LockOperationsApiTest : IntegrationTest() {
             start = "${min.hour.toString().padStart(2, '0')}:${min.minute.toString().padStart(2, '0')}",
             end = "${max.hour.toString().padStart(2, '0')}:${max.minute.toString().padStart(2, '0')}",
             timezone = TimeZone.UTC.id,
-            days = setOf(DayOfWeek.entries.random()),
+            days = jsSetOf(DayOfWeek.entries.random()),
             exceptions = emptyJsArray()
         )
         ContextManager.setOperationContext(
@@ -867,7 +870,7 @@ class LockOperationsApiTest : IntegrationTest() {
                         start = "",
                         end = "",
                         timezone = TimeZone.UTC.id,
-                        days = emptySet(),
+                        days = emptyJsSet(),
                         exceptions = emptyJsArray()
                     )
                 )

--- a/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsApiTest.js.kt
+++ b/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsApiTest.js.kt
@@ -715,7 +715,7 @@ class LockOperationsApiTest : IntegrationTest() {
         assertEquals(updatedUnlockBetween.start, lock.settings.unlockBetweenWindow.start)
         assertEquals(updatedUnlockBetween.end, lock.settings.unlockBetweenWindow.end)
         assertEquals(updatedUnlockBetween.timezone, lock.settings.unlockBetweenWindow.timezone)
-        assertEquals(updatedUnlockBetween.days, lock.settings.unlockBetweenWindow.days)
+        assertEquals(updatedUnlockBetween.days.toSet(), lock.settings.unlockBetweenWindow.days.toSet())
 
         // Given - shouldRemoveSecureSettingUnlockBetween
         val removeBaseOperation = LockOperations.BaseOperation(
@@ -778,7 +778,7 @@ class LockOperationsApiTest : IntegrationTest() {
         assertEquals(updatedUnlockBetween.start, lock.settings.unlockBetweenWindow.start)
         assertEquals(updatedUnlockBetween.end, lock.settings.unlockBetweenWindow.end)
         assertEquals(updatedUnlockBetween.timezone, lock.settings.unlockBetweenWindow.timezone)
-        assertEquals(updatedUnlockBetween.days, lock.settings.unlockBetweenWindow.days)
+        assertEquals(updatedUnlockBetween.days.toSet(), lock.settings.unlockBetweenWindow.days.toSet())
 
         // Given
         LockOperationsApi.updateSecureSettingUnlockBetween(


### PR DESCRIPTION
Replacing `Sets` with `JsSets`, as we previously did with `Lists`.