### PR TITLE
Replace JsSet with JsArray @ JS platform

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -66,7 +66,7 @@ jobs:
           WIREGUARD_PEER_ENDPOINT: ${{ secrets.WIREGUARD_PEER_ENDPOINT }}
 
       - name: Tests
-        run: ./gradlew ${{ matrix.test }} --rerun-tasks --no-build-cache
+        run: ./gradlew ${{ matrix.test }}
 
   python-build:
     name: Python build

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperations.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/model/data/LockOperations.js.kt
@@ -8,9 +8,7 @@ import com.doordeck.multiplatform.sdk.util.validateLongitude
 import com.doordeck.multiplatform.sdk.util.validateRadius
 import kotlin.time.Clock
 import kotlin.js.collections.JsArray
-import kotlin.js.collections.JsSet
 import kotlin.js.collections.toList
-import kotlin.js.collections.toSet
 import kotlin.time.Duration.Companion.minutes
 import kotlin.uuid.Uuid
 
@@ -21,18 +19,18 @@ object LockOperations {
         val start: String, // HH:mm
         val end: String, // HH:mm
         val timezone: String,
-        val days: JsSet<DayOfWeek>
+        val days: JsArray<DayOfWeek>
     ) {
         class Builder {
             private var start: String? = null
             private var end: String? = null
             private var timezone: String? = null
-            private var days: JsSet<DayOfWeek>? = null
+            private var days: JsArray<DayOfWeek>? = null
 
             fun setStart(start: String): Builder = apply { this.start = start }
             fun setEnd(end: String): Builder = apply { this.end = end }
             fun setTimezone(timezone: String) = apply { this.timezone = timezone }
-            fun setDays(days: JsSet<DayOfWeek>) = apply { this.days = days }
+            fun setDays(days: JsArray<DayOfWeek>) = apply { this.days = days }
 
             fun build(): TimeRequirement {
                 return TimeRequirement(
@@ -88,20 +86,20 @@ object LockOperations {
         val start: String, // HH:mm
         val end: String, // HH:mm
         val timezone: String,
-        val days: JsSet<DayOfWeek>,
+        val days: JsArray<DayOfWeek>,
         val exceptions: JsArray<String>? = null
     ) {
         class Builder {
             private var start: String? = null
             private var end: String? = null
             private var timezone: String? = null
-            private var days: JsSet<DayOfWeek>? = null
+            private var days: JsArray<DayOfWeek>? = null
             private var exceptions: JsArray<String>? = null
 
             fun setStart(start: String): Builder = apply { this.start = start }
             fun setEnd(end: String): Builder = apply { this.end = end }
             fun setTimezone(timezone: String): Builder = apply { this.timezone = timezone }
-            fun setDays(days: JsSet<DayOfWeek>): Builder = apply { this.days = days }
+            fun setDays(days: JsArray<DayOfWeek>): Builder = apply { this.days = days }
             fun setExceptions(exceptions: JsArray<String>?): Builder = apply { this.exceptions = exceptions }
 
             fun build(): UnlockBetween {
@@ -320,7 +318,7 @@ internal fun JsArray<LockOperations.TimeRequirement>.toBasicTimeRequirement(): L
         start = requirement.start,
         end = requirement.end,
         timezone = requirement.timezone,
-        days = requirement.days.toSet()
+        days = requirement.days.toList().toSet()
     )
 }
 
@@ -339,7 +337,7 @@ internal fun LockOperations.UnlockBetween.toBasicUnlockBetween(): BasicUnlockBet
         start = start,
         end = end,
         timezone = timezone,
-        days = days.toSet(),
+        days = days.toList().toSet(),
         exceptions = exceptions?.toList()
     )
 }

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/LockResponses.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/LockResponses.js.kt
@@ -7,9 +7,7 @@ import com.doordeck.multiplatform.sdk.model.common.DayOfWeek
 import com.doordeck.multiplatform.sdk.model.common.UserRole
 import com.doordeck.multiplatform.sdk.util.emptyJsArray
 import com.doordeck.multiplatform.sdk.util.toJsArray
-import com.doordeck.multiplatform.sdk.util.toJsSet
 import kotlin.js.collections.JsArray
-import kotlin.js.collections.JsSet
 
 @JsExport
 data class LockResponse(
@@ -47,7 +45,7 @@ data class TimeRequirementResponse(
     val start: String,
     val end: String,
     val timezone: String,
-    val days: JsSet<DayOfWeek>
+    val days: JsArray<DayOfWeek>
 )
 
 @JsExport
@@ -64,7 +62,7 @@ data class UnlockBetweenSettingResponse(
     val start: String,
     val end: String,
     val timezone: String,
-    val days: JsSet<DayOfWeek>,
+    val days: JsArray<DayOfWeek>,
     val exceptions: JsArray<String> = emptyJsArray()
 )
 
@@ -183,7 +181,7 @@ internal fun BasicTimeRequirementResponse.toTimeRequirementResponse(): TimeRequi
     start = start,
     end = end,
     timezone = timezone,
-    days = days.toJsSet()
+    days = days.toList().toJsArray()
 )
 
 internal fun BasicLocationRequirementResponse.toLocationRequirementResponse(): LocationRequirementResponse = LocationRequirementResponse(
@@ -198,7 +196,7 @@ internal fun BasicUnlockBetweenSettingResponse.toUnlockBetweenSettingResponse():
     start = start,
     end = end,
     timezone = timezone,
-    days = days.toJsSet(),
+    days = days.toList().toJsArray(),
     exceptions = exceptions.toJsArray()
 )
 

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.js.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.promise
 import kotlin.js.Promise
 import kotlin.js.collections.JsArray
-import kotlin.js.collections.JsSet
 
 internal actual fun HttpClientConfig<*>.installCertificatePinner() {
     // Certificate pinner is not supported on the JS engine
@@ -14,8 +13,6 @@ internal actual fun HttpClientConfig<*>.installCertificatePinner() {
 internal inline fun <reified T>emptyJsArray(): JsArray<T> = emptyList<T>().toMutableList().asJsArrayView()
 
 internal inline fun <reified T>List<T>.toJsArray(): JsArray<T> = toMutableList().asJsArrayView()
-
-internal inline fun <reified T>Set<T>.toJsSet(): JsSet<T> = toMutableSet().asJsSetView()
 
 /**
  * Creates a `Promise` from a suspendable function.

--- a/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/Platform.test.js.kt
+++ b/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/Platform.test.js.kt
@@ -1,11 +1,8 @@
 package com.doordeck.multiplatform.sdk
 
 import com.doordeck.multiplatform.sdk.util.toJsArray
-import com.doordeck.multiplatform.sdk.util.toJsSet
 import kotlin.js.collections.JsArray
-import kotlin.js.collections.JsSet
 import kotlin.js.collections.toList
-import kotlin.js.collections.toSet
 
 actual fun getEnvironmentVariable(name: String): String? =
     js("process.env[name]").unsafeCast<String?>()
@@ -14,8 +11,6 @@ internal inline fun <reified T>JsArray<T>.isEmpty(): Boolean = toList().isEmpty(
 internal inline fun <reified T>JsArray<T>.isNotEmpty(): Boolean = !isEmpty()
 internal inline fun <reified T>JsArray<T>.first(): T = toList().first()
 internal inline fun <reified T>JsArray<T>.contains(element: T): Boolean = toList().contains(element)
-internal inline fun <reified T>jsSetOf(element: T) = setOf(element).toJsSet()
-internal inline fun <reified T>JsSet<T>.first(): T = toSet().first()
 internal inline fun <reified T>jsArrayOf(element: T) = listOf(element).toJsArray()
 internal inline fun <reified T>jsArrayOf(vararg elements: T) = elements.asList().toJsArray()
 internal inline fun <reified T>JsArray<T>.any(predicate: (T) -> Boolean) = toList().any {
@@ -27,4 +22,3 @@ internal inline fun <reified T>JsArray<T>.firstOrNull(predicate: (T) -> Boolean)
 }
 
 internal inline fun <reified T>JsArray<T>.size() = toList().size
-internal inline fun <reified T>emptyJsSet(): JsSet<T> = emptySet<T>().toMutableSet().asJsSetView()

--- a/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.js.kt
+++ b/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/RandomObjectGeneration.js.kt
@@ -8,7 +8,6 @@ import com.doordeck.multiplatform.sdk.model.data.LockOperations
 import com.doordeck.multiplatform.sdk.model.data.LockOperations.ShareLock
 import com.doordeck.multiplatform.sdk.model.data.PlatformOperations
 import com.doordeck.multiplatform.sdk.util.toJsArray
-import com.doordeck.multiplatform.sdk.util.toJsSet
 
 internal fun randomBaseOperation() = LockOperations.BaseOperation(
     userId = randomNullable { randomUuidString() },
@@ -25,7 +24,7 @@ internal fun randomTimeRequirement() = LockOperations.TimeRequirement(
     start = randomString(),
     end = randomString(),
     timezone = randomString(),
-    days = DayOfWeek.entries.shuffled().take(3).toSet().toJsSet()
+    days = DayOfWeek.entries.shuffled().take(3).toJsArray()
 )
 
 internal fun randomLocationRequirement() = LockOperations.LocationRequirement(
@@ -40,7 +39,7 @@ internal fun randomUnlockBetween() = LockOperations.UnlockBetween(
     start = randomString(),
     end = randomString(),
     timezone = randomString(),
-    days = DayOfWeek.entries.shuffled().take(3).toSet().toJsSet(),
+    days = DayOfWeek.entries.shuffled().take(3).toJsArray(),
     exceptions = (1..3).map { randomString() }.toJsArray()
 )
 

--- a/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsApiTest.js.kt
+++ b/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsApiTest.js.kt
@@ -17,14 +17,12 @@ import com.doordeck.multiplatform.sdk.TestConstants.TEST_SUPPLEMENTARY_USER_ID
 import com.doordeck.multiplatform.sdk.any
 import com.doordeck.multiplatform.sdk.context.ContextManager
 import com.doordeck.multiplatform.sdk.crypto.CryptoManager
-import com.doordeck.multiplatform.sdk.emptyJsSet
 import com.doordeck.multiplatform.sdk.exceptions.MissingContextFieldException
 import com.doordeck.multiplatform.sdk.first
 import com.doordeck.multiplatform.sdk.firstOrNull
 import com.doordeck.multiplatform.sdk.isEmpty
 import com.doordeck.multiplatform.sdk.isNotEmpty
 import com.doordeck.multiplatform.sdk.jsArrayOf
-import com.doordeck.multiplatform.sdk.jsSetOf
 import com.doordeck.multiplatform.sdk.model.common.DayOfWeek
 import com.doordeck.multiplatform.sdk.model.common.UserRole
 import com.doordeck.multiplatform.sdk.model.data.LockOperations
@@ -38,7 +36,6 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.js.collections.toList
-import kotlin.js.collections.toSet
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -157,7 +154,7 @@ class LockOperationsApiTest : IntegrationTest() {
             start = "${min.hour.toString().padStart(2, '0')}:${min.minute.toString().padStart(2, '0')}",
             end = "${max.hour.toString().padStart(2, '0')}:${max.minute.toString().padStart(2, '0')}",
             timezone = TimeZone.UTC.id,
-            days = jsSetOf(DayOfWeek.entries.random())
+            days = jsArrayOf(DayOfWeek.entries.random())
         )
 
         // When
@@ -170,7 +167,7 @@ class LockOperationsApiTest : IntegrationTest() {
         assertEquals(addedTimeRestriction.start, actualTime.start)
         assertEquals(addedTimeRestriction.end, actualTime.end)
         assertEquals(addedTimeRestriction.timezone, actualTime.timezone)
-        assertContains(actualTime.days.toSet(), addedTimeRestriction.days.first())
+        assertContains(actualTime.days.toList(), addedTimeRestriction.days.toList().first())
 
         // Given - shouldRemoveLockSettingTimeRestrictions
         val removedTimeRestriction = emptyJsArray<LockOperations.TimeRequirement>()
@@ -691,7 +688,7 @@ class LockOperationsApiTest : IntegrationTest() {
             start = "${min.hour.toString().padStart(2, '0')}:${min.minute.toString().padStart(2, '0')}",
             end = "${max.hour.toString().padStart(2, '0')}:${max.minute.toString().padStart(2, '0')}",
             timezone = TimeZone.UTC.id,
-            days = jsSetOf(DayOfWeek.entries.random()),
+            days = jsArrayOf(DayOfWeek.entries.random()),
             exceptions = emptyJsArray()
         )
         val addBaseOperation = LockOperations.BaseOperation(
@@ -715,7 +712,7 @@ class LockOperationsApiTest : IntegrationTest() {
         assertEquals(updatedUnlockBetween.start, lock.settings.unlockBetweenWindow.start)
         assertEquals(updatedUnlockBetween.end, lock.settings.unlockBetweenWindow.end)
         assertEquals(updatedUnlockBetween.timezone, lock.settings.unlockBetweenWindow.timezone)
-        assertEquals(updatedUnlockBetween.days.toSet(), lock.settings.unlockBetweenWindow.days.toSet())
+        assertEquals(updatedUnlockBetween.days.toList(), lock.settings.unlockBetweenWindow.days.toList())
 
         // Given - shouldRemoveSecureSettingUnlockBetween
         val removeBaseOperation = LockOperations.BaseOperation(
@@ -753,7 +750,7 @@ class LockOperationsApiTest : IntegrationTest() {
             start = "${min.hour.toString().padStart(2, '0')}:${min.minute.toString().padStart(2, '0')}",
             end = "${max.hour.toString().padStart(2, '0')}:${max.minute.toString().padStart(2, '0')}",
             timezone = TimeZone.UTC.id,
-            days = jsSetOf(DayOfWeek.entries.random()),
+            days = jsArrayOf(DayOfWeek.entries.random()),
             exceptions = emptyJsArray()
         )
         ContextManager.setOperationContext(
@@ -778,7 +775,7 @@ class LockOperationsApiTest : IntegrationTest() {
         assertEquals(updatedUnlockBetween.start, lock.settings.unlockBetweenWindow.start)
         assertEquals(updatedUnlockBetween.end, lock.settings.unlockBetweenWindow.end)
         assertEquals(updatedUnlockBetween.timezone, lock.settings.unlockBetweenWindow.timezone)
-        assertEquals(updatedUnlockBetween.days.toSet(), lock.settings.unlockBetweenWindow.days.toSet())
+        assertEquals(updatedUnlockBetween.days.toList(), lock.settings.unlockBetweenWindow.days.toList())
 
         // Given
         LockOperationsApi.updateSecureSettingUnlockBetween(
@@ -870,7 +867,7 @@ class LockOperationsApiTest : IntegrationTest() {
                         start = "",
                         end = "",
                         timezone = TimeZone.UTC.id,
-                        days = emptyJsSet(),
+                        days = emptyJsArray(),
                         exceptions = emptyJsArray()
                     )
                 )


### PR DESCRIPTION
@RafaRuiz requested replacing the `JsSet` with a `JsArray` on the JS platform because the `JsArray` is much easier to use.