### PR TITLE
Re-added site colour

### DIFF
--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/SiteResponses.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/SiteResponses.android.kt
@@ -8,6 +8,7 @@ import java.util.UUID
 data class SiteResponse(
     val id: UUID,
     val name: String,
+    val colour: String,
     val longitude: Double,
     val latitude: Double,
     val radius: Int,
@@ -29,6 +30,7 @@ internal fun List<BasicSiteResponse>.toSiteResponse(): List<SiteResponse> = map 
     SiteResponse(
         id = site.id.toUuid(),
         name = site.name,
+        colour = site.colour,
         longitude = site.longitude,
         latitude = site.latitude,
         radius = site.radius,

--- a/doordeck-sdk/src/appleMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/SiteResponses.apple.kt
+++ b/doordeck-sdk/src/appleMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/SiteResponses.apple.kt
@@ -3,6 +3,7 @@ package com.doordeck.multiplatform.sdk.model.responses
 data class SiteResponse(
     val id: String,
     val name: String,
+    val colour: String,
     val longitude: Double,
     val latitude: Double,
     val radius: Int,
@@ -23,6 +24,7 @@ internal fun List<BasicSiteResponse>.toSiteResponse(): List<SiteResponse> = map 
     SiteResponse(
         id = site.id,
         name = site.name,
+        colour = site.colour,
         longitude = site.longitude,
         latitude = site.latitude,
         radius = site.radius,

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/SiteResponses.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/SiteResponses.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 internal data class BasicSiteResponse(
     val id: String,
     val name: String,
+    val colour: String,
     val longitude: Double,
     val latitude: Double,
     val radius: Int,

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/SiteResponses.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/SiteResponses.js.kt
@@ -8,6 +8,7 @@ import kotlin.js.collections.JsReadonlyArray
 data class SiteResponse(
     val id: String,
     val name: String,
+    val colour: String,
     val longitude: Double,
     val latitude: Double,
     val radius: Int,
@@ -29,6 +30,7 @@ internal fun List<BasicSiteResponse>.toSiteResponse(): JsArray<SiteResponse> = m
     SiteResponse(
         id = site.id,
         name = site.name,
+        colour = site.colour,
         longitude = site.longitude,
         latitude = site.latitude,
         radius = site.radius,

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/SiteResponses.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/model/responses/SiteResponses.jvm.kt
@@ -8,6 +8,7 @@ import java.util.UUID
 data class SiteResponse(
     val id: UUID,
     val name: String,
+    val colour: String,
     val longitude: Double,
     val latitude: Double,
     val radius: Int,
@@ -29,6 +30,7 @@ internal fun List<BasicSiteResponse>.toSiteResponse(): List<SiteResponse> = map 
     SiteResponse(
         id = site.id.toUuid(),
         name = site.name,
+        colour = site.colour,
         longitude = site.longitude,
         latitude = site.latitude,
         radius = site.radius,

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/SiteResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/SiteResponses.cs
@@ -4,6 +4,7 @@ public class SiteResponse
 {
     public string Id { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
+    public string Colour { get; set; } = string.Empty;
     public double Longitude { get; set; }
     public double Latitude { get; set; }
     public int Radius { get; set; }


### PR DESCRIPTION
The `colour` field from the site response is still used in the web UI, so it has been re-added (it was removed [here](https://github.com/doordeck/doordeck-headless-sdk/pull/247#discussion_r2275791907))