### PR TITLE
Enhance data integrity - Mingw

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,18 +24,18 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - name: JVM
-            test: jvmTest
-            os: ubuntu-latest
-          - name: Android
-            test: testReleaseUnitTest
-            os: ubuntu-latest
-          - name: JS
-            test: kotlinUpgradeYarnLock jsTest
-            os: ubuntu-latest
-          - name: Apple
-            test: macosArm64Test iosSimulatorArm64Test watchosSimulatorArm64Test
-            os: macos-latest
+#          - name: JVM
+#            test: jvmTest
+#            os: ubuntu-latest
+#          - name: Android
+#            test: testReleaseUnitTest
+#            os: ubuntu-latest
+#          - name: JS
+#            test: kotlinUpgradeYarnLock jsTest
+#            os: ubuntu-latest
+#          - name: Apple
+#            test: macosArm64Test iosSimulatorArm64Test watchosSimulatorArm64Test
+#            os: macos-latest
           - name: Windows
             test: mingwX64Test
             os: windows-latest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,18 +24,18 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-#          - name: JVM
-#            test: jvmTest
-#            os: ubuntu-latest
-#          - name: Android
-#            test: testReleaseUnitTest
-#            os: ubuntu-latest
-#          - name: JS
-#            test: kotlinUpgradeYarnLock jsTest
-#            os: ubuntu-latest
-#          - name: Apple
-#            test: macosArm64Test iosSimulatorArm64Test watchosSimulatorArm64Test
-#            os: macos-latest
+          - name: JVM
+            test: jvmTest
+            os: ubuntu-latest
+          - name: Android
+            test: testReleaseUnitTest
+            os: ubuntu-latest
+          - name: JS
+            test: kotlinUpgradeYarnLock jsTest
+            os: ubuntu-latest
+          - name: Apple
+            test: macosArm64Test iosSimulatorArm64Test watchosSimulatorArm64Test
+            os: macos-latest
           - name: Windows
             test: mingwX64Test
             os: windows-latest

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/Platform.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/Platform.mingw.kt
@@ -1,5 +1,11 @@
 package com.doordeck.multiplatform.sdk
 
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CFunction
+import kotlinx.cinterop.CPointer
+
 actual val platformType: PlatformType = PlatformType.WINDOWS
 
 internal actual object ApplicationContext
+
+typealias CStringCallback = CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountApi.mingw.kt
@@ -1,5 +1,6 @@
 package com.doordeck.multiplatform.sdk.api
 
+import com.doordeck.multiplatform.sdk.CStringCallback
 import com.doordeck.multiplatform.sdk.annotations.DoordeckOnly
 import com.doordeck.multiplatform.sdk.clients.AccountClient
 import com.doordeck.multiplatform.sdk.model.data.ChangePasswordData
@@ -9,11 +10,8 @@ import com.doordeck.multiplatform.sdk.model.data.RegisterEphemeralKeyWithSeconda
 import com.doordeck.multiplatform.sdk.model.data.UpdateUserDetailsData
 import com.doordeck.multiplatform.sdk.model.data.VerifyEphemeralKeyRegistrationData
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
-import com.doordeck.multiplatform.sdk.util.callback
+import com.doordeck.multiplatform.sdk.util.handleCallback
 import com.doordeck.multiplatform.sdk.util.fromJson
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CFunction
-import kotlinx.cinterop.CPointer
 
 actual object AccountApi {
     /**
@@ -23,14 +21,9 @@ actual object AccountApi {
      */
     @DoordeckOnly
     @CName("refreshToken")
-    fun refreshToken(data: String? = null, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val refreshTokenData = data?.fromJson<RefreshTokenData>()
-                AccountClient.refreshTokenRequest(refreshTokenData?.refreshToken)
-            },
-            callback = callback
-        )
+    fun refreshToken(data: String? = null, callback: CStringCallback) = callback.handleCallback {
+        val refreshTokenData = data?.fromJson<RefreshTokenData>()
+        AccountClient.refreshTokenRequest(refreshTokenData?.refreshToken)
     }
 
     /**
@@ -39,13 +32,8 @@ actual object AccountApi {
      * @see <a href="https://developer.doordeck.com/docs/#logout">API Doc</a>
      */
     @CName("logout")
-    fun logout(callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                AccountClient.logoutRequest()
-            },
-            callback = callback
-        )
+    fun logout(callback: CStringCallback) = callback.handleCallback {
+        AccountClient.logoutRequest()
     }
 
     /**
@@ -54,16 +42,11 @@ actual object AccountApi {
      * @see <a href="https://developer.doordeck.com/docs/#register-ephemeral-key">API Doc</a>
      */
     @CName("registerEphemeralKey")
-    fun registerEphemeralKey(data: String? = null, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val registerEphemeralKeyData = data?.fromJson<RegisterEphemeralKeyData>()
-                AccountClient.registerEphemeralKeyRequest(
-                    publicKey = registerEphemeralKeyData?.publicKey?.decodeBase64ToByteArray(),
-                    privateKey = registerEphemeralKeyData?.privateKey?.decodeBase64ToByteArray(),
-                )
-            },
-            callback = callback
+    fun registerEphemeralKey(data: String? = null, callback: CStringCallback) = callback.handleCallback {
+        val registerEphemeralKeyData = data?.fromJson<RegisterEphemeralKeyData>()
+        AccountClient.registerEphemeralKeyRequest(
+            publicKey = registerEphemeralKeyData?.publicKey?.decodeBase64ToByteArray(),
+            privateKey = registerEphemeralKeyData?.privateKey?.decodeBase64ToByteArray()
         )
     }
 
@@ -73,15 +56,15 @@ actual object AccountApi {
      * @see <a href="https://developer.doordeck.com/docs/#register-ephemeral-key-with-secondary-authentication">API Doc</a>
      */
     @CName("registerEphemeralKeyWithSecondaryAuthentication")
-    fun registerEphemeralKeyWithSecondaryAuthentication(data: String? = null, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val registerEphemeralKeyWithSecondaryAuthenticationData = data?.fromJson<RegisterEphemeralKeyWithSecondaryAuthenticationData>()
-                AccountClient.registerEphemeralKeyWithSecondaryAuthenticationRequest(
-                    publicKey = registerEphemeralKeyWithSecondaryAuthenticationData?.publicKey?.decodeBase64ToByteArray(),
-                    method = registerEphemeralKeyWithSecondaryAuthenticationData?.method)
-            },
-            callback = callback
+    fun registerEphemeralKeyWithSecondaryAuthentication(
+        data: String? = null,
+        callback: CStringCallback
+    ) = callback.handleCallback {
+        val registerEphemeralKeyWithSecondaryAuthenticationData = data
+            ?.fromJson<RegisterEphemeralKeyWithSecondaryAuthenticationData>()
+        AccountClient.registerEphemeralKeyWithSecondaryAuthenticationRequest(
+            publicKey = registerEphemeralKeyWithSecondaryAuthenticationData?.publicKey?.decodeBase64ToByteArray(),
+            method = registerEphemeralKeyWithSecondaryAuthenticationData?.method
         )
     }
 
@@ -91,17 +74,12 @@ actual object AccountApi {
      * @see <a href="https://developer.doordeck.com/docs/#verify-ephemeral-key-registration">API Doc</a>
      */
     @CName("verifyEphemeralKeyRegistration")
-    fun verifyEphemeralKeyRegistration(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val verifyEphemeralKeyRegistrationData = data.fromJson<VerifyEphemeralKeyRegistrationData>()
-                AccountClient.verifyEphemeralKeyRegistrationRequest(
-                    code = verifyEphemeralKeyRegistrationData.code,
-                    publicKey = verifyEphemeralKeyRegistrationData.publicKey?.decodeBase64ToByteArray(),
-                    privateKey = verifyEphemeralKeyRegistrationData.privateKey?.decodeBase64ToByteArray()
-                )
-            },
-            callback = callback
+    fun verifyEphemeralKeyRegistration(data: String, callback: CStringCallback) = callback.handleCallback {
+        val verifyEphemeralKeyRegistrationData = data.fromJson<VerifyEphemeralKeyRegistrationData>()
+        AccountClient.verifyEphemeralKeyRegistrationRequest(
+            code = verifyEphemeralKeyRegistrationData.code,
+            publicKey = verifyEphemeralKeyRegistrationData.publicKey?.decodeBase64ToByteArray(),
+            privateKey = verifyEphemeralKeyRegistrationData.privateKey?.decodeBase64ToByteArray()
         )
     }
 
@@ -112,13 +90,8 @@ actual object AccountApi {
      */
     @DoordeckOnly
     @CName("reverifyEmail")
-    fun reverifyEmail(callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                AccountClient.reverifyEmailRequest()
-            },
-            callback = callback
-        )
+    fun reverifyEmail(callback: CStringCallback) = callback.handleCallback {
+        AccountClient.reverifyEmailRequest()
     }
 
     /**
@@ -128,13 +101,11 @@ actual object AccountApi {
      */
     @DoordeckOnly
     @CName("changePassword")
-    fun changePassword(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val changePasswordData = data.fromJson<ChangePasswordData>()
-                AccountClient.changePasswordRequest(changePasswordData.oldPassword, changePasswordData.newPassword)
-            },
-            callback = callback
+    fun changePassword(data: String, callback: CStringCallback) = callback.handleCallback {
+        val changePasswordData = data.fromJson<ChangePasswordData>()
+        AccountClient.changePasswordRequest(
+            oldPassword = changePasswordData.oldPassword,
+            newPassword = changePasswordData.newPassword
         )
     }
 
@@ -144,13 +115,8 @@ actual object AccountApi {
      * @see <a href="https://developer.doordeck.com/docs/#get-user-details">API Doc</a>
      */
     @CName("getUserDetails")
-    fun getUserDetails(callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                AccountClient.getUserDetailsRequest()
-            },
-            callback = callback
-        )
+    fun getUserDetails(callback: CStringCallback) = callback.handleCallback {
+        AccountClient.getUserDetailsRequest()
     }
 
     /**
@@ -159,14 +125,11 @@ actual object AccountApi {
      * @see <a href="https://developer.doordeck.com/docs/#update-user-details">API Doc</a>
      */
     @CName("updateUserDetails")
-    fun updateUserDetails(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateUserDetailsData = data.fromJson<UpdateUserDetailsData>()
-                AccountClient.updateUserDetailsRequest(updateUserDetailsData.displayName)
-            },
-            callback = callback
-        )
+    fun updateUserDetails(data: String, callback: CStringCallback) {
+        callback.handleCallback {
+            val updateUserDetailsData = data.fromJson<UpdateUserDetailsData>()
+            AccountClient.updateUserDetailsRequest(updateUserDetailsData.displayName)
+        }
     }
 
     /**
@@ -175,13 +138,8 @@ actual object AccountApi {
      * @see <a href="https://developer.doordeck.com/docs/#delete-account">API Doc</a>
      */
     @CName("deleteAccount")
-    fun deleteAccount(callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                AccountClient.deleteAccountRequest()
-            },
-            callback = callback
-        )
+    fun deleteAccount(callback: CStringCallback) = callback.handleCallback {
+        AccountClient.deleteAccountRequest()
     }
 }
 

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountlessApi.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/AccountlessApi.mingw.kt
@@ -1,5 +1,6 @@
 package com.doordeck.multiplatform.sdk.api
 
+import com.doordeck.multiplatform.sdk.CStringCallback
 import com.doordeck.multiplatform.sdk.clients.AccountlessClient
 import com.doordeck.multiplatform.sdk.model.data.LoginData
 import com.doordeck.multiplatform.sdk.model.data.PasswordResetData
@@ -7,11 +8,8 @@ import com.doordeck.multiplatform.sdk.model.data.PasswordResetVerifyData
 import com.doordeck.multiplatform.sdk.model.data.RegistrationData
 import com.doordeck.multiplatform.sdk.model.data.VerifyEmailData
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
-import com.doordeck.multiplatform.sdk.util.callback
+import com.doordeck.multiplatform.sdk.util.handleCallback
 import com.doordeck.multiplatform.sdk.util.fromJson
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CFunction
-import kotlinx.cinterop.CPointer
 
 actual object AccountlessApi {
     /**
@@ -20,16 +18,11 @@ actual object AccountlessApi {
      * @see <a href="https://developer.doordeck.com/docs/#login-v2">API Doc</a>
      */
     @CName("login")
-    fun login(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val loginData = data.fromJson<LoginData>()
-                AccountlessClient.loginRequest(
-                    email = loginData.email,
-                    password = loginData.password
-                )
-            },
-            callback = callback
+    fun login(data: String, callback: CStringCallback) = callback.handleCallback {
+        val loginData = data.fromJson<LoginData>()
+        AccountlessClient.loginRequest(
+            email = loginData.email,
+            password = loginData.password
         )
     }
 
@@ -39,19 +32,14 @@ actual object AccountlessApi {
      * @see <a href="https://developer.doordeck.com/docs/#registration-v3">API Doc</a>
      */
     @CName("registration")
-    fun registration(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val registrationData = data.fromJson<RegistrationData>()
-                AccountlessClient.registrationRequest(
-                    email = registrationData.email,
-                    password = registrationData.password,
-                    displayName = registrationData.displayName,
-                    force = registrationData.force,
-                    publicKey = registrationData.publicKey?.decodeBase64ToByteArray()
-                )
-            },
-            callback = callback
+    fun registration(data: String, callback: CStringCallback) = callback.handleCallback {
+        val registrationData = data.fromJson<RegistrationData>()
+        AccountlessClient.registrationRequest(
+            email = registrationData.email,
+            password = registrationData.password,
+            displayName = registrationData.displayName,
+            force = registrationData.force,
+            publicKey = registrationData.publicKey?.decodeBase64ToByteArray()
         )
     }
 
@@ -61,45 +49,30 @@ actual object AccountlessApi {
      * @see <a href="https://developer.doordeck.com/docs/#verify-email">API Doc</a>
      */
     @CName("verifyEmail")
-    fun verifyEmail(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val verifyEmailData = data.fromJson<VerifyEmailData>()
-                AccountlessClient.verifyEmailRequest(verifyEmailData.code)
-            },
-            callback = callback
-        )
+    fun verifyEmail(data: String, callback: CStringCallback) = callback.handleCallback {
+        val verifyEmailData = data.fromJson<VerifyEmailData>()
+        AccountlessClient.verifyEmailRequest(verifyEmailData.code)
     }
 
     /**
      * Password reset
      */
     @CName("passwordReset")
-    fun passwordReset(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val passwordResetData = data.fromJson<PasswordResetData>()
-                AccountlessClient.passwordResetRequest(passwordResetData.email)
-            },
-            callback = callback
-        )
+    fun passwordReset(data: String, callback: CStringCallback) = callback.handleCallback {
+        val passwordResetData = data.fromJson<PasswordResetData>()
+        AccountlessClient.passwordResetRequest(passwordResetData.email)
     }
 
     /**
      * Password reset verify
      */
     @CName("passwordResetVerify")
-    fun passwordResetVerify(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val passwordResetVerifyData = data.fromJson<PasswordResetVerifyData>()
-                AccountlessClient.passwordResetVerifyRequest(
-                    userId = passwordResetVerifyData.userId,
-                    token = passwordResetVerifyData.token,
-                    password = passwordResetVerifyData.password
-                )
-            },
-            callback = callback
+    fun passwordResetVerify(data: String, callback: CStringCallback) = callback.handleCallback {
+        val passwordResetVerifyData = data.fromJson<PasswordResetVerifyData>()
+        AccountlessClient.passwordResetVerifyRequest(
+            userId = passwordResetVerifyData.userId,
+            token = passwordResetVerifyData.token,
+            password = passwordResetVerifyData.password
         )
     }
 }

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/FusionApi.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/FusionApi.mingw.kt
@@ -1,112 +1,77 @@
 package com.doordeck.multiplatform.sdk.api
 
+import com.doordeck.multiplatform.sdk.CStringCallback
 import com.doordeck.multiplatform.sdk.annotations.DoordeckOnly
 import com.doordeck.multiplatform.sdk.clients.FusionClient
 import com.doordeck.multiplatform.sdk.model.data.DeviceIdData
 import com.doordeck.multiplatform.sdk.model.data.EnableDoorData
 import com.doordeck.multiplatform.sdk.model.data.FusionLoginData
 import com.doordeck.multiplatform.sdk.model.data.GetIntegrationConfigurationData
-import com.doordeck.multiplatform.sdk.util.callback
 import com.doordeck.multiplatform.sdk.util.fromJson
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CFunction
-import kotlinx.cinterop.CPointer
+import com.doordeck.multiplatform.sdk.util.handleCallback
 
 actual object FusionApi {
 
     @DoordeckOnly
     @CName("loginFusion")
-    fun login(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val fusionLoginData = data.fromJson<FusionLoginData>()
-                FusionClient.loginRequest(fusionLoginData.email, fusionLoginData.password)
-            },
-            callback = callback
+    fun login(data: String, callback: CStringCallback) = callback.handleCallback {
+        val fusionLoginData = data.fromJson<FusionLoginData>()
+        FusionClient.loginRequest(
+            email = fusionLoginData.email,
+            password = fusionLoginData.password
         )
     }
 
     @DoordeckOnly
     @CName("getIntegrationType")
-    fun getIntegrationType(callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                FusionClient.getIntegrationTypeRequest()
-            },
-            callback = callback
-        )
+    fun getIntegrationType(callback: CStringCallback) = callback.handleCallback {
+        FusionClient.getIntegrationTypeRequest()
     }
 
     @DoordeckOnly
     @CName("getIntegrationConfiguration")
-    fun getIntegrationConfiguration(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getIntegrationConfigurationData = data.fromJson<GetIntegrationConfigurationData>()
-                FusionClient.getIntegrationConfigurationRequest(getIntegrationConfigurationData.type)
-            },
-            callback = callback
-        )
+    fun getIntegrationConfiguration(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getIntegrationConfigurationData = data.fromJson<GetIntegrationConfigurationData>()
+        FusionClient.getIntegrationConfigurationRequest(getIntegrationConfigurationData.type)
     }
 
     @DoordeckOnly
     @CName("enableDoor")
-    fun enableDoor(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val enableDoorData = data.fromJson<EnableDoorData>()
-                FusionClient.enableDoorRequest(enableDoorData.name, enableDoorData.siteId, enableDoorData.controller)
-            },
-            callback = callback
+    fun enableDoor(data: String, callback: CStringCallback) = callback.handleCallback {
+        val enableDoorData = data.fromJson<EnableDoorData>()
+        FusionClient.enableDoorRequest(
+            name = enableDoorData.name,
+            siteId = enableDoorData.siteId,
+            controller = enableDoorData.controller
         )
     }
 
     @DoordeckOnly
     @CName("deleteDoor")
-    fun deleteDoor(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val deviceIdData = data.fromJson<DeviceIdData>()
-                FusionClient.deleteDoorRequest(deviceIdData.deviceId)
-            },
-            callback = callback
-        )
+    fun deleteDoor(data: String, callback: CStringCallback) = callback.handleCallback {
+        val deviceIdData = data.fromJson<DeviceIdData>()
+        FusionClient.deleteDoorRequest(deviceIdData.deviceId)
     }
 
     @DoordeckOnly
     @CName("getDoorStatus")
-    fun getDoorStatus(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val deviceIdData = data.fromJson<DeviceIdData>()
-                FusionClient.getDoorStatusRequest(deviceIdData.deviceId)
-            },
-            callback = callback
-        )
+    fun getDoorStatus(data: String, callback: CStringCallback) = callback.handleCallback {
+        val deviceIdData = data.fromJson<DeviceIdData>()
+        FusionClient.getDoorStatusRequest(deviceIdData.deviceId)
     }
 
     @DoordeckOnly
     @CName("startDoor")
-    fun startDoor(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val deviceIdData = data.fromJson<DeviceIdData>()
-                FusionClient.startDoorRequest(deviceIdData.deviceId)
-            },
-            callback = callback
-        )
+    fun startDoor(data: String, callback: CStringCallback) = callback.handleCallback {
+        val deviceIdData = data.fromJson<DeviceIdData>()
+        FusionClient.startDoorRequest(deviceIdData.deviceId)
     }
 
     @DoordeckOnly
     @CName("stopDoor")
-    fun stopDoor(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val deviceIdData = data.fromJson<DeviceIdData>()
-                FusionClient.stopDoorRequest(deviceIdData.deviceId)
-            },
-            callback = callback
-        )
+    fun stopDoor(data: String, callback: CStringCallback) = callback.handleCallback {
+        val deviceIdData = data.fromJson<DeviceIdData>()
+        FusionClient.stopDoorRequest(deviceIdData.deviceId)
     }
 }
 

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/HelperApi.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/HelperApi.mingw.kt
@@ -1,72 +1,53 @@
 package com.doordeck.multiplatform.sdk.api
 
+import com.doordeck.multiplatform.sdk.CStringCallback
 import com.doordeck.multiplatform.sdk.clients.HelperClient
 import com.doordeck.multiplatform.sdk.model.data.AssistedLoginData
 import com.doordeck.multiplatform.sdk.model.data.AssistedRegisterData
 import com.doordeck.multiplatform.sdk.model.data.AssistedRegisterEphemeralKeyData
 import com.doordeck.multiplatform.sdk.model.data.UploadPlatformLogoData
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
-import com.doordeck.multiplatform.sdk.util.callback
 import com.doordeck.multiplatform.sdk.util.fromJson
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CFunction
-import kotlinx.cinterop.CPointer
+import com.doordeck.multiplatform.sdk.util.handleCallback
 
 actual object HelperApi {
 
     @CName("uploadPlatformLogo")
-    fun uploadPlatformLogo(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val uploadPlatformLogoData = data.fromJson<UploadPlatformLogoData>()
-                HelperClient.uploadPlatformLogoRequest(
-                    applicationId = uploadPlatformLogoData.applicationId,
-                    contentType = uploadPlatformLogoData.contentType,
-                    image = uploadPlatformLogoData.image.decodeBase64ToByteArray()
-                )
-            },
-            callback = callback
+    fun uploadPlatformLogo(data: String, callback: CStringCallback) = callback.handleCallback {
+        val uploadPlatformLogoData = data.fromJson<UploadPlatformLogoData>()
+        HelperClient.uploadPlatformLogoRequest(
+            applicationId = uploadPlatformLogoData.applicationId,
+            contentType = uploadPlatformLogoData.contentType,
+            image = uploadPlatformLogoData.image.decodeBase64ToByteArray()
         )
     }
 
     @CName("assistedLogin")
-    fun assistedLogin(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val assistedLoginData = data.fromJson<AssistedLoginData>()
-                HelperClient.assistedLoginRequest(assistedLoginData.email, assistedLoginData.password)
-            },
-            callback = callback
+    fun assistedLogin(data: String, callback: CStringCallback) = callback.handleCallback {
+        val assistedLoginData = data.fromJson<AssistedLoginData>()
+        HelperClient.assistedLoginRequest(
+            email = assistedLoginData.email,
+            password = assistedLoginData.password
         )
     }
 
     @CName("assistedRegisterEphemeralKey")
-    fun assistedRegisterEphemeralKey(data: String? = null, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val assistedRegisterEphemeralKeyData = data?.fromJson<AssistedRegisterEphemeralKeyData>()
-                HelperClient.assistedRegisterEphemeralKeyRequest(
-                    publicKey = assistedRegisterEphemeralKeyData?.publicKey?.decodeBase64ToByteArray(),
-                    privateKey = assistedRegisterEphemeralKeyData?.privateKey?.decodeBase64ToByteArray()
-                )
-            },
-            callback = callback
+    fun assistedRegisterEphemeralKey(data: String? = null, callback: CStringCallback) = callback.handleCallback {
+        val assistedRegisterEphemeralKeyData = data?.fromJson<AssistedRegisterEphemeralKeyData>()
+        HelperClient.assistedRegisterEphemeralKeyRequest(
+            publicKey = assistedRegisterEphemeralKeyData?.publicKey?.decodeBase64ToByteArray(),
+            privateKey = assistedRegisterEphemeralKeyData?.privateKey?.decodeBase64ToByteArray()
         )
     }
 
     @CName("assistedRegister")
-    fun assistedRegister(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val assistedRegisterData = data.fromJson<AssistedRegisterData>()
-                HelperClient.assistedRegisterRequest(
-                    email = assistedRegisterData.email,
-                    password = assistedRegisterData.password,
-                    displayName = assistedRegisterData.displayName,
-                    force = assistedRegisterData.force
-                )
-            },
-            callback = callback
+    fun assistedRegister(data: String, callback: CStringCallback) = callback.handleCallback {
+        val assistedRegisterData = data.fromJson<AssistedRegisterData>()
+        HelperClient.assistedRegisterRequest(
+            email = assistedRegisterData.email,
+            password = assistedRegisterData.password,
+            displayName = assistedRegisterData.displayName,
+            force = assistedRegisterData.force
         )
     }
 }

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsApi.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsApi.mingw.kt
@@ -1,5 +1,6 @@
 package com.doordeck.multiplatform.sdk.api
 
+import com.doordeck.multiplatform.sdk.CStringCallback
 import com.doordeck.multiplatform.sdk.clients.LockOperationsClient
 import com.doordeck.multiplatform.sdk.model.data.BatchShareLockOperationData
 import com.doordeck.multiplatform.sdk.model.data.GetAuditForUserData
@@ -37,11 +38,8 @@ import com.doordeck.multiplatform.sdk.model.data.toTimeRequirementList
 import com.doordeck.multiplatform.sdk.model.data.toUnlockOperation
 import com.doordeck.multiplatform.sdk.model.data.toUpdateSecureSettingUnlockBetween
 import com.doordeck.multiplatform.sdk.model.data.toUpdateSecureSettingUnlockDuration
-import com.doordeck.multiplatform.sdk.util.callback
 import com.doordeck.multiplatform.sdk.util.fromJson
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CFunction
-import kotlinx.cinterop.CPointer
+import com.doordeck.multiplatform.sdk.util.handleCallback
 
 actual object LockOperationsApi {
     /**
@@ -50,14 +48,9 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#get-a-single-lock">API Doc</a>
      */
     @CName("getSingleLock")
-    fun getSingleLock(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getSingleLockData = data.fromJson<GetSingleLockData>()
-                LockOperationsClient.getSingleLockRequest(getSingleLockData.lockId)
-            },
-            callback = callback
-        )
+    fun getSingleLock(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getSingleLockData = data.fromJson<GetSingleLockData>()
+        LockOperationsClient.getSingleLockRequest(getSingleLockData.lockId)
     }
 
     /**
@@ -66,13 +59,12 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#get-lock-audit-trail-v2">API Doc</a>
      */
     @CName("getLockAuditTrail")
-    fun getLockAuditTrail(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getLockAuditTrailData = data.fromJson<GetLockAuditTrailData>()
-                LockOperationsClient.getLockAuditTrailRequest(getLockAuditTrailData.lockId, getLockAuditTrailData.start, getLockAuditTrailData.end)
-            },
-            callback = callback
+    fun getLockAuditTrail(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getLockAuditTrailData = data.fromJson<GetLockAuditTrailData>()
+        LockOperationsClient.getLockAuditTrailRequest(
+            lockId = getLockAuditTrailData.lockId,
+            start = getLockAuditTrailData.start,
+            end = getLockAuditTrailData.end
         )
     }
 
@@ -82,13 +74,12 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#get-audit-for-a-user">API Doc</a>
      */
     @CName("getAuditForUser")
-    fun getAuditForUser(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getAuditForUserData = data.fromJson<GetAuditForUserData>()
-                LockOperationsClient.getAuditForUserRequest(getAuditForUserData.userId, getAuditForUserData.start, getAuditForUserData.end)
-            },
-            callback = callback
+    fun getAuditForUser(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getAuditForUserData = data.fromJson<GetAuditForUserData>()
+        LockOperationsClient.getAuditForUserRequest(
+            userId = getAuditForUserData.userId,
+            start = getAuditForUserData.start,
+            end = getAuditForUserData.end
         )
     }
 
@@ -98,14 +89,9 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#get-users-for-a-lock">API Doc</a>
      */
     @CName("getUsersForLock")
-    fun getUsersForLock(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getUsersForLockData = data.fromJson<GetUsersForLockData>()
-                LockOperationsClient.getUsersForLockRequest(getUsersForLockData.lockId)
-            },
-            callback = callback
-        )
+    fun getUsersForLock(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getUsersForLockData = data.fromJson<GetUsersForLockData>()
+        LockOperationsClient.getUsersForLockRequest(getUsersForLockData.lockId)
     }
 
     /**
@@ -114,14 +100,9 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#get-locks-for-a-user">API Doc</a>
      */
     @CName("getLocksForUser")
-    fun getLocksForUser(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getLocksForUserData = data.fromJson<GetLocksForUserData>()
-                LockOperationsClient.getLocksForUserRequest(getLocksForUserData.userId)
-            },
-            callback = callback
-        )
+    fun getLocksForUser(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getLocksForUserData = data.fromJson<GetLocksForUserData>()
+        LockOperationsClient.getLocksForUserRequest(getLocksForUserData.userId)
     }
 
     /**
@@ -130,13 +111,11 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     @CName("updateLockName")
-    fun updateLockName(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateLockNameData = data.fromJson<UpdateLockNameData>()
-                LockOperationsClient.updateLockNameRequest(updateLockNameData.lockId, updateLockNameData.name)
-            },
-            callback = callback
+    fun updateLockName(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateLockNameData = data.fromJson<UpdateLockNameData>()
+        LockOperationsClient.updateLockNameRequest(
+            lockId = updateLockNameData.lockId,
+            name = updateLockNameData.name
         )
     }
 
@@ -146,13 +125,11 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     @CName("updateLockFavourite")
-    fun updateLockFavourite(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateLockFavouriteData = data.fromJson<UpdateLockFavouriteData>()
-                LockOperationsClient.updateLockFavouriteRequest(updateLockFavouriteData.lockId, updateLockFavouriteData.favourite)
-            },
-            callback = callback
+    fun updateLockFavourite(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateLockFavouriteData = data.fromJson<UpdateLockFavouriteData>()
+        LockOperationsClient.updateLockFavouriteRequest(
+            lockId = updateLockFavouriteData.lockId,
+            favourite = updateLockFavouriteData.favourite
         )
     }
 
@@ -162,13 +139,11 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     @CName("updateLockSettingDefaultName")
-    fun updateLockSettingDefaultName(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateLockSettingDefaultNameData = data.fromJson<UpdateLockSettingDefaultNameData>()
-                LockOperationsClient.updateLockSettingDefaultNameRequest(updateLockSettingDefaultNameData.lockId, updateLockSettingDefaultNameData.name)
-            },
-            callback = callback
+    fun updateLockSettingDefaultName(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateLockSettingDefaultNameData = data.fromJson<UpdateLockSettingDefaultNameData>()
+        LockOperationsClient.updateLockSettingDefaultNameRequest(
+            lockId = updateLockSettingDefaultNameData.lockId,
+            name = updateLockSettingDefaultNameData.name
         )
     }
 
@@ -178,13 +153,11 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     @CName("setLockSettingPermittedAddresses")
-    fun setLockSettingPermittedAddresses(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val setLockSettingPermittedAddressesData = data.fromJson<SetLockSettingPermittedAddressesData>()
-                LockOperationsClient.setLockSettingPermittedAddressesRequest(setLockSettingPermittedAddressesData.lockId, setLockSettingPermittedAddressesData.permittedAddresses)
-            },
-            callback = callback
+    fun setLockSettingPermittedAddresses(data: String, callback: CStringCallback) = callback.handleCallback {
+        val setLockSettingPermittedAddressesData = data.fromJson<SetLockSettingPermittedAddressesData>()
+        LockOperationsClient.setLockSettingPermittedAddressesRequest(
+            lockId = setLockSettingPermittedAddressesData.lockId,
+            permittedAddresses = setLockSettingPermittedAddressesData.permittedAddresses
         )
     }
 
@@ -194,13 +167,11 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     @CName("updateLockSettingHidden")
-    fun updateLockSettingHidden(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateLockSettingHiddenData = data.fromJson<UpdateLockSettingHiddenData>()
-                LockOperationsClient.updateLockSettingHiddenRequest(updateLockSettingHiddenData.lockId, updateLockSettingHiddenData.hidden)
-            },
-            callback = callback
+    fun updateLockSettingHidden(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateLockSettingHiddenData = data.fromJson<UpdateLockSettingHiddenData>()
+        LockOperationsClient.updateLockSettingHiddenRequest(
+            lockId = updateLockSettingHiddenData.lockId,
+            hidden = updateLockSettingHiddenData.hidden
         )
     }
 
@@ -210,13 +181,11 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     @CName("setLockSettingTimeRestrictions")
-    fun setLockSettingTimeRestrictions(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val setLockSettingTimeRestrictionsData = data.fromJson<SetLockSettingTimeRestrictionsData>()
-                LockOperationsClient.setLockSettingTimeRestrictionsRequest(setLockSettingTimeRestrictionsData.lockId, setLockSettingTimeRestrictionsData.times.toTimeRequirementList())
-            },
-            callback = callback
+    fun setLockSettingTimeRestrictions(data: String, callback: CStringCallback) = callback.handleCallback {
+        val setLockSettingTimeRestrictionsData = data.fromJson<SetLockSettingTimeRestrictionsData>()
+        LockOperationsClient.setLockSettingTimeRestrictionsRequest(
+            lockId = setLockSettingTimeRestrictionsData.lockId,
+            times = setLockSettingTimeRestrictionsData.times.toTimeRequirementList()
         )
     }
 
@@ -226,13 +195,11 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#update-lock-properties">API Doc</a>
      */
     @CName("updateLockSettingLocationRestrictions")
-    fun updateLockSettingLocationRestrictions(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateLockSettingLocationRestrictionsData = data.fromJson<UpdateLockSettingLocationRestrictionsData>()
-                LockOperationsClient.updateLockSettingLocationRestrictionsRequest(updateLockSettingLocationRestrictionsData.lockId, updateLockSettingLocationRestrictionsData.location?.toLocationRequirement())
-            },
-            callback = callback
+    fun updateLockSettingLocationRestrictions(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateLockSettingLocationRestrictionsData = data.fromJson<UpdateLockSettingLocationRestrictionsData>()
+        LockOperationsClient.updateLockSettingLocationRestrictionsRequest(
+            lockId = updateLockSettingLocationRestrictionsData.lockId,
+            location = updateLockSettingLocationRestrictionsData.location?.toLocationRequirement()
         )
     }
 
@@ -242,13 +209,11 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#get-a-doordeck-user-s-public-key">API Doc</a>
      */
     @CName("getUserPublicKey")
-    fun getUserPublicKey(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getUserPublicKeyData = data.fromJson<GetUserPublicKeyData>()
-                LockOperationsClient.getUserPublicKeyRequest(getUserPublicKeyData.userEmail, getUserPublicKeyData.visitor)
-            },
-            callback = callback
+    fun getUserPublicKey(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getUserPublicKeyData = data.fromJson<GetUserPublicKeyData>()
+        LockOperationsClient.getUserPublicKeyRequest(
+            userEmail = getUserPublicKeyData.userEmail,
+            visitor = getUserPublicKeyData.visitor
         )
     }
 
@@ -258,14 +223,9 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#lookup-user-public-key-v1">API Doc</a>
      */
     @CName("getUserPublicKeyByEmail")
-    fun getUserPublicKeyByEmail(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getUserPublicKeyData = data.fromJson<GetUserPublicKeyByEmailData>()
-                LockOperationsClient.getUserPublicKeyByEmailRequest(getUserPublicKeyData.email)
-            },
-            callback = callback
-        )
+    fun getUserPublicKeyByEmail(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getUserPublicKeyData = data.fromJson<GetUserPublicKeyByEmailData>()
+        LockOperationsClient.getUserPublicKeyByEmailRequest(getUserPublicKeyData.email)
     }
 
     /**
@@ -274,14 +234,9 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#lookup-user-public-key-v1">API Doc</a>
      */
     @CName("getUserPublicKeyByTelephone")
-    fun getUserPublicKeyByTelephone(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getUserPublicKeyByTelephoneData = data.fromJson<GetUserPublicKeyByTelephoneData>()
-                LockOperationsClient.getUserPublicKeyByTelephoneRequest(getUserPublicKeyByTelephoneData.telephone)
-            },
-            callback = callback
-        )
+    fun getUserPublicKeyByTelephone(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getUserPublicKeyByTelephoneData = data.fromJson<GetUserPublicKeyByTelephoneData>()
+        LockOperationsClient.getUserPublicKeyByTelephoneRequest(getUserPublicKeyByTelephoneData.telephone)
     }
 
     /**
@@ -290,14 +245,9 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#lookup-user-public-key-v1">API Doc</a>
      */
     @CName("getUserPublicKeyByLocalKey")
-    fun getUserPublicKeyByLocalKey(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getUserPublicKeyByLocalKeyData = data.fromJson<GetUserPublicKeyByLocalKeyData>()
-                LockOperationsClient.getUserPublicKeyByLocalKeyRequest(getUserPublicKeyByLocalKeyData.localKey)
-            },
-            callback = callback
-        )
+    fun getUserPublicKeyByLocalKey(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getUserPublicKeyByLocalKeyData = data.fromJson<GetUserPublicKeyByLocalKeyData>()
+        LockOperationsClient.getUserPublicKeyByLocalKeyRequest(getUserPublicKeyByLocalKeyData.localKey)
     }
 
     /**
@@ -306,14 +256,9 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#lookup-user-public-key-v1">API Doc</a>
      */
     @CName("getUserPublicKeyByForeignKey")
-    fun getUserPublicKeyByForeignKey(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getUserPublicKeyByForeignKeyData = data.fromJson<GetUserPublicKeyByForeignKeyData>()
-                LockOperationsClient.getUserPublicKeyByForeignKeyRequest(getUserPublicKeyByForeignKeyData.foreignKey)
-            },
-            callback = callback
-        )
+    fun getUserPublicKeyByForeignKey(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getUserPublicKeyByForeignKeyData = data.fromJson<GetUserPublicKeyByForeignKeyData>()
+        LockOperationsClient.getUserPublicKeyByForeignKeyRequest(getUserPublicKeyByForeignKeyData.foreignKey)
     }
 
     /**
@@ -322,14 +267,9 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#lookup-user-public-key-v1">API Doc</a>
      */
     @CName("getUserPublicKeyByIdentity")
-    fun getUserPublicKeyByIdentity(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getUserPublicKeyByIdentityData = data.fromJson<GetUserPublicKeyByIdentityData>()
-                LockOperationsClient.getUserPublicKeyByIdentityRequest(getUserPublicKeyByIdentityData.identity)
-            },
-            callback = callback
-        )
+    fun getUserPublicKeyByIdentity(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getUserPublicKeyByIdentityData = data.fromJson<GetUserPublicKeyByIdentityData>()
+        LockOperationsClient.getUserPublicKeyByIdentityRequest(getUserPublicKeyByIdentityData.identity)
     }
 
     /**
@@ -338,14 +278,9 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#lookup-user-public-key-v2">API Doc</a>
      */
     @CName("getUserPublicKeyByEmails")
-    fun getUserPublicKeyByEmails(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getUserPublicKeyByEmailsData = data.fromJson<GetUserPublicKeyByEmailsData>()
-                LockOperationsClient.getUserPublicKeyByEmailsRequest(getUserPublicKeyByEmailsData.emails)
-            },
-            callback = callback
-        )
+    fun getUserPublicKeyByEmails(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getUserPublicKeyByEmailsData = data.fromJson<GetUserPublicKeyByEmailsData>()
+        LockOperationsClient.getUserPublicKeyByEmailsRequest(getUserPublicKeyByEmailsData.emails)
     }
 
     /**
@@ -354,14 +289,9 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#lookup-user-public-key-v2">API Doc</a>
      */
     @CName("getUserPublicKeyByTelephones")
-    fun getUserPublicKeyByTelephones(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getUserPublicKeyByTelephonesData = data.fromJson<GetUserPublicKeyByTelephonesData>()
-                LockOperationsClient.getUserPublicKeyByTelephonesRequest(getUserPublicKeyByTelephonesData.telephones)
-            },
-            callback = callback
-        )
+    fun getUserPublicKeyByTelephones(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getUserPublicKeyByTelephonesData = data.fromJson<GetUserPublicKeyByTelephonesData>()
+        LockOperationsClient.getUserPublicKeyByTelephonesRequest(getUserPublicKeyByTelephonesData.telephones)
     }
 
     /**
@@ -370,14 +300,9 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#lookup-user-public-key-v2">API Doc</a>
      */
     @CName("getUserPublicKeyByLocalKeys")
-    fun getUserPublicKeyByLocalKeys(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getUserPublicKeyByLocalKeysData = data.fromJson<GetUserPublicKeyByLocalKeysData>()
-                LockOperationsClient.getUserPublicKeyByLocalKeysRequest(getUserPublicKeyByLocalKeysData.localKeys)
-            },
-            callback = callback
-        )
+    fun getUserPublicKeyByLocalKeys(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getUserPublicKeyByLocalKeysData = data.fromJson<GetUserPublicKeyByLocalKeysData>()
+        LockOperationsClient.getUserPublicKeyByLocalKeysRequest(getUserPublicKeyByLocalKeysData.localKeys)
     }
 
     /**
@@ -386,13 +311,10 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#lookup-user-public-key-v2">API Doc</a>
      */
     @CName("getUserPublicKeyByForeignKeys")
-    fun getUserPublicKeyByForeignKeys(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getUserPublicKeyByForeignKeysData = data.fromJson<GetUserPublicKeyByForeignKeysData>()
-                LockOperationsClient.getUserPublicKeyByForeignKeysRequest(getUserPublicKeyByForeignKeysData.foreignKeys)
-            },
-            callback = callback
+    fun getUserPublicKeyByForeignKeys(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getUserPublicKeyByForeignKeysData = data.fromJson<GetUserPublicKeyByForeignKeysData>()
+        LockOperationsClient.getUserPublicKeyByForeignKeysRequest(
+            foreignKeys = getUserPublicKeyByForeignKeysData.foreignKeys
         )
     }
 
@@ -402,14 +324,9 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#unlock">API Doc</a>
      */
     @CName("unlock")
-    fun unlock(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val unlockOperationData = data.fromJson<UnlockOperationData>()
-                LockOperationsClient.unlockRequest(unlockOperationData.toUnlockOperation())
-            },
-            callback = callback
-        )
+    fun unlock(data: String, callback: CStringCallback) = callback.handleCallback {
+        val unlockOperationData = data.fromJson<UnlockOperationData>()
+        LockOperationsClient.unlockRequest(unlockOperationData.toUnlockOperation())
     }
 
     /**
@@ -418,14 +335,9 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#share-a-lock">API Doc</a>
      */
     @CName("shareLock")
-    fun shareLock(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val shareLockOperationData = data.fromJson<ShareLockOperationData>()
-                LockOperationsClient.shareLockRequest(shareLockOperationData.toShareLockOperation())
-            },
-            callback = callback
-        )
+    fun shareLock(data: String, callback: CStringCallback) = callback.handleCallback {
+        val shareLockOperationData = data.fromJson<ShareLockOperationData>()
+        LockOperationsClient.shareLockRequest(shareLockOperationData.toShareLockOperation())
     }
 
     /**
@@ -434,13 +346,10 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#batch-share-a-lock-v2">API Doc</a>
      */
     @CName("batchShareLock")
-    fun batchShareLock(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val batchShareLockOperationData = data.fromJson<BatchShareLockOperationData>()
-                LockOperationsClient.batchShareLockRequest(batchShareLockOperationData.toBatchShareLockOperation())
-            },
-            callback = callback
+    fun batchShareLock(data: String, callback: CStringCallback) = callback.handleCallback {
+        val batchShareLockOperationData = data.fromJson<BatchShareLockOperationData>()
+        LockOperationsClient.batchShareLockRequest(
+            batchShareLockOperation = batchShareLockOperationData.toBatchShareLockOperation()
         )
     }
 
@@ -450,13 +359,10 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#revoke-access-to-a-lock">API Doc</a>
      */
     @CName("revokeAccessToLock")
-    fun revokeAccessToLock(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val revokeAccessToLockOperationData = data.fromJson<RevokeAccessToLockOperationData>()
-                LockOperationsClient.revokeAccessToLockRequest(revokeAccessToLockOperationData.toRevokeAccessToLockOperation())
-            },
-            callback = callback
+    fun revokeAccessToLock(data: String, callback: CStringCallback) = callback.handleCallback {
+        val revokeAccessToLockOperationData = data.fromJson<RevokeAccessToLockOperationData>()
+        LockOperationsClient.revokeAccessToLockRequest(
+            revokeAccessToLockOperation = revokeAccessToLockOperationData.toRevokeAccessToLockOperation()
         )
     }
 
@@ -466,13 +372,11 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#update-secure-settings">API Doc</a>
      */
     @CName("updateSecureSettingUnlockDuration")
-    fun updateSecureSettingUnlockDuration(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateSecureSettingUnlockDurationData = data.fromJson<UpdateSecureSettingUnlockDurationData>()
-                LockOperationsClient.updateSecureSettingUnlockDurationRequest(updateSecureSettingUnlockDurationData.toUpdateSecureSettingUnlockDuration())
-            },
-            callback = callback
+    fun updateSecureSettingUnlockDuration(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateSecureSettingUnlockDurationData = data.fromJson<UpdateSecureSettingUnlockDurationData>()
+        LockOperationsClient.updateSecureSettingUnlockDurationRequest(
+            updateSecureSettingUnlockDuration = updateSecureSettingUnlockDurationData
+                .toUpdateSecureSettingUnlockDuration()
         )
     }
 
@@ -482,13 +386,11 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#update-secure-settings">API Doc</a>
      */
     @CName("updateSecureSettingUnlockBetween")
-    fun updateSecureSettingUnlockBetween(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateSecureSettingUnlockBetweenData = data.fromJson<UpdateSecureSettingUnlockBetweenData>()
-                LockOperationsClient.updateSecureSettingUnlockBetweenRequest(updateSecureSettingUnlockBetweenData.toUpdateSecureSettingUnlockBetween())
-            },
-            callback = callback
+    fun updateSecureSettingUnlockBetween(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateSecureSettingUnlockBetweenData = data.fromJson<UpdateSecureSettingUnlockBetweenData>()
+        LockOperationsClient.updateSecureSettingUnlockBetweenRequest(
+            updateSecureSettingUnlockBetween = updateSecureSettingUnlockBetweenData
+                .toUpdateSecureSettingUnlockBetween()
         )
     }
 
@@ -498,13 +400,8 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#get-pinned-locks">API Doc</a>
      */
     @CName("getPinnedLocks")
-    fun getPinnedLocks(callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                LockOperationsClient.getPinnedLocksRequest()
-            },
-            callback = callback
-        )
+    fun getPinnedLocks(callback: CStringCallback) = callback.handleCallback {
+        LockOperationsClient.getPinnedLocksRequest()
     }
 
     /**
@@ -513,13 +410,8 @@ actual object LockOperationsApi {
      * @see <a href="https://developer.doordeck.com/docs/#get-shareable-locks">API Doc</a>
      */
     @CName("getShareableLocks")
-    fun getShareableLocks(callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                LockOperationsClient.getShareableLocksRequest()
-            },
-            callback = callback
-        )
+    fun getShareableLocks(callback: CStringCallback) = callback.handleCallback {
+        LockOperationsClient.getShareableLocksRequest()
     }
 }
 

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/PlatformApi.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/PlatformApi.mingw.kt
@@ -1,5 +1,6 @@
 package com.doordeck.multiplatform.sdk.api
 
+import com.doordeck.multiplatform.sdk.CStringCallback
 import com.doordeck.multiplatform.sdk.annotations.DoordeckOnly
 import com.doordeck.multiplatform.sdk.clients.PlatformClient
 import com.doordeck.multiplatform.sdk.model.data.AddAuthKeyData
@@ -20,11 +21,8 @@ import com.doordeck.multiplatform.sdk.model.data.UpdateApplicationSupportContact
 import com.doordeck.multiplatform.sdk.model.data.toAuthKey
 import com.doordeck.multiplatform.sdk.model.data.toCreateApplication
 import com.doordeck.multiplatform.sdk.model.data.toEmailPreferences
-import com.doordeck.multiplatform.sdk.util.callback
 import com.doordeck.multiplatform.sdk.util.fromJson
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CFunction
-import kotlinx.cinterop.CPointer
+import com.doordeck.multiplatform.sdk.util.handleCallback
 
 actual object PlatformApi {
     /**
@@ -34,14 +32,9 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("createApplication")
-    fun createApplication(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val createApplicationData = data.fromJson<CreateApplicationData>()
-                PlatformClient.createApplicationRequest(createApplicationData.toCreateApplication())
-            },
-            callback = callback
-        )
+    fun createApplication(data: String, callback: CStringCallback) = callback.handleCallback {
+        val createApplicationData = data.fromJson<CreateApplicationData>()
+        PlatformClient.createApplicationRequest(createApplicationData.toCreateApplication())
     }
 
     /**
@@ -51,13 +44,8 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("listApplications")
-    fun listApplications(callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                PlatformClient.listApplicationsRequest()
-            },
-            callback = callback
-        )
+    fun listApplications(callback: CStringCallback) = callback.handleCallback {
+        PlatformClient.listApplicationsRequest()
     }
 
     /**
@@ -67,14 +55,9 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("getApplication")
-    fun getApplication(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val applicationIdData = data.fromJson<ApplicationIdData>()
-                PlatformClient.getApplicationRequest(applicationIdData.applicationId)
-            },
-            callback = callback
-        )
+    fun getApplication(data: String, callback: CStringCallback) = callback.handleCallback {
+        val applicationIdData = data.fromJson<ApplicationIdData>()
+        PlatformClient.getApplicationRequest(applicationIdData.applicationId)
     }
 
     /**
@@ -84,13 +67,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("updateApplicationName")
-    fun updateApplicationName(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateApplicationName = data.fromJson<UpdateApplicationNameData>()
-                PlatformClient.updateApplicationNameRequest(updateApplicationName.applicationId, updateApplicationName.name)
-            },
-            callback = callback
+    fun updateApplicationName(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateApplicationName = data.fromJson<UpdateApplicationNameData>()
+        PlatformClient.updateApplicationNameRequest(
+            applicationId = updateApplicationName.applicationId,
+            name = updateApplicationName.name
         )
     }
 
@@ -101,16 +82,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("updateApplicationCompanyName")
-    fun updateApplicationCompanyName(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateApplicationCompanyName = data.fromJson<UpdateApplicationCompanyNameData>()
-                PlatformClient.updateApplicationCompanyNameRequest(
-                    applicationId = updateApplicationCompanyName.applicationId,
-                    companyName = updateApplicationCompanyName.companyName
-                )
-            },
-            callback = callback
+    fun updateApplicationCompanyName(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateApplicationCompanyName = data.fromJson<UpdateApplicationCompanyNameData>()
+        PlatformClient.updateApplicationCompanyNameRequest(
+            applicationId = updateApplicationCompanyName.applicationId,
+            companyName = updateApplicationCompanyName.companyName
         )
     }
 
@@ -121,16 +97,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("updateApplicationMailingAddress")
-    fun updateApplicationMailingAddress(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateApplicationMailingAddressData = data.fromJson<UpdateApplicationMailingAddressData>()
-                PlatformClient.updateApplicationMailingAddressRequest(
-                    applicationId = updateApplicationMailingAddressData.applicationId,
-                    mailingAddress = updateApplicationMailingAddressData.mailingAddress
-                )
-            },
-            callback = callback
+    fun updateApplicationMailingAddress(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateApplicationMailingAddressData = data.fromJson<UpdateApplicationMailingAddressData>()
+        PlatformClient.updateApplicationMailingAddressRequest(
+            applicationId = updateApplicationMailingAddressData.applicationId,
+            mailingAddress = updateApplicationMailingAddressData.mailingAddress
         )
     }
 
@@ -141,16 +112,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("updateApplicationPrivacyPolicy")
-    fun updateApplicationPrivacyPolicy(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateApplicationPrivacyPolicyData = data.fromJson<UpdateApplicationPrivacyPolicyData>()
-                PlatformClient.updateApplicationPrivacyPolicyRequest(
-                    applicationId = updateApplicationPrivacyPolicyData.applicationId,
-                    privacyPolicy = updateApplicationPrivacyPolicyData.privacyPolicy
-                )
-            },
-            callback = callback
+    fun updateApplicationPrivacyPolicy(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateApplicationPrivacyPolicyData = data.fromJson<UpdateApplicationPrivacyPolicyData>()
+        PlatformClient.updateApplicationPrivacyPolicyRequest(
+            applicationId = updateApplicationPrivacyPolicyData.applicationId,
+            privacyPolicy = updateApplicationPrivacyPolicyData.privacyPolicy
         )
     }
 
@@ -161,16 +127,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("updateApplicationSupportContact")
-    fun updateApplicationSupportContact(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateApplicationSupportContactData = data.fromJson<UpdateApplicationSupportContactData>()
-                PlatformClient.updateApplicationSupportContactRequest(
-                    applicationId = updateApplicationSupportContactData.applicationId,
-                    supportContact = updateApplicationSupportContactData.supportContact
-                )
-            },
-            callback = callback
+    fun updateApplicationSupportContact(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateApplicationSupportContactData = data.fromJson<UpdateApplicationSupportContactData>()
+        PlatformClient.updateApplicationSupportContactRequest(
+            applicationId = updateApplicationSupportContactData.applicationId,
+            supportContact = updateApplicationSupportContactData.supportContact
         )
     }
 
@@ -181,16 +142,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("updateApplicationAppLink")
-    fun updateApplicationAppLink(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateApplicationAppLinkData = data.fromJson<UpdateApplicationAppLinkData>()
-                PlatformClient.updateApplicationAppLinkRequest(
-                    applicationId = updateApplicationAppLinkData.applicationId,
-                    appLink = updateApplicationAppLinkData.appLink
-                )
-            },
-            callback = callback
+    fun updateApplicationAppLink(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateApplicationAppLinkData = data.fromJson<UpdateApplicationAppLinkData>()
+        PlatformClient.updateApplicationAppLinkRequest(
+            applicationId = updateApplicationAppLinkData.applicationId,
+            appLink = updateApplicationAppLinkData.appLink
         )
     }
 
@@ -201,16 +157,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("updateApplicationEmailPreferences")
-    fun updateApplicationEmailPreferences(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateApplicationEmailPreferencesData = data.fromJson<UpdateApplicationEmailPreferencesData>()
-                PlatformClient.updateApplicationEmailPreferencesRequest(
-                    applicationId = updateApplicationEmailPreferencesData.applicationId,
-                    emailPreferences = updateApplicationEmailPreferencesData.emailPreferences.toEmailPreferences()
-                )
-            },
-            callback = callback
+    fun updateApplicationEmailPreferences(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateApplicationEmailPreferencesData = data.fromJson<UpdateApplicationEmailPreferencesData>()
+        PlatformClient.updateApplicationEmailPreferencesRequest(
+            applicationId = updateApplicationEmailPreferencesData.applicationId,
+            emailPreferences = updateApplicationEmailPreferencesData.emailPreferences.toEmailPreferences()
         )
     }
 
@@ -221,16 +172,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("updateApplicationLogoUrl")
-    fun updateApplicationLogoUrl(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val updateApplicationLogoUrlData = data.fromJson<UpdateApplicationLogoUrlData>()
-                PlatformClient.updateApplicationLogoUrlRequest(
-                    applicationId = updateApplicationLogoUrlData.applicationId,
-                    logoUrl = updateApplicationLogoUrlData.logoUrl
-                )
-            },
-            callback = callback
+    fun updateApplicationLogoUrl(data: String, callback: CStringCallback) = callback.handleCallback {
+        val updateApplicationLogoUrlData = data.fromJson<UpdateApplicationLogoUrlData>()
+        PlatformClient.updateApplicationLogoUrlRequest(
+            applicationId = updateApplicationLogoUrlData.applicationId,
+            logoUrl = updateApplicationLogoUrlData.logoUrl
         )
     }
 
@@ -241,14 +187,9 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("deleteApplication")
-    fun deleteApplication(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val applicationIdData = data.fromJson<ApplicationIdData>()
-                PlatformClient.deleteApplicationRequest(applicationIdData.applicationId)
-            },
-            callback = callback
-        )
+    fun deleteApplication(data: String, callback: CStringCallback) = callback.handleCallback {
+        val applicationIdData = data.fromJson<ApplicationIdData>()
+        PlatformClient.deleteApplicationRequest(applicationIdData.applicationId)
     }
 
     /**
@@ -258,13 +199,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("getLogoUploadUrl")
-    fun getLogoUploadUrl(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getLogoUploadUrlData = data.fromJson<GetLogoUploadUrlData>()
-                PlatformClient.getLogoUploadUrlRequest(getLogoUploadUrlData.applicationId, getLogoUploadUrlData.contentType)
-            },
-            callback = callback
+    fun getLogoUploadUrl(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getLogoUploadUrlData = data.fromJson<GetLogoUploadUrlData>()
+        PlatformClient.getLogoUploadUrlRequest(
+            applicationId = getLogoUploadUrlData.applicationId,
+            contentType = getLogoUploadUrlData.contentType
         )
     }
 
@@ -275,13 +214,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("addAuthKey")
-    fun addAuthKey(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val addAuthKeyData = data.fromJson<AddAuthKeyData>()
-                PlatformClient.addAuthKeyRequest(addAuthKeyData.applicationId, addAuthKeyData.key.toAuthKey())
-            },
-            callback = callback
+    fun addAuthKey(data: String, callback: CStringCallback) = callback.handleCallback {
+        val addAuthKeyData = data.fromJson<AddAuthKeyData>()
+        PlatformClient.addAuthKeyRequest(
+            applicationId = addAuthKeyData.applicationId,
+            key = addAuthKeyData.key.toAuthKey()
         )
     }
 
@@ -292,13 +229,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("addAuthIssuer")
-    fun addAuthIssuer(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val authIssuerData = data.fromJson<AuthIssuerData>()
-                PlatformClient.addAuthIssuerRequest(authIssuerData.applicationId, authIssuerData.url)
-            },
-            callback = callback
+    fun addAuthIssuer(data: String, callback: CStringCallback) = callback.handleCallback {
+        val authIssuerData = data.fromJson<AuthIssuerData>()
+        PlatformClient.addAuthIssuerRequest(
+            applicationId = authIssuerData.applicationId,
+            url = authIssuerData.url
         )
     }
 
@@ -309,13 +244,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("deleteAuthIssuer")
-    fun deleteAuthIssuer(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val authIssuerData = data.fromJson<AuthIssuerData>()
-                PlatformClient.deleteAuthIssuerRequest(authIssuerData.applicationId, authIssuerData.url)
-            },
-            callback = callback
+    fun deleteAuthIssuer(data: String, callback: CStringCallback) = callback.handleCallback {
+        val authIssuerData = data.fromJson<AuthIssuerData>()
+        PlatformClient.deleteAuthIssuerRequest(
+            applicationId = authIssuerData.applicationId,
+            url = authIssuerData.url
         )
     }
 
@@ -326,13 +259,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("addCorsDomain")
-    fun addCorsDomain(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val corsDomainData = data.fromJson<CorsDomainData>()
-                PlatformClient.addCorsDomainRequest(corsDomainData.applicationId, corsDomainData.url)
-            },
-            callback = callback
+    fun addCorsDomain(data: String, callback: CStringCallback) = callback.handleCallback {
+        val corsDomainData = data.fromJson<CorsDomainData>()
+        PlatformClient.addCorsDomainRequest(
+            applicationId = corsDomainData.applicationId,
+            url = corsDomainData.url
         )
     }
 
@@ -343,13 +274,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("removeCorsDomain")
-    fun removeCorsDomain(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val corsDomainData = data.fromJson<CorsDomainData>()
-                PlatformClient.removeCorsDomainRequest(corsDomainData.applicationId, corsDomainData.url)
-            },
-            callback = callback
+    fun removeCorsDomain(data: String, callback: CStringCallback) = callback.handleCallback {
+        val corsDomainData = data.fromJson<CorsDomainData>()
+        PlatformClient.removeCorsDomainRequest(
+            applicationId = corsDomainData.applicationId,
+            url = corsDomainData.url
         )
     }
 
@@ -360,16 +289,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("addApplicationOwner")
-    fun addApplicationOwner(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val applicationOwnerData = data.fromJson<ApplicationOwnerData>()
-                PlatformClient.addApplicationOwnerRequest(
-                    applicationId = applicationOwnerData.applicationId,
-                    userId = applicationOwnerData.userId
-                )
-            },
-            callback = callback
+    fun addApplicationOwner(data: String, callback: CStringCallback) = callback.handleCallback {
+        val applicationOwnerData = data.fromJson<ApplicationOwnerData>()
+        PlatformClient.addApplicationOwnerRequest(
+            applicationId = applicationOwnerData.applicationId,
+            userId = applicationOwnerData.userId
         )
     }
 
@@ -380,16 +304,11 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("removeApplicationOwner")
-    fun removeApplicationOwner(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val applicationOwnerData = data.fromJson<ApplicationOwnerData>()
-                PlatformClient.removeApplicationOwnerRequest(
-                    applicationId = applicationOwnerData.applicationId,
-                    userId = applicationOwnerData.userId
-                )
-            },
-            callback = callback
+    fun removeApplicationOwner(data: String, callback: CStringCallback) = callback.handleCallback {
+        val applicationOwnerData = data.fromJson<ApplicationOwnerData>()
+        PlatformClient.removeApplicationOwnerRequest(
+            applicationId = applicationOwnerData.applicationId,
+            userId = applicationOwnerData.userId
         )
     }
 
@@ -400,14 +319,9 @@ actual object PlatformApi {
      */
     @DoordeckOnly
     @CName("getApplicationOwnersDetails")
-    fun getApplicationOwnersDetails(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val applicationIdData = data.fromJson<ApplicationIdData>()
-                PlatformClient.getApplicationOwnersDetailsRequest(applicationIdData.applicationId)
-            },
-            callback = callback
-        )
+    fun getApplicationOwnersDetails(data: String, callback: CStringCallback) = callback.handleCallback {
+        val applicationIdData = data.fromJson<ApplicationIdData>()
+        PlatformClient.getApplicationOwnersDetailsRequest(applicationIdData.applicationId)
     }
 }
 

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/SitesApi.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/SitesApi.mingw.kt
@@ -1,12 +1,10 @@
 package com.doordeck.multiplatform.sdk.api
 
+import com.doordeck.multiplatform.sdk.CStringCallback
 import com.doordeck.multiplatform.sdk.clients.SitesClient
 import com.doordeck.multiplatform.sdk.model.data.SiteIdData
-import com.doordeck.multiplatform.sdk.util.callback
+import com.doordeck.multiplatform.sdk.util.handleCallback
 import com.doordeck.multiplatform.sdk.util.fromJson
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CFunction
-import kotlinx.cinterop.CPointer
 
 actual object SitesApi {
     /**
@@ -15,13 +13,8 @@ actual object SitesApi {
      * @see <a href="https://developer.doordeck.com/docs/#sites">API Doc</a>
      */
     @CName("listSites")
-    fun listSites(callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                SitesClient.listSitesRequest()
-            },
-            callback = callback
-        )
+    fun listSites(callback: CStringCallback) = callback.handleCallback {
+        SitesClient.listSitesRequest()
     }
 
     /**
@@ -30,14 +23,9 @@ actual object SitesApi {
      * @see <a href="https://developer.doordeck.com/docs/#get-locks-for-site">API Doc</a>
      */
     @CName("getLocksForSite")
-    fun getLocksForSite(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val siteIdData = data.fromJson<SiteIdData>()
-                SitesClient.getLocksForSiteRequest(siteIdData.siteId)
-            },
-            callback = callback
-        )
+    fun getLocksForSite(data: String, callback: CStringCallback) = callback.handleCallback {
+        val siteIdData = data.fromJson<SiteIdData>()
+        SitesClient.getLocksForSiteRequest(siteIdData.siteId)
     }
 
     /**
@@ -46,14 +34,9 @@ actual object SitesApi {
      * @see <a href="https://developer.doordeck.com/docs/#get-users-for-a-site">API Doc</a>
      */
     @CName("getUsersForSite")
-    fun getUsersForSite(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val siteIdData = data.fromJson<SiteIdData>()
-                SitesClient.getUsersForSiteRequest(siteIdData.siteId)
-            },
-            callback = callback
-        )
+    fun getUsersForSite(data: String, callback: CStringCallback) = callback.handleCallback {
+        val siteIdData = data.fromJson<SiteIdData>()
+        SitesClient.getUsersForSiteRequest(siteIdData.siteId)
     }
 }
 

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/TilesApi.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/api/TilesApi.mingw.kt
@@ -1,14 +1,12 @@
 package com.doordeck.multiplatform.sdk.api
 
+import com.doordeck.multiplatform.sdk.CStringCallback
 import com.doordeck.multiplatform.sdk.annotations.SiteAdmin
 import com.doordeck.multiplatform.sdk.clients.TilesClient
 import com.doordeck.multiplatform.sdk.model.data.AssociateMultipleLocksData
 import com.doordeck.multiplatform.sdk.model.data.GetLocksBelongingToTileData
-import com.doordeck.multiplatform.sdk.util.callback
+import com.doordeck.multiplatform.sdk.util.handleCallback
 import com.doordeck.multiplatform.sdk.util.fromJson
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CFunction
-import kotlinx.cinterop.CPointer
 
 actual object TilesApi {
     /**
@@ -17,14 +15,9 @@ actual object TilesApi {
      * @see <a href="https://developer.doordeck.com/docs/#get-locks-belonging-to-tile-v3">API Doc</a>
      */
     @CName("getLocksBelongingToTile")
-    fun getLocksBelongingToTile(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val getLocksBelongingToTileData = data.fromJson<GetLocksBelongingToTileData>()
-                TilesClient.getLocksBelongingToTileRequest(getLocksBelongingToTileData.tileId)
-            },
-            callback = callback
-        )
+    fun getLocksBelongingToTile(data: String, callback: CStringCallback) = callback.handleCallback {
+        val getLocksBelongingToTileData = data.fromJson<GetLocksBelongingToTileData>()
+        TilesClient.getLocksBelongingToTileRequest(getLocksBelongingToTileData.tileId)
     }
 
     /**
@@ -34,17 +27,12 @@ actual object TilesApi {
      */
     @SiteAdmin
     @CName("associateMultipleLocks")
-    fun associateMultipleLocks(data: String, callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block = {
-                val associateMultipleLocksData = data.fromJson<AssociateMultipleLocksData>()
-                TilesClient.associateMultipleLocksRequest(
-                    tileId = associateMultipleLocksData.tileId,
-                    siteId = associateMultipleLocksData.siteId,
-                    lockIds = associateMultipleLocksData.lockIds
-                )
-            },
-            callback = callback
+    fun associateMultipleLocks(data: String, callback: CStringCallback) = callback.handleCallback {
+        val associateMultipleLocksData = data.fromJson<AssociateMultipleLocksData>()
+        TilesClient.associateMultipleLocksRequest(
+            tileId = associateMultipleLocksData.tileId,
+            siteId = associateMultipleLocksData.siteId,
+            lockIds = associateMultipleLocksData.lockIds
         )
     }
 }

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.mingw.kt
@@ -11,7 +11,7 @@ import com.doordeck.multiplatform.sdk.storage.createSecureStorage
  * This class holds various configuration options for initializing and operating the SDK.
  */
 data class SdkConfig(
-    val apiEnvironment: ApiEnvironment? = null,
+    val apiEnvironment: String? = null,
     val cloudAuthToken: String? = null,
     val cloudRefreshToken: String? = null,
     val fusionHost: String?,
@@ -25,7 +25,7 @@ data class SdkConfig(
      * an immutable [SdkConfig] instance.
      */
     class Builder {
-        private var apiEnvironment: ApiEnvironment? = null
+        private var apiEnvironment: String? = null
         private var cloudAuthToken: String? = null
         private var cloudRefreshToken: String? = null
         private var fusionHost: String? = null
@@ -35,7 +35,7 @@ data class SdkConfig(
         /**
          * Sets the API environment for the SDK.
          */
-        fun setApiEnvironment(apiEnvironment: ApiEnvironment?): Builder = apply { this.apiEnvironment = apiEnvironment }
+        fun setApiEnvironment(apiEnvironment: String?): Builder = apply { this.apiEnvironment = apiEnvironment }
 
         /**
          * Sets the cloud authentication token.
@@ -82,7 +82,7 @@ data class SdkConfig(
 }
 
 internal fun SdkConfig.toBasicSdkConfig(): BasicSdkConfig = BasicSdkConfig(
-    apiEnvironment = apiEnvironment,
+    apiEnvironment = apiEnvironment?.let { ApiEnvironment.valueOf(it) },
     cloudAuthToken = cloudAuthToken,
     cloudRefreshToken = cloudRefreshToken,
     fusionHost = fusionHost.toString(),

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.mingw.kt
@@ -16,7 +16,7 @@ data class SdkConfig(
     val cloudRefreshToken: String? = null,
     val fusionHost: String?,
     val secureStorage: SecureStorage,
-    val debugLogging: Boolean? = null
+    val debugLogging: String? = null
 ) {
     /**
      * Builder for constructing [SdkConfig] instances.
@@ -30,7 +30,7 @@ data class SdkConfig(
         private var cloudRefreshToken: String? = null
         private var fusionHost: String? = null
         private var secureStorage: SecureStorage? = null
-        private var debugLogging: Boolean? = null
+        private var debugLogging: String? = null
 
         /**
          * Sets the API environment for the SDK.
@@ -60,7 +60,7 @@ data class SdkConfig(
         /**
          * Enables debug logging. Beware: it may output sensitive information.
          */
-        fun setDebugLogging(enabled: Boolean?): Builder = apply { this.debugLogging = enabled }
+        fun setDebugLogging(enabled: String?): Builder = apply { this.debugLogging = enabled }
 
         /**
          * Builds a new [SdkConfig] instance.
@@ -87,5 +87,5 @@ internal fun SdkConfig.toBasicSdkConfig(): BasicSdkConfig = BasicSdkConfig(
     cloudRefreshToken = cloudRefreshToken,
     fusionHost = fusionHost.toString(),
     secureStorage = secureStorage,
-    debugLogging = debugLogging
+    debugLogging = debugLogging?.toBoolean()
 )

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManager.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/context/ContextManager.mingw.kt
@@ -1,142 +1,95 @@
 package com.doordeck.multiplatform.sdk.context
 
+import com.doordeck.multiplatform.sdk.CStringCallback
 import com.doordeck.multiplatform.sdk.model.data.ApiEnvironment
 import com.doordeck.multiplatform.sdk.model.data.Crypto
 import com.doordeck.multiplatform.sdk.model.data.OperationContextData
 import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
 import com.doordeck.multiplatform.sdk.util.Utils.stringToCertificateChain
-import com.doordeck.multiplatform.sdk.util.callback
+import com.doordeck.multiplatform.sdk.util.handleCallback
 import com.doordeck.multiplatform.sdk.util.fromJson
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CFunction
-import kotlinx.cinterop.CPointer
 
 actual object ContextManager {
 
-    fun setApiEnvironment(apiEnvironment: ApiEnvironment) {
-        Context.setApiEnvironment(apiEnvironment)
-    }
+    fun setApiEnvironment(apiEnvironment: String) =
+        Context.setApiEnvironment(ApiEnvironment.valueOf(apiEnvironment))
 
     @CName("getApiEnvironment")
-    fun getApiEnvironment(): ApiEnvironment {
-        return Context.getApiEnvironment()
-    }
+    fun getApiEnvironment(): String = Context.getApiEnvironment().name
 
     @CName("setCloudAuthToken")
-    fun setCloudAuthToken(token: String) {
-        Context.setCloudAuthToken(token)
-    }
+    fun setCloudAuthToken(token: String) = Context.setCloudAuthToken(token)
 
     @CName("getCloudAuthToken")
-    fun getCloudAuthToken(): String? {
-        return Context.getCloudAuthToken()
-    }
+    fun getCloudAuthToken(): String? = Context.getCloudAuthToken()
 
     @CName("isCloudAuthTokenInvalidOrExpired")
-    fun isCloudAuthTokenInvalidOrExpired(callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block =  {
-                Context.isCloudAuthTokenInvalidOrExpired()
-            },
-            callback = callback
-        )
+    fun isCloudAuthTokenInvalidOrExpired(callback: CStringCallback) = callback.handleCallback {
+        Context.isCloudAuthTokenInvalidOrExpired()
     }
 
     @CName("setCloudRefreshToken")
-    fun setCloudRefreshToken(token: String) {
-        Context.setCloudRefreshToken(token)
-    }
+    fun setCloudRefreshToken(token: String) = Context.setCloudRefreshToken(token)
 
     @CName("getCloudRefreshToken")
-    fun getCloudRefreshToken(): String? {
-        return Context.getCloudRefreshToken()
-    }
+    fun getCloudRefreshToken(): String? = Context.getCloudRefreshToken()
 
     @CName("setFusionHost")
-    fun setFusionHost(host: String) {
-        Context.setFusionHost(host)
-    }
+    fun setFusionHost(host: String) = Context.setFusionHost(host)
 
     @CName("getFusionHost")
-    fun getFusionHost(): String {
-        return Context.getFusionHost()
-    }
+    fun getFusionHost(): String = Context.getFusionHost()
 
     @CName("setFusionAuthToken")
-    fun setFusionAuthToken(token: String) {
-        Context.setFusionAuthToken(token)
-    }
+    fun setFusionAuthToken(token: String) = Context.setFusionAuthToken(token)
 
     @CName("getFusionAuthToken")
-    fun getFusionAuthToken(): String? {
-        return Context.getFusionAuthToken()
-    }
+    fun getFusionAuthToken(): String? = Context.getFusionAuthToken()
 
     @CName("setUserId")
-    fun setUserId(userId: String) {
-        Context.setUserId(userId)
-    }
+    fun setUserId(userId: String) = Context.setUserId(userId)
 
     @CName("getUserId")
-    fun getUserId(): String? {
-        return Context.getUserId()
-    }
+    fun getUserId(): String? = Context.getUserId()
 
     @CName("setUserEmail")
-    fun setUserEmail(email: String) {
-        Context.setUserEmail(email)
-    }
+    fun setUserEmail(email: String) = Context.setUserEmail(email)
 
     @CName("getUserEmail")
-    fun getUserEmail(): String? {
-        return Context.getUserEmail()
-    }
+    fun getUserEmail(): String? = Context.getUserEmail()
 
-    fun setCertificateChain(certificateChain: List<String>) {
-        Context.setCertificateChain(certificateChain)
-    }
+    fun setCertificateChain(certificateChain: List<String>) = Context.setCertificateChain(certificateChain)
 
-    fun getCertificateChain(): List<String>? {
-        return Context.getCertificateChain()
-    }
+    fun getCertificateChain(): List<String>? = Context.getCertificateChain()
 
     @CName("isCertificateChainInvalidOrExpired")
-    fun isCertificateChainInvalidOrExpired(): Boolean {
-        return Context.isCertificateChainInvalidOrExpired()
-    }
+    fun isCertificateChainInvalidOrExpired(): Boolean = Context.isCertificateChainInvalidOrExpired()
 
-    fun setKeyPair(publicKey: ByteArray, privateKey: ByteArray) {
-        Context.setKeyPair(publicKey, privateKey)
-    }
+    fun setKeyPair(publicKey: ByteArray, privateKey: ByteArray) = Context.setKeyPair(publicKey, privateKey)
 
-    fun getKeyPair(): Crypto.KeyPair? {
-        return Context.getKeyPair()
-    }
+    fun getKeyPair(): Crypto.KeyPair? = Context.getKeyPair()
 
-    fun setKeyPairVerified(publicKey: ByteArray?) {
-        Context.setKeyPairVerified(publicKey)
-    }
+    fun setKeyPairVerified(publicKey: ByteArray?) = Context.setKeyPairVerified(publicKey)
 
     @CName("isKeyPairVerified")
-    fun isKeyPairVerified(): Boolean {
-        return Context.isKeyPairVerified()
-    }
+    fun isKeyPairVerified(): Boolean = Context.isKeyPairVerified()
 
     @CName("isKeyPairValid")
-    fun isKeyPairValid(): Boolean {
-        return Context.isKeyPairValid()
-    }
+    fun isKeyPairValid(): Boolean = Context.isKeyPairValid()
 
-    fun setOperationContext(userId: String, certificateChain: List<String>, publicKey: ByteArray,
-                            privateKey: ByteArray, isKeyPairVerified: Boolean) {
-        Context.setOperationContext(
-            userId = userId,
-            certificateChain = certificateChain,
-            publicKey = publicKey,
-            privateKey = privateKey,
-            isKeyPairVerified = isKeyPairVerified
-        )
-    }
+    fun setOperationContext(
+        userId: String,
+        certificateChain: List<String>,
+        publicKey: ByteArray,
+        privateKey: ByteArray,
+        isKeyPairVerified: Boolean
+    ) = Context.setOperationContext(
+        userId = userId,
+        certificateChain = certificateChain,
+        publicKey = publicKey,
+        privateKey = privateKey,
+        isKeyPairVerified = isKeyPairVerified
+    )
 
     /**
      * Sets all necessary fields to perform secure operations in JSON format, the provided values will be automatically stored in secure storage.
@@ -154,19 +107,12 @@ actual object ContextManager {
     }
 
     @CName("getContextState")
-    fun getContextState(callback: CPointer<CFunction<(CPointer<ByteVar>) -> CPointer<ByteVar>>>) {
-        callback(
-            block =  {
-                Context.getContextState()
-            },
-            callback = callback
-        )
+    fun getContextState(callback: CStringCallback) = callback.handleCallback {
+        Context.getContextState()
     }
 
     @CName("clearContext")
-    fun clearContext() {
-        Context.clearContext()
-    }
+    fun clearContext() = Context.clearContext()
 }
 
 actual fun contextManager(): ContextManager = ContextManager

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/crypto/CryptoManager.mingw.kt
@@ -3,14 +3,13 @@ package com.doordeck.multiplatform.sdk.crypto
 import com.doordeck.multiplatform.sdk.exceptions.SdkException
 import com.doordeck.multiplatform.sdk.logger.SdkLogger
 import com.doordeck.multiplatform.sdk.model.data.Crypto
+import com.doordeck.multiplatform.sdk.model.data.EncodedKeyPair
 import com.doordeck.multiplatform.sdk.util.Utils.encodeByteArrayToBase64
 import com.doordeck.multiplatform.sdk.util.isCertificateInvalidOrExpired
 import com.doordeck.multiplatform.sdk.util.toJson
 import com.ionspin.kotlin.crypto.LibsodiumInitializer
 import com.ionspin.kotlin.crypto.signature.Signature
 import io.ktor.utils.io.core.toByteArray
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * Platform-specific implementation of [CryptoManager].
@@ -43,11 +42,9 @@ actual object CryptoManager {
     @CName("generateEncodedKeyPair")
     fun generateEncodedKeyPair(): String {
         val keyPair = generateRawKeyPair()
-        return JsonObject(
-            content = mapOf(
-                "private" to JsonPrimitive(keyPair.private.encodeByteArrayToBase64()),
-                "public" to JsonPrimitive(keyPair.public.encodeByteArrayToBase64())
-            )
+        return EncodedKeyPair(
+            publicKey = keyPair.public.encodeByteArrayToBase64(),
+            privateKey = keyPair.private.encodeByteArrayToBase64()
         ).toJson()
     }
 

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/model/data/ContextData.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/model/data/ContextData.kt
@@ -5,8 +5,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class OperationContextData(
     val userId: String,
-    val userCertificateChain: String,
-    val userPublicKey: String,
-    val userPrivateKey: String,
+    val certificateChain: String,
+    val publicKey: String,
+    val privateKey: String,
     val isKeyPairVerified: Boolean = true
 )

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/model/data/EncodedKeyPair.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/model/data/EncodedKeyPair.kt
@@ -1,0 +1,9 @@
+package com.doordeck.multiplatform.sdk.model.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EncodedKeyPair(
+    val publicKey: String,
+    val privateKey: String
+)

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.mingw.kt
@@ -36,7 +36,7 @@ fun buildSdkConfig(
         .setCloudRefreshToken(cloudRefreshToken)
         .setFusionHost(fusionHost)
         .setSecureStorageOverride(secureStorage)
-        .setDebugLogging(debugLogging?.toBoolean())
+        .setDebugLogging(debugLogging)
         .build()
 }
 

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/DateOnlyJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/DateOnlyJsonConverter.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ConsoleApp2.Doordeck.Headless.Sdk.Converter;
+
+public class DateOnlyJsonConverter : JsonConverter<DateOnly>
+{
+    private const string Format = "yyyy-MM-dd";
+
+    public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        try
+        {
+            var dateString = reader.GetString();
+            if (string.IsNullOrEmpty(dateString)) return default;
+            return DateOnly.ParseExact(dateString, Format, CultureInfo.InvariantCulture);
+        }
+        catch (FormatException ex)
+        {
+            throw new JsonException($"Invalid date format. Expected {Format}.", ex);
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString(Format, CultureInfo.InvariantCulture));
+    }
+}

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/DateOnlyJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/DateOnlyJsonConverter.cs
@@ -2,7 +2,7 @@ using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace ConsoleApp2.Doordeck.Headless.Sdk.Converter;
+namespace Doordeck.Headless.Sdk.Converter;
 
 public class DateOnlyJsonConverter : JsonConverter<DateOnly>
 {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/DateOnlyJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/DateOnlyJsonConverter.cs
@@ -12,13 +12,14 @@ public class DateOnlyJsonConverter : JsonConverter<DateOnly>
     {
         try
         {
-            var dateString = reader.GetString();
-            if (string.IsNullOrEmpty(dateString)) return default;
-            return DateOnly.ParseExact(dateString, Format, CultureInfo.InvariantCulture);
+            var value = reader.GetString();
+            return !string.IsNullOrWhiteSpace(value) ?
+                DateOnly.ParseExact(value, Format, CultureInfo.InvariantCulture) :
+                throw new JsonException($"Invalid date time: {value}");
         }
         catch (FormatException ex)
         {
-            throw new JsonException($"Invalid date format. Expected {Format}.", ex);
+            throw new JsonException($"Invalid date format", ex);
         }
     }
 

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/DateTimeJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/DateTimeJsonConverter.cs
@@ -2,7 +2,7 @@ using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace ConsoleApp2.Doordeck.Headless.Sdk.Converter;
+namespace Doordeck.Headless.Sdk.Converter;
 
 public class DateTimeJsonConverter : JsonConverter<DateTime>
 {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/DateTimeJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/DateTimeJsonConverter.cs
@@ -48,8 +48,7 @@ public class DateTimeJsonConverter : JsonConverter<DateTime>
 
     public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
     {
-        var unixTime = (value - DateTime.UnixEpoch).TotalSeconds;
-        writer.WriteNumberValue(unixTime);
+        writer.WriteNumberValue((long)(value.ToUniversalTime() - DateTime.UnixEpoch).TotalSeconds);
     }
 }
 

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/DateTimeJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/DateTimeJsonConverter.cs
@@ -1,0 +1,66 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ConsoleApp2.Doordeck.Headless.Sdk.Converter;
+
+public class DateTimeJsonConverter : JsonConverter<DateTime>
+{
+    private const long TicksPerSecond = TimeSpan.TicksPerSecond;
+    
+    public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    { 
+        string? s;
+
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            s = reader.GetString();
+        }
+        else if (reader.TokenType == JsonTokenType.Number)
+        {
+            s = reader.GetDouble().ToString("R", CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            throw new JsonException($"Unexpected token parsing DateTime. Token: {reader.TokenType}");
+        }
+
+        if (string.IsNullOrEmpty(s)) return default;
+
+        if (!decimal.TryParse(s, NumberStyles.Float | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture,
+                out var totalSeconds))
+        {
+            throw new JsonException($"Invalid epoch-second.nano format: '{s}'");
+        }
+        
+        // Convert seconds (possibly fractional) to ticks
+        var ticksDecimal = totalSeconds * TicksPerSecond;
+        long ticks;
+        try
+        {
+            ticks = (long)Math.Round(ticksDecimal);
+        }
+        catch (OverflowException ex)
+        {
+            throw new JsonException("Epoch seconds value is out of range for DateTime.", ex);
+        }
+        
+        var epoch = DateTime.UnixEpoch;
+        try
+        {
+            return epoch.AddTicks(ticks);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            throw new JsonException("Resulting DateTime is out of range.", ex);
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+    {
+        // Convert back to Unix timestamp when serializing
+        var unixTime = (value - DateTime.UnixEpoch).TotalSeconds;
+        writer.WriteNumberValue(unixTime);
+    }
+}
+

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/DateTimeJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/DateTimeJsonConverter.cs
@@ -16,7 +16,7 @@ public class DateTimeJsonConverter : JsonConverter<DateTime>
             reader.GetDouble().ToString("R", CultureInfo.InvariantCulture) :
             throw new JsonException($"Invalid date time: {reader.TokenType}");
 
-        if (!string.IsNullOrWhiteSpace(value) ||
+        if (string.IsNullOrWhiteSpace(value) ||
             !decimal.TryParse(value, NumberStyles.Float | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture,
                 out var totalSeconds))
         {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/IpAddressJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/IpAddressJsonConverter.cs
@@ -1,0 +1,21 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ConsoleApp2.Doordeck.Headless.Sdk.Converter;
+
+public class IpAddressJsonConverter : JsonConverter<IPAddress>
+{
+    public override IPAddress? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        if (IPAddress.TryParse(value, out var address)) return address;
+        throw new JsonException($"Invalid IP address: {value}");
+    }
+
+    public override void Write(Utf8JsonWriter writer, IPAddress value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/IpAddressJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/IpAddressJsonConverter.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace ConsoleApp2.Doordeck.Headless.Sdk.Converter;
+namespace Doordeck.Headless.Sdk.Converter;
 
 public class IpAddressJsonConverter : JsonConverter<IPAddress>
 {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/IpAddressJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/IpAddressJsonConverter.cs
@@ -6,12 +6,12 @@ namespace Doordeck.Headless.Sdk.Converter;
 
 public class IpAddressJsonConverter : JsonConverter<IPAddress>
 {
-    public override IPAddress? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override IPAddress Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var value = reader.GetString();
-        if (string.IsNullOrWhiteSpace(value)) return null;
-        if (IPAddress.TryParse(value, out var address)) return address;
-        throw new JsonException($"Invalid IP address: {value}");
+        return !string.IsNullOrWhiteSpace(value) ?
+            IPAddress.Parse(value) :
+            throw new JsonException($"Invalid IP address: {value}");
     }
 
     public override void Write(Utf8JsonWriter writer, IPAddress value, JsonSerializerOptions options)

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeOnlyJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeOnlyJsonConverter.cs
@@ -10,9 +10,9 @@ public class TimeOnlyJsonConverter : JsonConverter<TimeOnly>
     public override TimeOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var value = reader.GetString();
-        if (string.IsNullOrWhiteSpace(value)) return default;
-        if (TimeOnly.TryParseExact(value, Format, out var time)) return time;
-        throw new JsonException($"Invalid time format. Expected format is {Format}.");
+        return !string.IsNullOrWhiteSpace(value) ?
+            TimeOnly.ParseExact(value, Format) :
+            throw new JsonException($"Invalid time only: {value}");
     }
 
     public override void Write(Utf8JsonWriter writer, TimeOnly value, JsonSerializerOptions options)

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeOnlyJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeOnlyJsonConverter.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ConsoleApp2.Doordeck.Headless.Sdk.Converter;
+
+public class TimeOnlyJsonConverter : JsonConverter<TimeOnly>
+{
+    private const string Format = "HH:mm";
+
+    public override TimeOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        if (string.IsNullOrWhiteSpace(value)) return default;
+        if (TimeOnly.TryParseExact(value, Format, out var time)) return time;
+        throw new JsonException($"Invalid time format. Expected format is {Format}.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, TimeOnly value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString(Format));
+    }
+}

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeOnlyJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeOnlyJsonConverter.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace ConsoleApp2.Doordeck.Headless.Sdk.Converter;
+namespace Doordeck.Headless.Sdk.Converter;
 
 public class TimeOnlyJsonConverter : JsonConverter<TimeOnly>
 {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeSpanJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeSpanJsonConverter.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace ConsoleApp2.Doordeck.Headless.Sdk.Converter;
+namespace Doordeck.Headless.Sdk.Converter;
 
 public class TimeSpanJsonConverter : JsonConverter<TimeSpan>
 {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeSpanJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeSpanJsonConverter.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ConsoleApp2.Doordeck.Headless.Sdk.Converter;
+
+public class TimeSpanJsonConverter : JsonConverter<TimeSpan>
+{
+    public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Number) return TimeSpan.FromSeconds(reader.GetDouble());
+        throw new JsonException("Expected numeric value for TimeSpan in seconds.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)
+    {
+        writer.WriteNumberValue(value.TotalSeconds);
+    }
+}

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeSpanJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeSpanJsonConverter.cs
@@ -7,8 +7,9 @@ public class TimeSpanJsonConverter : JsonConverter<TimeSpan>
 {
     public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        if (reader.TokenType == JsonTokenType.Number) return TimeSpan.FromSeconds(reader.GetDouble());
-        throw new JsonException("Expected numeric value for TimeSpan in seconds.");
+        return reader.TokenType == JsonTokenType.Number ?
+            TimeSpan.FromSeconds(reader.GetDouble()) :
+            throw new JsonException($"Invalid time span: {reader.TokenType}");
     }
 
     public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeZoneInfoJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeZoneInfoJsonConverter.cs
@@ -7,15 +7,10 @@ public class TimeZoneInfoJsonConverter : JsonConverter<TimeZoneInfo>
 {
     public override TimeZoneInfo Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        var timeZoneId = reader.GetString()!;
-        try
-        {
-            return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
-        }
-        catch (TimeZoneNotFoundException)
-        {
-            throw new JsonException($"Time zone '{timeZoneId}' was not found on this system.");
-        }
+        var value = reader.GetString();
+        return !string.IsNullOrWhiteSpace(value) ?
+            TimeZoneInfo.FindSystemTimeZoneById(value) :
+            throw new JsonException($"Invalid time zone: {value}");
     }
 
     public override void Write(Utf8JsonWriter writer, TimeZoneInfo value, JsonSerializerOptions options)

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeZoneInfoJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeZoneInfoJsonConverter.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ConsoleApp2.Doordeck.Headless.Sdk.Converter;
+
+public class TimeZoneInfoJsonConverter : JsonConverter<TimeZoneInfo>
+{
+    public override TimeZoneInfo Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var timeZoneId = reader.GetString()!;
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            throw new JsonException($"Time zone '{timeZoneId}' was not found on this system.");
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, TimeZoneInfo value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.Id);
+    }
+}

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeZoneInfoJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/TimeZoneInfoJsonConverter.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace ConsoleApp2.Doordeck.Headless.Sdk.Converter;
+namespace Doordeck.Headless.Sdk.Converter;
 
 public class TimeZoneInfoJsonConverter : JsonConverter<TimeZoneInfo>
 {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Converter/X509CertificateJsonConverter.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Converter/X509CertificateJsonConverter.cs
@@ -1,0 +1,28 @@
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Doordeck.Headless.Sdk.Converter;
+
+public class X509CertificateJsonConverter : JsonConverter<X509Certificate>
+{
+    public override X509Certificate Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        try
+        {
+            var value = reader.GetString();
+            return !string.IsNullOrWhiteSpace(value) ?
+                X509CertificateLoader.LoadCertificate(Convert.FromBase64String(value)) :
+                throw new JsonException($"Invalid certificate value: {value}");
+        }
+        catch (Exception exception)
+        {
+            throw new JsonException("Invalid X509Certificate", exception);
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, X509Certificate value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(Convert.ToBase64String(value.Export(X509ContentType.Cert)));
+    }
+}

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Doordeck.Headless.Sdk.csproj
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Doordeck.Headless.Sdk.csproj
@@ -1,6 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
+        <PackageId>Doordeck.Headless.Sdk</PackageId>
+        <AssemblyName>Doordeck.Headless.Sdk</AssemblyName>
+        <RootNamespace>Doordeck.Headless.Sdk</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/doordeck-sdk/src/mingwMain/resources/csharp/DoordeckSdk.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/DoordeckSdk.cs
@@ -39,6 +39,7 @@ public class DoordeckSdk
     {
         _factory = _symbols->kotlin.root.com.doordeck.multiplatform.sdk.KDoordeckFactory._instance();
 
+        var environment = Utils.Utils.ToSByte(apiEnvironment.ToString());
         var token = cloudAuthToken != null ? Utils.Utils.ToSByte(cloudAuthToken) : null;
         var refreshToken = cloudRefreshToken != null ? Utils.Utils.ToSByte(cloudRefreshToken) : null;
         var fHost = fusionHost != null ? Utils.Utils.ToSByte(fusionHost) : null;
@@ -46,7 +47,7 @@ public class DoordeckSdk
 
         var sdkConfig = _symbols->kotlin.root.com.doordeck.multiplatform.sdk.config.SdkConfig;
         var builder = sdkConfig.Builder.Builder();
-        sdkConfig.Builder.setApiEnvironment(builder, apiEnvironment.ToString());
+        sdkConfig.Builder.setApiEnvironment(builder, environment);
 
         if (token != null) sdkConfig.Builder.setCloudAuthToken(builder, token);
         if (refreshToken != null) sdkConfig.Builder.setCloudRefreshToken(builder, refreshToken);
@@ -168,6 +169,7 @@ public class DoordeckSdk
         }
         finally
         {
+            Marshal.FreeHGlobal((IntPtr)environment);
             if (token != null) Marshal.FreeHGlobal((IntPtr)token);
             if (refreshToken != null) Marshal.FreeHGlobal((IntPtr)refreshToken);
             if (fHost != null) Marshal.FreeHGlobal((IntPtr)fHost);

--- a/doordeck-sdk/src/mingwMain/resources/csharp/DoordeckSdk.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/DoordeckSdk.cs
@@ -40,10 +40,10 @@ public class DoordeckSdk
     {
         _factory = _symbols->kotlin.root.com.doordeck.multiplatform.sdk.KDoordeckFactory._instance();
 
-        var environment = Utils.StringToSByte(apiEnvironment.ToString());
-        var token = cloudAuthToken != null ? Utils.StringToSByte(cloudAuthToken) : null;
-        var refreshToken = cloudRefreshToken != null ? Utils.StringToSByte(cloudRefreshToken) : null;
-        var fHost = fusionHost != null ? Utils.StringToSByte(fusionHost) : null;
+        var environment = apiEnvironment.ToString().StringToSByte();
+        var token = cloudAuthToken != null ? cloudAuthToken.StringToSByte() : null;
+        var refreshToken = cloudRefreshToken != null ? cloudRefreshToken.StringToSByte() : null;
+        var fHost = fusionHost != null ? fusionHost.StringToSByte() : null;
         var dLogging = _symbols->createNullableBoolean((debugLogging ?? false).BooleanToByte());
 
         var sdkConfig = _symbols->kotlin.root.com.doordeck.multiplatform.sdk.config.SdkConfig;
@@ -209,55 +209,25 @@ public class DoordeckSdk
             _symbols->kotlin.root.com.doordeck.multiplatform.sdk.crypto.CryptoManager, _symbols);
     }
 
-    public Account GetAccount()
-    {
-        return _account;
-    }
+    public Account GetAccount() => _account;
 
-    public Accountless GetAccountless()
-    {
-        return _accountless;
-    }
+    public Accountless GetAccountless() => _accountless;
 
-    public Fusion GetFusion()
-    {
-        return _fusion;
-    }
+    public Fusion GetFusion() => _fusion;
 
-    public Helper GetHelper()
-    {
-        return _helper;
-    }
+    public Helper GetHelper() => _helper;
 
-    public LockOperations GetLockOperations()
-    {
-        return _lockOperations;
-    }
+    public LockOperations GetLockOperations() => _lockOperations;
 
-    public Platform GetPlatform()
-    {
-        return _platform;
-    }
+    public Platform GetPlatform() => _platform;
 
-    public Sites GetSites()
-    {
-        return _sites;
-    }
+    public Sites GetSites() => _sites;
 
-    public Tiles GetTiles()
-    {
-        return _tiles;
-    }
+    public Tiles GetTiles() => _tiles;
 
-    public ContextManager GetContextManager()
-    {
-        return _contextManager;
-    }
+    public ContextManager GetContextManager() => _contextManager;
 
-    public CryptoManager GetCryptoManager()
-    {
-        return _cryptoManager;
-    }
+    public CryptoManager GetCryptoManager() => _cryptoManager;
 
     public unsafe void Release()
     {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/DoordeckSdk.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/DoordeckSdk.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using Doordeck.Headless.Sdk.Model;
+using Doordeck.Headless.Sdk.Utilities;
 using Doordeck.Headless.Sdk.Wrapper;
 
 namespace Doordeck.Headless.Sdk;
@@ -39,11 +40,11 @@ public class DoordeckSdk
     {
         _factory = _symbols->kotlin.root.com.doordeck.multiplatform.sdk.KDoordeckFactory._instance();
 
-        var environment = Utils.Utils.ToSByte(apiEnvironment.ToString());
-        var token = cloudAuthToken != null ? Utils.Utils.ToSByte(cloudAuthToken) : null;
-        var refreshToken = cloudRefreshToken != null ? Utils.Utils.ToSByte(cloudRefreshToken) : null;
-        var fHost = fusionHost != null ? Utils.Utils.ToSByte(fusionHost) : null;
-        var dLogging = _symbols->createNullableBoolean(Convert.ToByte(debugLogging ?? false));
+        var environment = Utils.StringToSByte(apiEnvironment.ToString());
+        var token = cloudAuthToken != null ? Utils.StringToSByte(cloudAuthToken) : null;
+        var refreshToken = cloudRefreshToken != null ? Utils.StringToSByte(cloudRefreshToken) : null;
+        var fHost = fusionHost != null ? Utils.StringToSByte(fusionHost) : null;
+        var dLogging = _symbols->createNullableBoolean((debugLogging ?? false).BooleanToByte());
 
         var sdkConfig = _symbols->kotlin.root.com.doordeck.multiplatform.sdk.config.SdkConfig;
         var builder = sdkConfig.Builder.Builder();

--- a/doordeck-sdk/src/mingwMain/resources/csharp/DoordeckSdk.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/DoordeckSdk.cs
@@ -8,7 +8,6 @@ public class DoordeckSdk
 {
     private readonly unsafe Doordeck_Headless_Sdk_ExportedSymbols* _symbols = Methods.Doordeck_Headless_Sdk_symbols();
 
-    private readonly Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_model_data_ApiEnvironment _apiEnvironment;
     private readonly Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_KDoordeckFactory _factory;
     private readonly Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_Doordeck _sdk;
 
@@ -38,17 +37,6 @@ public class DoordeckSdk
         string? cloudRefreshToken = null, string? fusionHost = null, ISecureStorage? secureStorageImpl = null,
         bool? debugLogging = null)
     {
-        _apiEnvironment = apiEnvironment switch
-        {
-            ApiEnvironment.DEV => _symbols->kotlin.root.com.doordeck.multiplatform.sdk.model.data.ApiEnvironment.DEV
-                .get(),
-            ApiEnvironment.STAGING => _symbols->kotlin.root.com.doordeck.multiplatform.sdk.model.data.ApiEnvironment
-                .STAGING.get(),
-            ApiEnvironment.PROD => _symbols->kotlin.root.com.doordeck.multiplatform.sdk.model.data.ApiEnvironment.PROD
-                .get(),
-            _ => _apiEnvironment
-        };
-
         _factory = _symbols->kotlin.root.com.doordeck.multiplatform.sdk.KDoordeckFactory._instance();
 
         var token = cloudAuthToken != null ? Utils.Utils.ToSByte(cloudAuthToken) : null;
@@ -58,7 +46,7 @@ public class DoordeckSdk
 
         var sdkConfig = _symbols->kotlin.root.com.doordeck.multiplatform.sdk.config.SdkConfig;
         var builder = sdkConfig.Builder.Builder();
-        sdkConfig.Builder.setApiEnvironment(builder, _apiEnvironment);
+        sdkConfig.Builder.setApiEnvironment(builder, apiEnvironment.ToString());
 
         if (token != null) sdkConfig.Builder.setCloudAuthToken(builder, token);
         if (refreshToken != null) sdkConfig.Builder.setCloudRefreshToken(builder, refreshToken);
@@ -270,7 +258,6 @@ public class DoordeckSdk
 
     public unsafe void Release()
     {
-        _symbols->DisposeStablePointer(_apiEnvironment.pinned);
         _symbols->DisposeStablePointer(_factory.pinned);
         _symbols->DisposeStablePointer(_sdk.pinned);
         _symbols->DisposeStablePointer(_accountApi.pinned);

--- a/doordeck-sdk/src/mingwMain/resources/csharp/DoordeckSdk.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/DoordeckSdk.cs
@@ -40,20 +40,20 @@ public class DoordeckSdk
     {
         _factory = _symbols->kotlin.root.com.doordeck.multiplatform.sdk.KDoordeckFactory._instance();
 
-        var environment = apiEnvironment.ToString().StringToSByte();
-        var token = cloudAuthToken != null ? cloudAuthToken.StringToSByte() : null;
-        var refreshToken = cloudRefreshToken != null ? cloudRefreshToken.StringToSByte() : null;
-        var fHost = fusionHost != null ? fusionHost.StringToSByte() : null;
-        var dLogging = _symbols->createNullableBoolean((debugLogging ?? false).BooleanToByte());
+        var apiEnvironmentPtr = apiEnvironment.ToString().StringToSByte();
+        var cloudAuthTokenPtr = cloudAuthToken != null ? cloudAuthToken.StringToSByte() : null;
+        var cloudRefreshTokenPtr = cloudRefreshToken != null ? cloudRefreshToken.StringToSByte() : null;
+        var fusionHostPtr = fusionHost != null ? fusionHost.StringToSByte() : null;
+        var debugLoggingPtr = (debugLogging ?? false).ToString().StringToSByte();
 
         var sdkConfig = _symbols->kotlin.root.com.doordeck.multiplatform.sdk.config.SdkConfig;
-        var builder = sdkConfig.Builder.Builder();
-        sdkConfig.Builder.setApiEnvironment(builder, environment);
+        var sdkConfigBuilder = sdkConfig.Builder.Builder();
+        sdkConfig.Builder.setApiEnvironment(sdkConfigBuilder, apiEnvironmentPtr);
 
-        if (token != null) sdkConfig.Builder.setCloudAuthToken(builder, token);
-        if (refreshToken != null) sdkConfig.Builder.setCloudRefreshToken(builder, refreshToken);
-        if (fHost != null) sdkConfig.Builder.setFusionHost(builder, fHost);
-        sdkConfig.Builder.setDebugLogging(builder, dLogging);
+        if (cloudAuthTokenPtr != null) sdkConfig.Builder.setCloudAuthToken(sdkConfigBuilder, cloudAuthTokenPtr);
+        if (cloudRefreshTokenPtr != null) sdkConfig.Builder.setCloudRefreshToken(sdkConfigBuilder, cloudRefreshTokenPtr);
+        if (fusionHostPtr != null) sdkConfig.Builder.setFusionHost(sdkConfigBuilder, fusionHostPtr);
+        sdkConfig.Builder.setDebugLogging(sdkConfigBuilder, debugLoggingPtr);
 
         if (secureStorageImpl != null)
         {
@@ -161,19 +161,20 @@ public class DoordeckSdk
                 pinned = secureStorage.pinned
             };
 
-            sdkConfig.Builder.setSecureStorageOverride(builder, secureStorageP);
+            sdkConfig.Builder.setSecureStorageOverride(sdkConfigBuilder, secureStorageP);
         }
 
         try
         {
-            _sdk = _symbols->kotlin.root.com.doordeck.multiplatform.sdk.KDoordeckFactory.initialize_(_factory, sdkConfig.Builder.build(builder));
+            _sdk = _symbols->kotlin.root.com.doordeck.multiplatform.sdk.KDoordeckFactory.initialize_(_factory, sdkConfig.Builder.build(sdkConfigBuilder));
         }
         finally
         {
-            Marshal.FreeHGlobal((IntPtr)environment);
-            if (token != null) Marshal.FreeHGlobal((IntPtr)token);
-            if (refreshToken != null) Marshal.FreeHGlobal((IntPtr)refreshToken);
-            if (fHost != null) Marshal.FreeHGlobal((IntPtr)fHost);
+            Marshal.FreeHGlobal((IntPtr)apiEnvironmentPtr);
+            Marshal.FreeHGlobal((IntPtr)debugLoggingPtr);
+            if (cloudAuthTokenPtr != null) Marshal.FreeHGlobal((IntPtr)cloudAuthTokenPtr);
+            if (cloudRefreshTokenPtr != null) Marshal.FreeHGlobal((IntPtr)cloudRefreshTokenPtr);
+            if (fusionHostPtr != null) Marshal.FreeHGlobal((IntPtr)fusionHostPtr);
         }
 
         _accountApi = _symbols->kotlin.root.com.doordeck.multiplatform.sdk.Doordeck.account_(_sdk);

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Fusion.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Fusion.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Net;
+using System.Text.Json.Serialization;
 
 namespace Doordeck.Headless.Sdk.Model;
 
@@ -28,155 +29,155 @@ public abstract class LockController : ILockController;
 
 public class AlpetaController : LockController
 {
-    public string? Username { get; set; } = string.Empty;
-    public string? Password { get; set; } = string.Empty;
-    public int DoorId { get; set; } = 0;
-    public string? BaseUrl { get; set; } = null;
+    public string? Username { get; set; }
+    public string? Password { get; set; }
+    public required int DoorId { get; set; }
+    public Uri? BaseUrl { get; set; }
 }
 
 public class AmagController : LockController
 {
-    public string Username { get; set; } = string.Empty;
-    public string Password { get; set; } = string.Empty;
-    public int DoorId { get; set; } = 0;
-    public string? BaseUrl { get; set; } = null;
+    public required string Username { get; set; }
+    public required string Password { get; set; }
+    public required int DoorId { get; set; }
+    public Uri? BaseUrl { get; set; }
 }
 
 public class AssaAbloyController : LockController
 {
-    public string BaseUrl { get; set; } = string.Empty;
-    public string DoorId { get; set; } = string.Empty;
+    public required Uri BaseUrl { get; set; }
+    public required string DoorId { get; set; }
 }
 
 public class AvigilonController : LockController
 {
-    public string BaseUrl { get; set; } = string.Empty;
-    public string Username { get; set; } = string.Empty;
-    public string Password { get; set; } = string.Empty;
-    public string DoorId { get; set; } = string.Empty;
+    public required Uri BaseUrl { get; set; }
+    public required string Username { get; set; }
+    public required string Password { get; set; }
+    public required string DoorId { get; set; }
 }
 
 public class AxisController : LockController
 {
-    public string BaseUrl { get; set; } = string.Empty;
-    public string DoorIdentifier { get; set; } = string.Empty;
+    public required Uri BaseUrl { get; set; }
+    public required string DoorIdentifier { get; set; }
 }
 
 public class CCureController : LockController
 {
-    public string BaseUrl { get; set; } = string.Empty;
-    public string Username { get; set; } = string.Empty;
-    public string Password { get; set; } = string.Empty;
-    public string DoorType { get; set; } = string.Empty;
-    public int DoorId { get; set; } = 0;
+    public Uri? BaseUrl { get; set; }
+    public required string Username { get; set; }
+    public required string Password { get; set; }
+    public required string DoorType { get; set; }
+    public required int DoorId { get; set; }
 }
 
 public class DemoController : LockController
 {
-    public ushort Port { get; set; } = 8080;
+    public required ushort Port { get; set; } = 8080;
 }
 
 public class GallagherController : LockController
 {
-    public string? BaseUrl { get; set; } = null;
-    public string ApiKey { get; set; } = string.Empty;
-    public string DoorId { get; set; } = string.Empty;
+    public Uri? BaseUrl { get; set; }
+    public required string ApiKey { get; set; }
+    public required string DoorId { get; set; }
 }
 
 public class GenetecController : LockController
 {
-    public string BaseUrl { get; set; } = string.Empty;
-    public string Username { get; set; } = string.Empty;
-    public string Password { get; set; } = string.Empty;
-    public string DoorId { get; set; } = string.Empty;
+    public required Uri BaseUrl { get; set; }
+    public required string Username { get; set; }
+    public required string Password { get; set; }
+    public required string DoorId { get; set; }
 }
 
 public class LenelController : LockController
 {
-    public string BaseUrl { get; set; } = string.Empty;
-    public string Username { get; set; } = string.Empty;
-    public string Password { get; set; } = string.Empty;
-    public string DirectoryId { get; set; } = string.Empty;
-    public string PanelId { get; set; } = string.Empty;
-    public string ReaderId { get; set; } = string.Empty;
+    public required Uri BaseUrl { get; set; }
+    public required string Username { get; set; }
+    public required string Password { get; set; }
+    public required string DirectoryId { get; set; }
+    public required string PanelId { get; set; }
+    public required string ReaderId { get; set; }
 }
 
 public class MitrefinchController : LockController
 {
-    public string Host { get; set; } = string.Empty;
-    public int Output { get; set; } = 0;
+    public required IPAddress Host { get; set; }
+    public required int Output { get; set; }
 }
 
 public class PaxtonNet2Controller : LockController
 {
-    public string Host { get; set; } = string.Empty;
-    public string? Username { get; set; } = null;
-    public string? Password { get; set; } = null;
-    public string Address { get; set; } = string.Empty;
-    public short Output { get; set; } = 0;
+    public required IPAddress Host { get; set; }
+    public string? Username { get; set; }
+    public string? Password { get; set; }
+    public required string Address { get; set; }
+    public required short Output { get; set; }
 }
 
 public class Paxton10Controller : LockController
 {
-    public string BaseUrl { get; set; } = string.Empty;
-    public string Username { get; set; } = string.Empty;
-    public string Password { get; set; } = string.Empty;
-    public int ApplianceId { get; set; } = 0;
+    public required Uri BaseUrl { get; set; }
+    public required string Username { get; set; }
+    public required string Password { get; set; }
+    public required int ApplianceId { get; set; }
 }
 
 public class IntegraV1Controller : LockController
 {
-    public string Username { get; set; } = string.Empty;
-    public string Password { get; set; } = string.Empty;
-    public int ControllerId { get; set; } = 0;
+    public required string Username { get; set; }
+    public required string Password { get; set; }
+    public required int ControllerId { get; set; }
 }
 
 public class IntegraV2Controller : LockController
 {
-    public string BaseUrl { get; set; } = string.Empty;
-    public string SessionId { get; set; } = string.Empty;
-    public int ControllerId { get; set; } = 0;
-    public int CardholderId { get; set; } = 0;
-    public int? PinCode { get; set; } = null;
+    public required Uri BaseUrl { get; set; }
+    public required string SessionId { get; set; }
+    public required int ControllerId { get; set; }
+    public required int CardholderId { get; set; }
+    public int? PinCode { get; set; }
 }
 
 public class PacController : LockController
 {
-    public DataSource DataSource { get; set; } = new();
-    public int OutputChannel { get; set; } = 0;
-    public int ControllerSerial { get; set; } = 0;
+    public required DataSource DataSource { get; set; }
+    public required int OutputChannel { get; set; }
+    public required int ControllerSerial { get; set; }
 }
 
 public class DataSource
 {
-    public string DriverClass { get; set; } = string.Empty;
-    public string Url { get; set; } = string.Empty;
-    public string User { get; set; } = string.Empty;
-    public string Password { get; set; } = string.Empty;
+    public required string DriverClass { get; set; }
+    public required string Url { get; set; }
+    public required string User { get; set; }
+    public required string Password { get; set; }
 }
 
 public class TdsiExgardeController : LockController
 {
-    public string? DbUrl { get; set; } = null;
-    public string Username { get; set; } = string.Empty;
-    public string Password { get; set; } = string.Empty;
-    public int DoorId { get; set; } = 0;
+    public string? DbUrl { get; set; }
+    public required string Username { get; set; }
+    public required string Password { get; set; }
+    public required int DoorId { get; set; }
 }
 
 public class TdsiGardisController : LockController
 {
-    public string Host { get; set; } = string.Empty;
-    public string Username { get; set; } = string.Empty;
-    public string Password { get; set; } = string.Empty;
-    public int DoorId { get; set; } = 0;
+    public required IPAddress Host { get; set; }
+    public required string Username { get; set; }
+    public required string Password { get; set; }
+    public required int DoorId { get; set; }
 }
 
 public class ZktecoController : LockController
 {
-    public string ClientSecret { get; set; } = string.Empty;
-    public string DoorId { get; set; } = string.Empty;
-    public string? BaseUrl { get; set; } = null;
-    public ZktecoEntityType EntityType { get; set; }
+    public required string ClientSecret { get; set; }
+    public required string DoorId { get; set; }
+    public string? BaseUrl { get; set; }
+    public required ZktecoEntityType EntityType { get; set; }
 }
     
 [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/KeyPair.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/KeyPair.cs
@@ -2,6 +2,6 @@
 
 public class EncodedKeyPair
 {
-    public string Private { get; set; } = String.Empty;
-    public string Public { get; set; } = string.Empty;
+    public required string Private { get; set; }
+    public required string Public { get; set; }
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/KeyPair.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/KeyPair.cs
@@ -1,7 +1,7 @@
 ﻿namespace Doordeck.Headless.Sdk.Model;
 
-public class EncodedKeyPair
+public class KeyPair
 {
-    public required string PrivateKey { get; set; }
-    public required string PublicKey { get; set; }
+    public required byte[] PrivateKey { get; set; }
+    public required byte[] PublicKey { get; set; }
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/KeyPair.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/KeyPair.cs
@@ -2,6 +2,6 @@
 
 public class EncodedKeyPair
 {
-    public required string Private { get; set; }
-    public required string Public { get; set; }
+    public required string PrivateKey { get; set; }
+    public required string PublicKey { get; set; }
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/LockOperations.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/LockOperations.cs
@@ -1,10 +1,10 @@
 ﻿namespace Doordeck.Headless.Sdk.Model;
 
-public class TimeRequirement(string start, string end, string timezone, List<DayOfWeek> days)
+public class TimeRequirement(TimeOnly start, TimeOnly end, TimeZoneInfo timezone, List<DayOfWeek> days)
 {
-    public string Start { get; set; } = start;
-    public string End { get; set; } = end;
-    public string Timezone { get; set; } = timezone;
+    public TimeOnly Start { get; set; } = start;
+    public TimeOnly End { get; set; } = end;
+    public TimeZoneInfo Timezone { get; set; } = timezone;
     public List<DayOfWeek> Days { get; set; } = days;
 }
 
@@ -22,24 +22,24 @@ public class LocationRequirement(
     public int Accuracy { get; set; } = accuracy;
 }
 
-public class UnlockOperation(BaseOperation baseOperation, List<string>? directAccessEndpoints = null)
+public class UnlockOperation(BaseOperation baseOperation, List<Uri>? directAccessEndpoints = null)
 {
     public BaseOperation BaseOperation { get; set; } = baseOperation;
-    public List<string>? DirectAccessEndpoints { get; set; } = directAccessEndpoints;
+    public List<Uri>? DirectAccessEndpoints { get; set; } = directAccessEndpoints;
 }
 
 public class BaseOperation
 {
-    public string? UserId { get; set; } = null;
-    public List<string>? UserCertificateChain { get; set; } = null;
-    public string? UserPrivateKey { get; set; } = null;
-    public string LockId { get; set; }
-    public int NotBefore { get; set; }
-    public int IssuedAt { get; set; }
-    public int ExpiresAt { get; set; }
-    public string Jti { get; set; }
+    public Guid? UserId { get; set; }
+    public List<string>? UserCertificateChain { get; set; }
+    public string? UserPrivateKey { get; set; }
+    public Guid LockId { get; set; }
+    public DateTime NotBefore { get; set; }
+    public DateTime IssuedAt { get; set; }
+    public DateTime ExpiresAt { get; set; }
+    public Guid Jti { get; set; }
 
-    public BaseOperation(string userId, List<string> userCertificateChain, string userPrivateKey, string lockId, int notBefore, int issuedAt, int expiresAt, string jti)
+    public BaseOperation(Guid userId, List<string> userCertificateChain, string userPrivateKey, Guid lockId, DateTime notBefore, DateTime issuedAt, DateTime expiresAt, Guid jti)
     {
         UserId = userId;
         UserCertificateChain = userCertificateChain;
@@ -51,28 +51,28 @@ public class BaseOperation
         Jti = jti;
     }
 
-    public BaseOperation(string lockId)
+    public BaseOperation(Guid lockId)
     {
         LockId = lockId;
-        NotBefore = (int)DateTimeOffset.Now.ToUnixTimeSeconds();
-        IssuedAt = (int)DateTimeOffset.Now.ToUnixTimeSeconds();
-        ExpiresAt = (int)DateTimeOffset.Now.AddMinutes(1).ToUnixTimeSeconds();
-        Jti = Guid.NewGuid().ToString();
+        NotBefore = DateTime.Now;
+        IssuedAt = DateTime.Now;
+        ExpiresAt = DateTime.Now.AddMinutes(1);
+        Jti = Guid.NewGuid();
     }
 }
 
 public class ShareLock(
-    string targetUserId,
+    Guid targetUserId,
     UserRole targetUserRole,
     string targetUserPublicKey,
-    int? start = null,
-    int? end = null)
+    DateTime? start = null,
+    DateTime? end = null)
 {
-    public string TargetUserId { get; set; } = targetUserId;
+    public Guid TargetUserId { get; set; } = targetUserId;
     public UserRole TargetUserRole { get; set; } = targetUserRole;
     public string TargetUserPublicKey { get; set; } = targetUserPublicKey;
-    public int? Start { get; set; } = start;
-    public int? End { get; set; } = end;
+    public DateTime? Start { get; set; } = start;
+    public DateTime? End { get; set; } = end;
 }
 
 public class ShareLockOperation(BaseOperation baseOperation, ShareLock shareLock)
@@ -87,30 +87,30 @@ public class BatchShareLockOperation(BaseOperation baseOperation, List<ShareLock
     public List<ShareLock> Users { get; set; } = users;
 }
 
-public class RevokeAccessToLockOperation(BaseOperation baseOperation, List<string> users)
+public class RevokeAccessToLockOperation(BaseOperation baseOperation, List<Guid> users)
 {
     public BaseOperation BaseOperation { get; set; } = baseOperation;
-    public List<string> Users { get; set; } = users;
+    public List<Guid> Users { get; set; } = users;
 }
 
-public class UpdateSecureSettingUnlockDuration(BaseOperation baseOperation, int unlockDuration)
+public class UpdateSecureSettingUnlockDuration(BaseOperation baseOperation, TimeSpan unlockDuration)
 {
     public BaseOperation BaseOperation { get; set; } = baseOperation;
-    public int UnlockDuration { get; set; } = unlockDuration;
+    public TimeSpan UnlockDuration { get; set; } = unlockDuration;
 }
 
 public class UnlockBetween(
-    string start,
-    string end,
-    string timezone,
+    TimeOnly start,
+    TimeOnly end,
+    TimeZoneInfo timezone,
     List<DayOfWeek> days,
-    List<string>? exceptions = null)
+    List<DateOnly>? exceptions = null)
 {
-    public string Start { get; set; } = start;
-    public string End { get; set; } = end;
-    public string Timezone { get; set; } = timezone;
+    public TimeOnly Start { get; set; } = start;
+    public TimeOnly End { get; set; } = end;
+    public TimeZoneInfo Timezone { get; set; } = timezone;
     public List<DayOfWeek> Days { get; set; } = days;
-    public List<string>? Exceptions { get; set; } = exceptions;
+    public List<DateOnly>? Exceptions { get; set; } = exceptions;
 }
 
 public class UpdateSecureSettingUnlockBetween(

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Platform.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Platform.cs
@@ -1,57 +1,44 @@
 ﻿namespace Doordeck.Headless.Sdk.Model;
 
-public class CreateApplication
+public class CreateApplication(
+    string name,
+    string companyName,
+    string mailingAddress,
+    Uri? privacyPolicy = null,
+    Uri? supportContact = null,
+    Uri? appLink = null,
+    EmailPreferences? emailPreferences = null,
+    Uri? logoUrl = null)
 {
-    public string Name { get; set; }
-    public string CompanyName { get; set; }
-    public string MailingAddress { get; set; }
-    public string? PrivacyPolicy { get; set; } = null;
-    public string? SupportContact { get; set; } = null;
-    public string? AppLink { get; set; } = null;
-    public EmailPreferences? EmailPreferences { get; set; } = null;
-    public string? LogoUrl { get; set; } = null;
-
-    public CreateApplication(string name, string companyName, string mailingAddress,
-        string? privacyPolicy = null, string? supportContact = null,
-        string? appLink = null, EmailPreferences? emailPreferences = null,
-        string? logoUrl = null)
-    {
-        Name = name;
-        CompanyName = companyName;
-        MailingAddress = mailingAddress;
-        PrivacyPolicy = privacyPolicy;
-        SupportContact = supportContact;
-        AppLink = appLink;
-        EmailPreferences = emailPreferences;
-        LogoUrl = logoUrl;
-    }
+    public string Name { get; set; } = name;
+    public string CompanyName { get; set; } = companyName;
+    public string MailingAddress { get; set; } = mailingAddress;
+    public Uri? PrivacyPolicy { get; set; } = privacyPolicy;
+    public Uri? SupportContact { get; set; } = supportContact;
+    public Uri? AppLink { get; set; } = appLink;
+    public EmailPreferences? EmailPreferences { get; set; } = emailPreferences;
+    public Uri? LogoUrl { get; set; } = logoUrl;
 }
 
-public class EmailPreferences
+public class EmailPreferences(
+    string? senderEmail = null,
+    string? senderName = null,
+    string? primaryColour = null,
+    string? secondaryColour = null,
+    bool? onlySendEssentialEmails = null,
+    EmailCallToAction? callToAction = null)
 {
-    public string? SenderEmail { get; set; } = null;
-    public string? SenderName { get; set; } = null;
-    public string? PrimaryColour { get; set; } = null;
-    public string? SecondaryColour { get; set; } = null;
-    public bool? OnlySendEssentialEmails { get; set; } = null;
-    public EmailCallToAction? CallToAction { get; set; } = null;
-
-    public EmailPreferences(string? senderEmail = null, string? senderName = null,
-        string? primaryColour = null, string? secondaryColour = null,
-        bool? onlySendEssentialEmails = null, EmailCallToAction? callToAction = null)
-    {
-        SenderEmail = senderEmail;
-        SenderName = senderName;
-        PrimaryColour = primaryColour;
-        SecondaryColour = secondaryColour;
-        OnlySendEssentialEmails = onlySendEssentialEmails;
-        CallToAction = callToAction;
-    }
+    public string? SenderEmail { get; set; } = senderEmail;
+    public string? SenderName { get; set; } = senderName;
+    public string? PrimaryColour { get; set; } = primaryColour;
+    public string? SecondaryColour { get; set; } = secondaryColour;
+    public bool? OnlySendEssentialEmails { get; set; } = onlySendEssentialEmails;
+    public EmailCallToAction? CallToAction { get; set; } = callToAction;
 }
 
-public class EmailCallToAction(string actionTarget, string headline, string actionText)
+public class EmailCallToAction(Uri actionTarget, string headline, string actionText)
 {
-    public string ActionTarget { get; set; } = actionTarget;
+    public Uri ActionTarget { get; set; } = actionTarget;
     public string Headline { get; set; } = headline;
     public string ActionText { get; set; } = actionText;
 }
@@ -64,61 +51,36 @@ public interface IAuthKey
     string? Alg { get; }
 }
 
-public class RsaKey : IAuthKey
+public class RsaKey(string use, string kid, string e, string n, string? alg = null)
+    : IAuthKey
 {
-    public string Kty { get; private set; } = "RSA";
-    public string Use { get; set; }
-    public string Kid { get; set; }
-    public string? Alg { get; set; } = null;
-    public string E { get; set; }
-    public string N { get; set; }
-
-    public RsaKey(string use, string kid, string e, string n, string? alg = null)
-    {
-        Use = use;
-        Kid = kid;
-        E = e;
-        N = n;
-        Alg = alg;
-    }
+    public string Kty { get; } = "RSA";
+    public string Use { get; set; } = use;
+    public string Kid { get; set; } = kid;
+    public string? Alg { get; set; } = alg;
+    public string E { get; set; } = e;
+    public string N { get; set; } = n;
 }
 
-public class EcKey : IAuthKey
+public class EcKey(string use, string kid, string crv, string x, string y, string? alg = null)
+    : IAuthKey
 {
-    public string Kty { get; private set; } = "EC";
-    public string Use { get; set; }
-    public string Kid { get; set; }
-    public string? Alg { get; set; } = null;
-    public string Crv { get; set; }
-    public string X { get; set; }
-    public string Y { get; set; }
-
-    public EcKey(string use, string kid, string crv, string x, string y, string? alg = null)
-    {
-        Use = use;
-        Kid = kid;
-        Crv = crv;
-        X = x;
-        Y = y;
-        Alg = alg;
-    }
+    public string Kty { get; } = "EC";
+    public string Use { get; set; } = use;
+    public string Kid { get; set; } = kid;
+    public string? Alg { get; set; } = alg;
+    public string Crv { get; set; } = crv;
+    public string X { get; set; } = x;
+    public string Y { get; set; } = y;
 }
 
-public class Ed25519Key : IAuthKey
+public class Ed25519Key(string use, string kid, string crv, string x, string? alg = null)
+    : IAuthKey
 {
-    public string Kty { get; private set; } = "OKP";
-    public string Use { get; set; }
-    public string Kid { get; set; }
-    public string? Alg { get; set; } = null;
-    public string Crv { get; set; }
-    public string X { get; set; }
-
-    public Ed25519Key(string use, string kid, string crv, string x, string? alg = null)
-    {
-        Use = use;
-        Kid = kid;
-        Crv = crv;
-        X = x;
-        Alg = alg;
-    }
+    public string Kty { get; } = "OKP";
+    public string Use { get; set; } = use;
+    public string Kid { get; set; } = kid;
+    public string? Alg { get; set; } = alg;
+    public string Crv { get; set; } = crv;
+    public string X { get; set; } = x;
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/AccountResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/AccountResponses.cs
@@ -13,7 +13,7 @@ public class UserDetailsResponse
     public required string Email { get; set; }
     public string? DisplayName { get; set; }
     public required bool EmailVerified { get; set; }
-    public required string PublicKey { get; set; }
+    public required byte[] PublicKey { get; set; }
 }
 
 public class RegisterEphemeralKeyResponse

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/AccountResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/AccountResponses.cs
@@ -1,26 +1,28 @@
-﻿namespace Doordeck.Headless.Sdk.Model.Responses;
+﻿using System.Security.Cryptography.X509Certificates;
+
+namespace Doordeck.Headless.Sdk.Model.Responses;
 
 public class TokenResponse
 {
-    public string AuthToken { get; set; } = string.Empty;
-    public string RefreshToken { get; set; } = string.Empty;
+    public required string AuthToken { get; set; }
+    public required string RefreshToken { get; set; }
 }
 
 public class UserDetailsResponse
 {
-    public string Email { get; set; } = string.Empty;
-    public string? DisplayName { get; set; } = null;
-    public bool EmailVerified { get; set; }
-    public string PublicKey { get; set; } = string.Empty;
+    public required string Email { get; set; }
+    public string? DisplayName { get; set; }
+    public required bool EmailVerified { get; set; }
+    public required string PublicKey { get; set; }
 }
 
 public class RegisterEphemeralKeyResponse
 {
-    public List<string> CertificateChain { get; set; } = [];
-    public string UserId { get; set; } = string.Empty;
+    public required List<X509Certificate> CertificateChain { get; set; }
+    public required Guid UserId { get; set; }
 }
 
 public class RegisterEphemeralKeyWithSecondaryAuthenticationResponse
 {
-    public TwoFactorMethod Method { get; set; }
+    public required TwoFactorMethod Method { get; set; }
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/FusionResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/FusionResponses.cs
@@ -4,42 +4,42 @@ namespace Doordeck.Headless.Sdk.Model.Responses;
 
 public class FusionLoginResponse
 {
-    public string AuthToken { get; set; } = string.Empty;
+    public required string AuthToken { get; set; }
 }
     
 public class IntegrationTypeResponse
 {
-    public string Status { get; set; } = string.Empty;
+    public string? Status { get; set; }
 }
     
 public class DoorStateResponse
 {
-    public ServiceStateType State { get; set; } = ServiceStateType.UNDEFINED;
+    public required ServiceStateType State { get; set; }
 }
     
 public class IntegrationConfigurationResponse
 {
-    public ControllerResponse? Doordeck { get; set; } = null;
-    public ServiceStateResponse? Service { get; set; } = null;
-    public DiscoveredDeviceResponse? Integration { get; set; } = null;
+    public ControllerResponse? Doordeck { get; set; }
+    public ServiceStateResponse? Service { get; set; }
+    public DiscoveredDeviceResponse? Integration { get; set; }
 }
     
 public class ControllerResponse
 {
-    public string Id { get; set; } = string.Empty;
-    public string? Name { get; set; } = null;
-    public string? Role { get; set; } = null;
+    public required Guid Id { get; set; }
+    public string? Name { get; set; }
+    public UserRole? Role { get; set; }
 }
     
 public class ServiceStateResponse
 {
-    public ServiceStateType State { get; set; } = ServiceStateType.UNDEFINED;
+    public required ServiceStateType State { get; set; }
 }
     
 public class DiscoveredDeviceResponse
 {
-    public LockController Key { get; set; } = new DemoController();
-    public Dictionary<string, string> Metadata { get; set; } = new();
+    public required LockController Key { get; set; }
+    public required Dictionary<string, string> Metadata { get; set; }
 }
 
 [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/HelperResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/HelperResponses.cs
@@ -2,12 +2,12 @@ namespace Doordeck.Headless.Sdk.Model.Responses;
 
 public class AssistedLoginResponse
 {
-    public bool RequiresVerification { get; set; }
-    public bool RequiresRetry { get; set; }
+    public required bool RequiresVerification { get; set; }
+    public required bool RequiresRetry { get; set; }
 }
 
 public class AssistedRegisterEphemeralKeyResponse
 {
-    public bool RequiresVerification { get; set; }
-    public bool RequiresRetry { get; set; }
+    public required bool RequiresVerification { get; set; }
+    public required bool RequiresRetry { get; set; }
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/LockOperationResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/LockOperationResponses.cs
@@ -1,136 +1,138 @@
-﻿namespace Doordeck.Headless.Sdk.Model.Responses;
+﻿using System.Net;
+
+namespace Doordeck.Headless.Sdk.Model.Responses;
 
 public class LockResponse
 {
-    public string Id { get; set; } = string.Empty;
-    public string Name { get; set; } = string.Empty;
-    public string? Start { get; set; } = null;
-    public string? End { get; set; } = null;
-    public UserRole Role { get; set; }
-    public LockSettingsResponse Settings { get; set; } = new LockSettingsResponse();
-    public LockStateResponse State { get; set; } = new LockStateResponse();
-    public bool Favourite { get; set; }
+    public required Guid Id { get; set; }
+    public required string Name { get; set; }
+    public DateTime? Start { get; set; }
+    public DateTime? End { get; set; }
+    public required UserRole Role { get; set; }
+    public required LockSettingsResponse Settings { get; set; }
+    public required LockStateResponse State { get; set; }
+    public required bool Favourite { get; set; }
 }
 
 public class LockSettingsResponse
 {
-    public double UnlockTime { get; set; }
-    public List<string> PermittedAddresses { get; set; } = [];
-    public string DefaultName { get; set; } = string.Empty;
-    public UsageRequirementsResponse? UsageRequirements { get; set; } = null;
-    public UnlockBetweenSettingResponse? UnlockBetweenWindow { get; set; } = null;
-    public List<string> Tiles { get; set; } = [];
-    public bool Hidden { get; set; }
-    public List<string> DirectAccessEndpoints { get; set; } = [];
-    public Dictionary<CapabilityType, CapabilityStatus> Capabilities { get; set; } = [];
+    public required TimeSpan UnlockTime { get; set; }
+    public required List<IPAddress> PermittedAddresses { get; set; }
+    public required string DefaultName { get; set; }
+    public UsageRequirementsResponse? UsageRequirements { get; set; }
+    public UnlockBetweenSettingResponse? UnlockBetweenWindow { get; set; }
+    public required List<Guid> Tiles { get; set; }
+    public required bool Hidden { get; set; }
+    public required List<Uri> DirectAccessEndpoints { get; set; }
+    public required Dictionary<CapabilityType, CapabilityStatus> Capabilities { get; set; }
 }
 
 public class UsageRequirementsResponse
 {
-    public List<TimeRequirementResponse>? Time { get; set; } = null;
-    public LocationRequirementResponse? Location { get; set; } = null;
+    public List<TimeRequirementResponse>? Time { get; set; }
+    public LocationRequirementResponse? Location { get; set; }
 }
 
 public class TimeRequirementResponse
 {
-    public string Start { get; set; } = string.Empty;
-    public string End { get; set; } = string.Empty;
-    public string Timezone { get; set; } = string.Empty;
-    public List<DayOfWeek> Days { get; set; } = [];
+    public required TimeOnly Start { get; set; }
+    public required TimeOnly End { get; set; }
+    public required TimeZoneInfo Timezone { get; set; }
+    public required List<DayOfWeek> Days { get; set; }
 }
 
 public class LocationRequirementResponse
 {
-    public double Latitude { get; set; }
-    public double Longitude { get; set; }
-    public bool Enabled { get; set; }
-    public int Radius { get; set; }
-    public int Accuracy { get; set; }
+    public required double Latitude { get; set; }
+    public required double Longitude { get; set; }
+    public required bool Enabled { get; set; }
+    public required int Radius { get; set; }
+    public required int Accuracy { get; set; }
 }
 
 public class UnlockBetweenSettingResponse
 {
-    public string Start { get; set; } = string.Empty;
-    public string End { get; set; } = string.Empty;
-    public string Timezone { get; set; } = string.Empty;
-    public List<DayOfWeek> Days { get; set; } = [];
-    public List<string>? Exceptions { get; set; } = null;
+    public required TimeOnly Start { get; set; }
+    public required TimeOnly End { get; set; }
+    public required TimeZoneInfo Timezone { get; set; }
+    public required List<DayOfWeek> Days { get; set; }
+    public List<DateOnly>? Exceptions { get; set; }
 }
 
 public class LockStateResponse
 {
-    public bool? Connected { get; set; } = null;
+    public bool? Connected { get; set; }
 }
 
 public class UserPublicKeyResponse
 {
-    public string Id { get; set; } = string.Empty;
-    public string PublicKey { get; set; } = string.Empty;
+    public required Guid Id { get; set; }
+    public required string PublicKey { get; set; }
 }
 
 public class BatchUserPublicKeyResponse
 {
-    public string Id { get; set; } = string.Empty;
-    public string? Email { get; set; } = null;
-    public string? ForeignKey { get; set; } = null;
-    public string? Phone { get; set; } = null;
-    public string PublicKey { get; set; } = string.Empty;
+    public required Guid Id { get; set; }
+    public string? Email { get; set; }
+    public string? ForeignKey { get; set; }
+    public string? Phone { get; set; }
+    public required string PublicKey { get; set; }
 }
 
 public class ShareableLockResponse
 {
-    public string Id { get; set; } = string.Empty;
-    public string Name { get; set; } = string.Empty;
+    public required Guid Id { get; set; }
+    public required string Name { get; set; }
 }
 
 public class UserLockResponse
 {
-    public string UserId { get; set; } = string.Empty;
-    public string Email { get; set; } = string.Empty;
-    public string PublicKey { get; set; } = string.Empty;
-    public string? DisplayName { get; set; } = null;
-    public bool Orphan { get; set; }
-    public bool Foreign { get; set; }
-    public UserRole Role { get; set; }
-    public double? Start { get; set; } = null;
-    public double? End { get; set; } = null;
+    public required Guid UserId { get; set; }
+    public required string Email { get; set; }
+    public required string PublicKey { get; set; }
+    public string? DisplayName { get; set; }
+    public required bool Orphan { get; set; }
+    public required bool Foreign { get; set; }
+    public required UserRole Role { get; set; }
+    public DateTime? Start { get; set; }
+    public DateTime? End { get; set; }
 }
 
 public class LockUserResponse
 {
-    public string UserId { get; set; } = string.Empty;
-    public string Email { get; set; } = string.Empty;
-    public string PublicKey { get; set; } = string.Empty;
-    public string? DisplayName { get; set; } = null;
-    public bool Orphan { get; set; }
-    public bool Foreign { get; set; }
-    public double? Start { get; set; } = null;
-    public double? End { get; set; } = null;
-    public List<LockUserDetailsResponse> Devices { get; set; } = [];
+    public required Guid UserId { get; set; }
+    public required string Email { get; set; }
+    public required string PublicKey { get; set; }
+    public string? DisplayName { get; set; }
+    public required bool Orphan { get; set; }
+    public required bool Foreign { get; set; }
+    public DateTime? Start { get; set; }
+    public DateTime? End { get; set; }
+    public required List<LockUserDetailsResponse> Devices { get; set; }
 }
 
 public class LockUserDetailsResponse
 {
-    public string DeviceId { get; set; } = string.Empty;
-    public UserRole Role { get; set; }
-    public double? Start { get; set; } = null;
-    public double? End { get; set; } = null;
+    public required Guid DeviceId { get; set; }
+    public required UserRole Role { get; set; }
+    public DateTime? Start { get; set; }
+    public DateTime? End { get; set; }
 }
 
 public class AuditResponse
 {
-    public string DeviceId { get; set; } = string.Empty;
-    public double Timestamp { get; set; }
-    public AuditEvent Type { get; set; }
-    public AuditUserResponse Issuer { get; set; } = new AuditUserResponse();
-    public AuditUserResponse? Subject { get; set; } = null;
-    public bool Rejected { get; set; }
+    public required Guid DeviceId { get; set; }
+    public required DateTime Timestamp { get; set; }
+    public required AuditEvent Type { get; set; }
+    public required AuditUserResponse Issuer { get; set; }
+    public AuditUserResponse? Subject { get; set; }
+    public required bool Rejected { get; set; }
 }
 
 public class AuditUserResponse
 {
-    public string UserId { get; set; } = string.Empty;
-    public string? Email { get; set; } = null;
-    public string? DisplayName { get; set; } = null;
-    public string? Ip { get; set; } = null;
+    public required Guid UserId { get; set; }
+    public string? Email { get; set; }
+    public string? DisplayName { get; set; }
+    public IPAddress? Ip { get; set; }
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/LockOperationResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/LockOperationResponses.cs
@@ -67,7 +67,7 @@ public class LockStateResponse
 public class UserPublicKeyResponse
 {
     public required Guid Id { get; set; }
-    public required string PublicKey { get; set; }
+    public required byte[] PublicKey { get; set; }
 }
 
 public class BatchUserPublicKeyResponse
@@ -76,7 +76,7 @@ public class BatchUserPublicKeyResponse
     public string? Email { get; set; }
     public string? ForeignKey { get; set; }
     public string? Phone { get; set; }
-    public required string PublicKey { get; set; }
+    public required byte[] PublicKey { get; set; }
 }
 
 public class ShareableLockResponse
@@ -89,7 +89,7 @@ public class UserLockResponse
 {
     public required Guid UserId { get; set; }
     public required string Email { get; set; }
-    public required string PublicKey { get; set; }
+    public required byte[] PublicKey { get; set; }
     public string? DisplayName { get; set; }
     public required bool Orphan { get; set; }
     public required bool Foreign { get; set; }
@@ -102,7 +102,7 @@ public class LockUserResponse
 {
     public required Guid UserId { get; set; }
     public required string Email { get; set; }
-    public required string PublicKey { get; set; }
+    public required byte[] PublicKey { get; set; }
     public string? DisplayName { get; set; }
     public required bool Orphan { get; set; }
     public required bool Foreign { get; set; }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/PlatformResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/PlatformResponses.cs
@@ -4,23 +4,23 @@ namespace Doordeck.Headless.Sdk.Model.Responses;
 
 public class ApplicationResponse
 {
-    public string ApplicationId { get; set; } = string.Empty;
-    public string Name { get; set; } = string.Empty;
-    public double? LastUpdated { get; set; } = null;
-    public List<string>? Owners { get; set; } = null;
-    public List<string>? CorsDomains { get; set; } = null;
-    public List<string>? AuthDomains { get; set; } = null;
-    public string? LogoUrl { get; set; } = null;
-    public string? PrivacyPolicy { get; set; } = null;
-    public string? MailingAddress { get; set; } = null;
-    public string? CompanyName { get; set; } = null;
-    public string? SupportContact { get; set; } = null;
-    public string? AppLink { get; set; } = null;
-    public string? Slug { get; set; } = null;
-    public EmailPreferencesResponse EmailPreferences { get; set; } = new EmailPreferencesResponse();
-    public Dictionary<string, AuthKeyResponse> AuthKeys { get; set; } = [];
-    public OauthResponse? Oauth { get; set; } = null;
-    public bool? IsDoordeckApplication { get; set; } = null;
+    public required Guid ApplicationId { get; set; }
+    public required string Name { get; set; }
+    public DateTime? LastUpdated { get; set; }
+    public List<Guid>? Owners { get; set; }
+    public List<Uri>? CorsDomains { get; set; }
+    public List<Uri>? AuthDomains { get; set; }
+    public Uri? LogoUrl { get; set; }
+    public Uri? PrivacyPolicy { get; set; }
+    public string? MailingAddress { get; set; }
+    public string? CompanyName { get; set; }
+    public Uri? SupportContact { get; set; }
+    public Uri? AppLink { get; set; }
+    public string? Slug { get; set; }
+    public required EmailPreferencesResponse EmailPreferences { get; set; }
+    public required Dictionary<string, AuthKeyResponse> AuthKeys { get; set; }
+    public OauthResponse? Oauth { get; set; }
+    public bool? IsDoordeckApplication { get; set; }
 }
 
 public interface IAuthKeyResponse;
@@ -33,99 +33,99 @@ public abstract class AuthKeyResponse : IAuthKeyResponse;
 
 public class RsaKeyResponse : AuthKeyResponse
 {
-    public string Kty { get; set; } = string.Empty;
-    public string Kid { get; set; } = string.Empty;
-    public string Use { get; set; } = string.Empty;
-    public string? Alg { get; set; } = null;
+    public required string Kty { get; set; }
+    public required string Kid { get; set; }
+    public required string Use { get; set; }
+    public string? Alg { get; set; }
     [JsonPropertyName("key_ops")]
-    public List<string>? Ops { get; set; } = null;
-    public string? X5U { get; set; } = null;
-    public string? X5T { get; set; } = null;
+    public List<string>? Ops { get; set; }
+    public string? X5U { get; set; }
+    public string? X5T { get; set; }
     [JsonPropertyName("x5t#S256")]
-    public string? X5T256 { get; set; } = null;
-    public List<string>? X5C { get; set; } = null;
-    public int? Exp { get; set; } = null;
-    public int? Nbf { get; set; } = null;
-    public int? Iat { get; set; } = null;
-    public string E { get; set; } = string.Empty;
-    public string N { get; set; } = string.Empty;
+    public string? X5T256 { get; set; }
+    public List<string>? X5C { get; set; }
+    public int? Exp { get; set; }
+    public int? Nbf { get; set; }
+    public int? Iat { get; set; }
+    public required string E { get; set; }
+    public required string N { get; set; }
 }
 
 public class EcKeyResponse : AuthKeyResponse
 {
-    public string Kty { get; set; } = string.Empty;
-    public string Kid { get; set; } = string.Empty;
-    public string Use { get; set; } = string.Empty;
-    public string? Alg { get; set; } = null;
+    public required string Kty { get; set; }
+    public required string Kid { get; set; }
+    public required string Use { get; set; }
+    public string? Alg { get; set; }
     [JsonPropertyName("key_ops")]
-    public List<string>? Ops { get; set; } = null;
-    public string? X5U { get; set; } = null;
-    public string? X5T { get; set; } = null;
+    public List<string>? Ops { get; set; }
+    public string? X5U { get; set; }
+    public string? X5T { get; set; }
     [JsonPropertyName("x5t#S256")]
-    public string? X5T256 { get; set; } = null;
-    public List<string>? X5C { get; set; } = null;
-    public int? Exp { get; set; } = null;
-    public int? Nbf { get; set; } = null;
-    public int? Iat { get; set; } = null;
-    public string Crv { get; set; } = string.Empty;
-    public string X { get; set; } = string.Empty;
-    public string Y { get; set; } = string.Empty;
+    public string? X5T256 { get; set; }
+    public List<string>? X5C { get; set; }
+    public int? Exp { get; set; }
+    public int? Nbf { get; set; }
+    public int? Iat { get; set; }
+    public required string Crv { get; set; }
+    public required string X { get; set; }
+    public required string Y { get; set; }
 }
 
 public class Ed25519KeyResponse : AuthKeyResponse
 {
-    public string Kty { get; set; } = string.Empty;
-    public string Kid { get; set; } = string.Empty;
-    public string Use { get; set; } = string.Empty;
-    public string? Alg { get; set; } = null;
+    public required string Kty { get; set; }
+    public required string Kid { get; set; }
+    public required string Use { get; set; }
+    public string? Alg { get; set; }
     [JsonPropertyName("key_ops")]
-    public List<string>? Ops { get; set; } = null;
-    public string? X5U { get; set; } = null;
-    public string? X5T { get; set; } = null;
+    public List<string>? Ops { get; set; }
+    public string? X5U { get; set; }
+    public string? X5T { get; set; }
     [JsonPropertyName("x5t#S256")]
-    public string? X5T256 { get; set; } = null;
-    public List<string>? X5C { get; set; } = null;
-    public int? Exp { get; set; } = null;
-    public int? Nbf { get; set; } = null;
-    public int? Iat { get; set; } = null;
-    public string Crv { get; set; } = string.Empty;
-    public string X { get; set; } = string.Empty;
+    public string? X5T256 { get; set; }
+    public List<string>? X5C { get; set; }
+    public int? Exp { get; set; }
+    public int? Nbf { get; set; }
+    public int? Iat { get; set; }
+    public required string Crv { get; set; }
+    public required string X { get; set; }
 }
 
 public class EmailPreferencesResponse
 {
-    public string? SenderEmail { get; set; } = null;
-    public string? SenderName { get; set; } = null;
-    public string PrimaryColour { get; set; } = string.Empty;
-    public string SecondaryColour { get; set; } = string.Empty;
-    public bool? OnlySendEssentialEmails { get; set; } = null;
-    public EmailCallToActionResponse? CallToAction { get; set; } = null;
+    public string? SenderEmail { get; set; }
+    public string? SenderName { get; set; }
+    public required string PrimaryColour { get; set; }
+    public required string SecondaryColour { get; set; }
+    public bool? OnlySendEssentialEmails { get; set; }
+    public required EmailCallToActionResponse? CallToAction { get; set; }
 }
 
 public class EmailCallToActionResponse
 {
-    public string ActionTarget { get; set; } = string.Empty;
-    public string Headline { get; set; } = string.Empty;
-    public string ActionText { get; set; } = string.Empty;
+    public required Uri ActionTarget { get; set; }
+    public required string Headline { get; set; }
+    public required string ActionText { get; set; }
 }
 
 public class OauthResponse
 {
-    public string AuthorizationEndpoint { get; set; } = string.Empty;
-    public string ClientId { get; set; } = string.Empty;
-    public GrantType GrantType { get; set; }
+    public required string AuthorizationEndpoint { get; set; }
+    public required string ClientId { get; set; }
+    public required GrantType GrantType { get; set; }
 }
 
 public class ApplicationOwnerDetailsResponse
 {
-    public string UserId { get; set; } = string.Empty;
-    public string Email { get; set; } = string.Empty;
-    public string? DisplayName { get; set; } = null;
-    public bool Orphan { get; set; }
-    public bool Foreign { get; set; }
+    public Guid UserId { get; set; }
+    public required string Email { get; set; }
+    public string? DisplayName { get; set; }
+    public required bool Orphan { get; set; }
+    public required bool Foreign { get; set; }
 }
 
 public class GetLogoUploadUrlResponse
 {
-    public string UploadUrl { get; set; } = string.Empty;
+    public required Uri UploadUrl { get; set; }
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/SiteResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/SiteResponses.cs
@@ -2,20 +2,20 @@
 
 public class SiteResponse
 {
-    public string Id { get; set; } = string.Empty;
-    public string Name { get; set; } = string.Empty;
-    public string Colour { get; set; } = string.Empty;
-    public double Longitude { get; set; }
-    public double Latitude { get; set; }
-    public int Radius { get; set; }
-    public string Created { get; set; } = string.Empty;
-    public string Updated { get; set; } = string.Empty;
+    public required Guid Id { get; set; }
+    public required string Name { get; set; }
+    public required string Colour { get; set; }
+    public required double Longitude { get; set; }
+    public required double Latitude { get; set; }
+    public required int Radius { get; set; }
+    public required DateTime Created { get; set; }
+    public required DateTime Updated { get; set; }
 }
 
 public class UserForSiteResponse
 {
-    public string UserId { get; set; } = string.Empty;
-    public string Email { get; set; } = string.Empty;
-    public string? DisplayName { get; set; } = null;
-    public bool Orphan { get; set; }
+    public required Guid UserId { get; set; }
+    public required string Email { get; set; }
+    public string? DisplayName { get; set; }
+    public required bool Orphan { get; set; }
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/TileResponses.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Model/Responses/TileResponses.cs
@@ -2,7 +2,7 @@
 
 public class TileLocksResponse
 {
-    public string SiteId { get; set; } = string.Empty;
-    public string TileId { get; set; } = string.Empty;
-    public List<string> DeviceIds { get; set; } = [];
+    public required Guid SiteId { get; set; }
+    public required Guid TileId { get; set; }
+    public required List<Guid> DeviceIds { get; set; }
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Utils/Utils.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Utils/Utils.cs
@@ -16,6 +16,7 @@ public static class Utils
             new TimeOnlyJsonConverter(),
             new TimeZoneInfoJsonConverter(),
             new DateOnlyJsonConverter(),
+            new X509CertificateJsonConverter(),
             new TimeSpanJsonConverter()
         }
     };

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Utils/Utils.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Utils/Utils.cs
@@ -7,7 +7,16 @@ public static class Utils
 {
     private static readonly JsonSerializerOptions JsonSerializerOptions = new()
     {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters =
+        {
+            new IpAddressJsonConverter(),
+            new DateTimeJsonConverter(),
+            new TimeOnlyJsonConverter(),
+            new TimeZoneInfoJsonConverter(),
+            new DateOnlyJsonConverter(),
+            new TimeSpanJsonConverter()
+        }
     };
 
     public static unsafe sbyte* ToJsonSByte<T>(this T input) => ToJson(input).StringToSByte();

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Utils/Utils.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Utils/Utils.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using System.Text.Json;
+using Doordeck.Headless.Sdk.Converter;
 
 namespace Doordeck.Headless.Sdk.Utilities;
 

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Utils/Utils.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Utils/Utils.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using Doordeck.Headless.Sdk.Converter;
 
@@ -41,7 +42,14 @@ public static class Utils
 
     public static string EncodeByteArrayToBase64(this byte[] input) => Convert.ToBase64String(input);
 
-    public static string CertificateChainToString(this List<string> input) => string.Join("|", input);
+    public static string CertificateChainToString(this List<X509Certificate> input) =>
+        string.Join("|", input.Select(cert => cert.Export(X509ContentType.Cert).EncodeByteArrayToBase64()));
 
-    public static List<string> StringToCertificateChain(this string input) => input.Split("|").ToList();
+    public static List<X509Certificate> StringToCertificateChain(this string input) =>
+    [
+        ..input.Split("|")
+            .ToList()
+            .Select(cert => X509CertificateLoader.LoadCertificate(cert.DecodeBase64ToByteArray()))
+            .ToList()
+    ];
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Utils/Utils.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Utils/Utils.cs
@@ -1,7 +1,7 @@
 ﻿using System.Runtime.InteropServices;
 using System.Text.Json;
 
-namespace Doordeck.Headless.Sdk.Utils;
+namespace Doordeck.Headless.Sdk.Utilities;
 
 public static class Utils
 {
@@ -10,33 +10,27 @@ public static class Utils
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    public static unsafe sbyte* ToData<T>(this T input) =>
-        JsonSerializer.Serialize(input, JsonSerializerOptions).ToSByte();
+    public static unsafe sbyte* ToJsonSByte<T>(this T input) => ToJson(input).StringToSByte();
 
-    public static unsafe T FromData<T>(sbyte* input) =>
-        JsonSerializer.Deserialize<T>(ConvertSByteToString(input), JsonSerializerOptions)!;
+    public static unsafe T FromJsonSByte<T>(sbyte* input) => FromJson<T>(SByteToString(input));
 
-    public static T FromData<T>(string input) =>
-        JsonSerializer.Deserialize<T>(input, JsonSerializerOptions)!;
+    private static string ToJson<T>(this T input) => JsonSerializer.Serialize(input, JsonSerializerOptions);
 
-    public static unsafe sbyte* ToSByte(this string input) =>
-        (sbyte*)Marshal.StringToHGlobalAnsi(input);
+    public static T FromJson<T>(string input) => JsonSerializer.Deserialize<T>(input, JsonSerializerOptions)!;
 
-    public static unsafe string ConvertSByteToString(sbyte* input) =>
-        Marshal.PtrToStringAnsi((IntPtr)input)!;
+    public static unsafe sbyte* StringToSByte(this string input) => (sbyte*)Marshal.StringToHGlobalAnsi(input);
 
-    public static bool ToBoolean(this byte input) =>
-        Convert.ToBoolean(input);
+    public static unsafe string SByteToString(sbyte* input) => Marshal.PtrToStringAnsi((IntPtr)input)!;
 
-    public static byte[] DecodeBase64ToByteArray(this string input) =>
-        Convert.FromBase64String(input);
+    public static bool ByteToBoolean(this byte input) => Convert.ToBoolean(input);
 
-    public static string EncodeByteArrayToBase64(this byte[] input) =>
-        Convert.ToBase64String(input);
+    public static byte BooleanToByte(this bool input) => Convert.ToByte(input);
 
-    public static string CertificateChainToString(this List<string> input) =>
-        string.Join("|", input);
+    public static byte[] DecodeBase64ToByteArray(this string input) => Convert.FromBase64String(input);
 
-    public static List<string> StringToCertificateChain(this string input) =>
-        input.Split("|").ToList();
+    public static string EncodeByteArrayToBase64(this byte[] input) => Convert.ToBase64String(input);
+
+    public static string CertificateChainToString(this List<string> input) => string.Join("|", input);
+
+    public static List<string> StringToCertificateChain(this string input) => input.Split("|").ToList();
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/AbstractWrapper.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/AbstractWrapper.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 using Doordeck.Headless.Sdk.Model;
-using Doordeck.Headless.Sdk.Utils;
+using Doordeck.Headless.Sdk.Utilities;
 
 namespace Doordeck.Headless.Sdk.Wrapper;
 
@@ -42,7 +42,7 @@ public abstract class AbstractWrapper
     
             try
             {
-                var resultData = Utils.Utils.FromData<ResultData<TResponse>>(result);
+                var resultData = Utils.FromJson<ResultData<TResponse>>(result);
                 HandleException(resultData);
                 var response = resultData.Success!.Result ?? default!;
                 _tcs.SetResult(response);
@@ -73,7 +73,7 @@ public abstract class AbstractWrapper
         delegate* unmanaged[Cdecl]<TApi, void*, void> processWithoutData) where TApi : unmanaged
     {
         var tcs = new TaskCompletionSource<TResponse>();
-        var sData = data != null ? data.ToData() : null;
+        var sData = data != null ? data.ToJsonSByte() : null;
         try
         {
             var holder = new CallbackHolder<TResponse>(tcs);

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/AbstractWrapper.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/AbstractWrapper.cs
@@ -6,17 +6,14 @@ namespace Doordeck.Headless.Sdk.Wrapper;
 
 public abstract class AbstractWrapper
 {
-    private static class Native
-    {
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void CallbackDelegate(IntPtr ptr);
-    }
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void CallbackDelegate(IntPtr ptr);
 
     private class NativeCallback<TResponse> : IDisposable
     {
         private readonly TaskCompletionSource<TResponse> _tcs;
         private GCHandle _handle;
-        public Native.CallbackDelegate CallbackDelegate { get; }
+        public CallbackDelegate CallbackDelegate { get; }
 
         public NativeCallback(TaskCompletionSource<TResponse> tcs)
         {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/AbstractWrapper.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/AbstractWrapper.cs
@@ -7,13 +7,13 @@ namespace Doordeck.Headless.Sdk.Wrapper;
 public abstract class AbstractWrapper
 {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackDelegate(IntPtr ptr);
+    private delegate void NativeCallbackDelegate(IntPtr ptr);
 
     private class NativeCallback<TResponse> : IDisposable
     {
         private readonly TaskCompletionSource<TResponse> _tcs;
         private GCHandle _handle;
-        public CallbackDelegate CallbackDelegate { get; }
+        public NativeCallbackDelegate CallbackDelegate { get; }
 
         public NativeCallback(TaskCompletionSource<TResponse> tcs)
         {
@@ -74,7 +74,7 @@ public abstract class AbstractWrapper
         delegate* unmanaged[Cdecl]<TApi, sbyte*, void*, void> processWithData,
         object data) where TApi : unmanaged =>
         Process<TApi, TResponse>(api, processWithData, null, data);
-    
+
     internal static unsafe Task<TResponse> Process<TApi, TResponse>(
         TApi api,
         delegate* unmanaged[Cdecl]<TApi, void*, void> processWithoutData) where TApi : unmanaged =>
@@ -86,7 +86,7 @@ public abstract class AbstractWrapper
         delegate* unmanaged[Cdecl]<TApi, void*, void> processWithoutData,
         object? data) where TApi : unmanaged
     {
-        var tcs = new TaskCompletionSource<TResponse>();
+        var tcs = new TaskCompletionSource<TResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
         var sData = data != null ? data.ToJsonSByte() : null;
         try
         {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/AbstractWrapper.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/AbstractWrapper.cs
@@ -12,40 +12,46 @@ public abstract class AbstractWrapper
         public delegate void CallbackDelegate(IntPtr ptr);
     }
 
-    private class CallbackHolder<TResponse> : IDisposable
+    private class NativeCallback<TResponse> : IDisposable
     {
         private readonly TaskCompletionSource<TResponse> _tcs;
         private GCHandle _handle;
         public Native.CallbackDelegate CallbackDelegate { get; }
-    
-        public CallbackHolder(TaskCompletionSource<TResponse> tcs)
+
+        public NativeCallback(TaskCompletionSource<TResponse> tcs)
         {
             _tcs = tcs;
-            CallbackDelegate = Callback;
+            CallbackDelegate = OnCallback;
             _handle = GCHandle.Alloc(this);
         }
-    
-        private void Callback(IntPtr ptr)
+
+        private void OnCallback(IntPtr ptr)
         {
             if (ptr == IntPtr.Zero)
             {
                 Dispose();
                 return;
             }
-    
+
             var result = Marshal.PtrToStringAnsi(ptr);
             if (result == null)
             {
                 Dispose();
                 return;
             }
-    
+
             try
             {
                 var resultData = Utils.FromJson<ResultData<TResponse>>(result);
-                HandleException(resultData);
-                var response = resultData.Success!.Result ?? default!;
-                _tcs.SetResult(response);
+                if (resultData.Failure != null)
+                {
+                    _tcs.SetException(HandleException(resultData));
+                }
+                else
+                {
+                    var response = resultData.Success!.Result ?? default!;
+                    _tcs.SetResult(response);
+                }
             }
             catch (Exception exception)
             {
@@ -56,7 +62,7 @@ public abstract class AbstractWrapper
                 Dispose();
             }
         }
-    
+
         public void Dispose()
         {
             if (_handle.IsAllocated)
@@ -65,18 +71,29 @@ public abstract class AbstractWrapper
             }
         }
     }
-    
-    internal static unsafe Task<TResponse> ProcessCommon<TApi, TResponse>(
+
+    internal static unsafe Task<TResponse> Process<TApi, TResponse>(
         TApi api,
-        object? data,
         delegate* unmanaged[Cdecl]<TApi, sbyte*, void*, void> processWithData,
-        delegate* unmanaged[Cdecl]<TApi, void*, void> processWithoutData) where TApi : unmanaged
+        object data) where TApi : unmanaged =>
+        Process<TApi, TResponse>(api, processWithData, null, data);
+    
+    internal static unsafe Task<TResponse> Process<TApi, TResponse>(
+        TApi api,
+        delegate* unmanaged[Cdecl]<TApi, void*, void> processWithoutData) where TApi : unmanaged =>
+        Process<TApi, TResponse>(api, null, processWithoutData, null);
+
+    private static unsafe Task<TResponse> Process<TApi, TResponse>(
+        TApi api,
+        delegate* unmanaged[Cdecl]<TApi, sbyte*, void*, void> processWithData,
+        delegate* unmanaged[Cdecl]<TApi, void*, void> processWithoutData,
+        object? data) where TApi : unmanaged
     {
         var tcs = new TaskCompletionSource<TResponse>();
         var sData = data != null ? data.ToJsonSByte() : null;
         try
         {
-            var holder = new CallbackHolder<TResponse>(tcs);
+            var holder = new NativeCallback<TResponse>(tcs);
             var callbackPointer = Marshal.GetFunctionPointerForDelegate(holder.CallbackDelegate);
             if (data != null)
             {
@@ -94,29 +111,28 @@ public abstract class AbstractWrapper
 
         return tcs.Task;
     }
-    
-    private static void HandleException<T>(ResultData<T> input)
+
+    private static Exception HandleException<T>(ResultData<T> input)
     {
-        if (input.IsSuccess) return;
         var exceptionType = input.Failure!.ExceptionType;
-        if (exceptionType.Contains("SdkException")) throw new SdkException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("MissingContextFieldException")) throw new MissingContextFieldException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("BatchShareFailedException")) throw new BatchShareFailedException(input.Failure.ExceptionMessage, []);
-        if (exceptionType.Contains("BadRequestException")) throw new BadRequestException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("UnauthorizedException")) throw new UnauthorizedException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("ForbiddenException")) throw new ForbiddenException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("NotFoundException")) throw new NotFoundException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("MethodNotAllowedException")) throw new MethodNotAllowedException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("NotAcceptableException")) throw new NotAcceptableException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("ConflictException")) throw new ConflictException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("GoneException")) throw new GoneException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("UnprocessableEntityException")) throw new UnprocessableEntityException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("LockedException")) throw new LockedException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("TooEarlyException")) throw new TooEarlyException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("TooManyRequestsException")) throw new TooManyRequestsException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("InternalServerErrorException")) throw new InternalServerErrorException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("ServiceUnavailableException")) throw new ServiceUnavailableException(input.Failure.ExceptionMessage);
-        if (exceptionType.Contains("GatewayTimeoutException")) throw new GatewayTimeoutException(input.Failure.ExceptionMessage);
-        throw new SdkException("Unhandled exception type: " + exceptionType);
+        if (exceptionType.Contains("SdkException")) return new SdkException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("MissingContextFieldException")) return new MissingContextFieldException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("BatchShareFailedException")) return new BatchShareFailedException(input.Failure.ExceptionMessage, []);
+        if (exceptionType.Contains("BadRequestException")) return new BadRequestException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("UnauthorizedException")) return new UnauthorizedException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("ForbiddenException")) return new ForbiddenException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("NotFoundException")) return new NotFoundException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("MethodNotAllowedException")) return new MethodNotAllowedException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("NotAcceptableException")) return new NotAcceptableException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("ConflictException")) return new ConflictException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("GoneException")) return new GoneException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("UnprocessableEntityException")) return new UnprocessableEntityException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("LockedException")) return new LockedException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("TooEarlyException")) return new TooEarlyException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("TooManyRequestsException")) return new TooManyRequestsException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("InternalServerErrorException")) return new InternalServerErrorException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("ServiceUnavailableException")) return new ServiceUnavailableException(input.Failure.ExceptionMessage);
+        if (exceptionType.Contains("GatewayTimeoutException")) return new GatewayTimeoutException(input.Failure.ExceptionMessage);
+        return new SdkException("Unhandled exception type: " + exceptionType);
     }
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Account.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Account.cs
@@ -3,50 +3,40 @@ using Doordeck.Headless.Sdk.Model.Responses;
 
 namespace Doordeck.Headless.Sdk.Wrapper;
 
+using AccountApi = Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_AccountApi;
+    
 public class Account(
     Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_AccountApi account,
     Doordeck_Headless_Sdk_ExportedSymbols._kotlin_e__Struct._root_e__Struct._com_e__Struct._doordeck_e__Struct.
         _multiplatform_e__Struct._sdk_e__Struct._api_e__Struct._AccountApi_e__Struct accountApi) : AbstractWrapper
 {
     public unsafe Task<TokenResponse> RefreshToken(string? refreshToken = null) =>
-        Process<TokenResponse>(accountApi.refreshToken_, null, new { refreshToken });
+        Process<AccountApi, TokenResponse>(account, accountApi.refreshToken_, new { refreshToken });
 
     public unsafe Task<object> Logout() =>
-        Process<object>(null, accountApi.logout_, null);
+        Process<AccountApi, object>(account, accountApi.logout_); 
 
     public unsafe Task<RegisterEphemeralKeyResponse> RegisterEphemeralKey(string? publicKey = null, string? privateKey = null) =>
-        Process<RegisterEphemeralKeyResponse>(accountApi.registerEphemeralKey_, null, new { publicKey, privateKey });
+        Process<AccountApi, RegisterEphemeralKeyResponse>(account, accountApi.registerEphemeralKey_, new { publicKey, privateKey });
 
     public unsafe Task<RegisterEphemeralKeyWithSecondaryAuthenticationResponse> RegisterEphemeralKeyWithSecondaryAuthentication(string? publicKey = null, TwoFactorMethod? method = null) =>
-        Process<RegisterEphemeralKeyWithSecondaryAuthenticationResponse>(accountApi.registerEphemeralKeyWithSecondaryAuthentication_, null, new { publicKey, method });
+        Process<AccountApi, RegisterEphemeralKeyWithSecondaryAuthenticationResponse>(account, accountApi.registerEphemeralKeyWithSecondaryAuthentication_, new { publicKey, method });
 
     public unsafe Task<RegisterEphemeralKeyResponse> VerifyEphemeralKeyRegistration(string code, string? publicKey = null, string? privateKey = null) =>
-        Process<RegisterEphemeralKeyResponse>(accountApi.verifyEphemeralKeyRegistration_, null, new { code, publicKey, privateKey });
+        Process<AccountApi, RegisterEphemeralKeyResponse>(account, accountApi.verifyEphemeralKeyRegistration_, new { code, publicKey, privateKey });
 
     public unsafe Task<object> ReverifyEmail() =>
-        Process<object>(null, accountApi.reverifyEmail_, null);
+        Process<AccountApi, object>(account, accountApi.reverifyEmail_);
 
     public unsafe Task<object> ChangePassword(string oldPassword, string newPassword) =>
-        Process<object>(accountApi.changePassword_, null, new { oldPassword, newPassword });
+        Process<AccountApi, object>(account, accountApi.changePassword_, new { oldPassword, newPassword });
 
     public unsafe Task<UserDetailsResponse> GetUserDetails() =>
-        Process<UserDetailsResponse>(null, accountApi.getUserDetails_, null);
+        Process<AccountApi, UserDetailsResponse>(account, accountApi.getUserDetails_);
 
     public unsafe Task<object> UpdateUserDetails(string displayName) =>
-        Process<object>(accountApi.updateUserDetails_, null, new { displayName });
+        Process<AccountApi, object>(account, accountApi.updateUserDetails_, new { displayName });
 
     public unsafe Task<object> DeleteAccount() =>
-        Process<object>(null, accountApi.deleteAccount_, null);
-
-    private unsafe Task<TResponse> Process<TResponse>(
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_AccountApi,
-            sbyte*, void*, void> processWithData,
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_AccountApi,
-            void*, void> processWithoutData,
-        object? data) =>
-        ProcessCommon<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_AccountApi, TResponse>(
-            account,
-            data,
-            processWithData,
-            processWithoutData);
+        Process<AccountApi, object>(account, accountApi.deleteAccount_);
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Account.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Account.cs
@@ -16,13 +16,13 @@ public class Account(
     public unsafe Task<object> Logout() =>
         Process<AccountApi, object>(account, accountApi.logout_); 
 
-    public unsafe Task<RegisterEphemeralKeyResponse> RegisterEphemeralKey(string? publicKey = null, string? privateKey = null) =>
+    public unsafe Task<RegisterEphemeralKeyResponse> RegisterEphemeralKey(byte[]? publicKey = null, byte[]? privateKey = null) =>
         Process<AccountApi, RegisterEphemeralKeyResponse>(account, accountApi.registerEphemeralKey_, new { publicKey, privateKey });
 
-    public unsafe Task<RegisterEphemeralKeyWithSecondaryAuthenticationResponse> RegisterEphemeralKeyWithSecondaryAuthentication(string? publicKey = null, TwoFactorMethod? method = null) =>
+    public unsafe Task<RegisterEphemeralKeyWithSecondaryAuthenticationResponse> RegisterEphemeralKeyWithSecondaryAuthentication(byte[]? publicKey = null, TwoFactorMethod? method = null) =>
         Process<AccountApi, RegisterEphemeralKeyWithSecondaryAuthenticationResponse>(account, accountApi.registerEphemeralKeyWithSecondaryAuthentication_, new { publicKey, method });
 
-    public unsafe Task<RegisterEphemeralKeyResponse> VerifyEphemeralKeyRegistration(string code, string? publicKey = null, string? privateKey = null) =>
+    public unsafe Task<RegisterEphemeralKeyResponse> VerifyEphemeralKeyRegistration(string code, byte[]? publicKey = null, byte[]? privateKey = null) =>
         Process<AccountApi, RegisterEphemeralKeyResponse>(account, accountApi.verifyEphemeralKeyRegistration_, new { code, publicKey, privateKey });
 
     public unsafe Task<object> ReverifyEmail() =>

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Accountless.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Accountless.cs
@@ -2,34 +2,25 @@ using Doordeck.Headless.Sdk.Model.Responses;
 
 namespace Doordeck.Headless.Sdk.Wrapper;
 
+using AccountlessApi = Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_AccountlessApi;
+
 public class Accountless(
     Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_AccountlessApi accountless,
     Doordeck_Headless_Sdk_ExportedSymbols._kotlin_e__Struct._root_e__Struct._com_e__Struct._doordeck_e__Struct.
         _multiplatform_e__Struct._sdk_e__Struct._api_e__Struct._AccountlessApi_e__Struct accountlessApi) : AbstractWrapper
 {
     public unsafe Task<TokenResponse> Login(string email, string password) =>
-        Process<TokenResponse>(accountlessApi.login_, null, new { email, password });
+        Process<AccountlessApi, TokenResponse>(accountless, accountlessApi.login_, new { email, password });
 
-    public unsafe Task<TokenResponse> Registration(string email, string password, string? displayName = null,
-        bool force = false, string? publicKey = null) =>
-        Process<TokenResponse>(accountlessApi.registration_, null, new { email, password, displayName, force, publicKey });
+    public unsafe Task<TokenResponse> Registration(string email, string password, string? displayName = null, bool force = false, string? publicKey = null) =>
+        Process<AccountlessApi, TokenResponse>(accountless, accountlessApi.registration_, new { email, password, displayName, force, publicKey });
     
     public unsafe Task<object> VerifyEmail(string code) =>
-        Process<object>(accountlessApi.verifyEmail_, null, new { code });
+        Process<AccountlessApi, object>(accountless, accountlessApi.verifyEmail_, new { code });
 
     public unsafe Task<object> PasswordReset(string email) =>
-        Process<object>(accountlessApi.passwordReset_, null, new { email });
+        Process<AccountlessApi, object>(accountless, accountlessApi.passwordReset_, new { email });
 
     public unsafe Task<object> PasswordResetVerify(string userId, string token, string password) =>
-        Process<object>(accountlessApi.passwordResetVerify_, null, new { userId, token, password });
-
-    private unsafe Task<TResponse> Process<TResponse>(
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_AccountlessApi, sbyte*, void*, void> processWithData,
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_AccountlessApi, void*, void> processWithoutData,
-        object? data = null) => 
-        ProcessCommon<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_AccountlessApi, TResponse>(
-            accountless,
-            data,
-            processWithData,
-            processWithoutData);
+        Process<AccountlessApi, object>(accountless, accountlessApi.passwordResetVerify_, new { userId, token, password });
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Accountless.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Accountless.cs
@@ -12,7 +12,7 @@ public class Accountless(
     public unsafe Task<TokenResponse> Login(string email, string password) =>
         Process<AccountlessApi, TokenResponse>(accountless, accountlessApi.login_, new { email, password });
 
-    public unsafe Task<TokenResponse> Registration(string email, string password, string? displayName = null, bool force = false, string? publicKey = null) =>
+    public unsafe Task<TokenResponse> Registration(string email, string password, string? displayName = null, bool force = false, byte[]? publicKey = null) =>
         Process<AccountlessApi, TokenResponse>(accountless, accountlessApi.registration_, new { email, password, displayName, force, publicKey });
     
     public unsafe Task<object> VerifyEmail(string code) =>

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Accountless.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Accountless.cs
@@ -21,6 +21,6 @@ public class Accountless(
     public unsafe Task<object> PasswordReset(string email) =>
         Process<AccountlessApi, object>(accountless, accountlessApi.passwordReset_, new { email });
 
-    public unsafe Task<object> PasswordResetVerify(string userId, string token, string password) =>
+    public unsafe Task<object> PasswordResetVerify(Guid userId, string token, string password) =>
         Process<AccountlessApi, object>(accountless, accountlessApi.passwordResetVerify_, new { userId, token, password });
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
@@ -4,6 +4,8 @@ using Doordeck.Headless.Sdk.Utilities;
 
 namespace Doordeck.Headless.Sdk.Wrapper;
 
+using ContextManagerApi = Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_context_ContextManager;
+
 public unsafe class ContextManager(
     Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_context_ContextManager context,
     Doordeck_Headless_Sdk_ExportedSymbols._kotlin_e__Struct._root_e__Struct._com_e__Struct._doordeck_e__Struct.
@@ -52,7 +54,7 @@ public unsafe class ContextManager(
     }
 
     public Task<bool> IsCloudAuthTokenInvalidOrExpired() =>
-            Process<bool>(null, contextManager.isCloudAuthTokenInvalidOrExpired_, null);
+            Process<ContextManagerApi, bool>(context, contextManager.isCloudAuthTokenInvalidOrExpired_);
 
     public void SetCloudRefreshToken(string token)
     {
@@ -227,8 +229,8 @@ public unsafe class ContextManager(
         }
     }
 
-    public Task<ContextState> GetContextState() =>
-            Process<ContextState>(null, contextManager.getContextState_, null);
+    public Task<ContextState> GetContextState() => 
+        Process<ContextManagerApi, ContextState>(context, contextManager.getContextState_);
 
     public void ClearContext()
     {
@@ -241,16 +243,4 @@ public unsafe class ContextManager(
 
         if (result != null) symbols->DisposeString(result);
     }
-
-    private Task<TResponse> Process<TResponse>(
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_context_ContextManager,
-            sbyte*, void*, void> processWithData,
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_context_ContextManager,
-            void*, void> processWithoutData,
-        object? data) =>
-        ProcessCommon<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_context_ContextManager, TResponse>(
-            context,
-            data,
-            processWithData,
-            processWithoutData);
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
@@ -10,28 +10,12 @@ public unsafe class ContextManager(
         _multiplatform_e__Struct._sdk_e__Struct._context_e__Struct._ContextManager_e__Struct contextManager,
     Doordeck_Headless_Sdk_ExportedSymbols* symbols) : AbstractWrapper
 {
-    public void SetApiEnvironment(ApiEnvironment apiEnvironment)
-    {
-        var newApiEnvironment = apiEnvironment switch
-        {
-            ApiEnvironment.DEV => symbols->kotlin.root.com.doordeck.multiplatform.sdk.model.data.ApiEnvironment.DEV
-                .get(),
-            ApiEnvironment.STAGING => symbols->kotlin.root.com.doordeck.multiplatform.sdk.model.data.ApiEnvironment
-                .STAGING.get(),
-            ApiEnvironment.PROD => symbols->kotlin.root.com.doordeck.multiplatform.sdk.model.data.ApiEnvironment.PROD
-                .get(),
-            _ => throw new ArgumentOutOfRangeException(nameof(apiEnvironment), apiEnvironment, null)
-        };
-        contextManager.setApiEnvironment(context, newApiEnvironment);
-    }
-
     public ApiEnvironment GetApiEnvironment()
     {
-        var apiEnvironment = contextManager.getApiEnvironment_(context);
         sbyte* result = null;
         try
         {
-            result = symbols->kotlin.root.com.doordeck.multiplatform.sdk.util.getApiEnvironmentName_(apiEnvironment);
+            result = contextManager.getApiEnvironment(context);
             return Enum.Parse<ApiEnvironment>(Utils.Utils.ConvertSByteToString(result));
         }
         finally

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
@@ -137,9 +137,9 @@ public unsafe class ContextManager(
         }
     }
 
-    public void SetUserId(string userId)
+    public void SetUserId(Guid userId)
     {
-        var data = userId.StringToSByte();
+        var data = userId.ToString().StringToSByte();
         try
         {
             contextManager.setUserId_(context, data);
@@ -150,13 +150,13 @@ public unsafe class ContextManager(
         }
     }
 
-    public string GetUserId()
+    public Guid GetUserId()
     {
         sbyte* result = null;
         try
         {
             result = contextManager.getUserId_(context);
-            return Utils.SByteToString(result);
+            return Guid.Parse(Utils.SByteToString(result));
         }
         finally
         {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
 using Doordeck.Headless.Sdk.Model;
 using Doordeck.Headless.Sdk.Utilities;
 
@@ -216,9 +217,9 @@ public unsafe class ContextManager(
         return contextManager.isKeyPairValid_(context).ByteToBoolean();
     }
 
-    public void SetOperationContext(string userId, string certificateChain, string publicKey, string privateKey, bool isKeyPairVerified)
+    public void SetOperationContext(Guid userId, List<X509Certificate> certificateChain, string publicKey, string privateKey, bool isKeyPairVerified)
     {
-        var sData = new { userId, certificateChain, publicKey, privateKey, isKeyPairVerified }.ToJsonSByte();
+        var sData = new { userId, certificateChain = certificateChain.CertificateChainToString(), publicKey, privateKey, isKeyPairVerified }.ToJsonSByte();
         try
         {
             contextManager.setOperationContext_(context, sData);

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
@@ -217,7 +217,7 @@ public unsafe class ContextManager(
         return contextManager.isKeyPairValid_(context).ByteToBoolean();
     }
 
-    public void SetOperationContext(Guid userId, List<X509Certificate> certificateChain, string publicKey, string privateKey, bool isKeyPairVerified)
+    public void SetOperationContext(Guid userId, List<X509Certificate> certificateChain, byte[] publicKey, byte[] privateKey, bool isKeyPairVerified)
     {
         var sData = new { userId, certificateChain = certificateChain.CertificateChainToString(), publicKey, privateKey, isKeyPairVerified }.ToJsonSByte();
         try

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
@@ -15,7 +15,7 @@ public unsafe class ContextManager(
         sbyte* result = null;
         try
         {
-            result = contextManager.getApiEnvironment(context);
+            result = contextManager.getApiEnvironment_(context);
             return Enum.Parse<ApiEnvironment>(Utils.Utils.ConvertSByteToString(result));
         }
         finally
@@ -219,7 +219,7 @@ public unsafe class ContextManager(
         var sData = new { userId, userCertificateChain, userPublicKey, userPrivateKey, isKeyPairVerified }.ToData();
         try
         {
-            contextManager.setOperationContextJson_(context, sData);
+            contextManager.setOperationContext_(context, sData);
         }
         finally
         {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ContextManager.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using Doordeck.Headless.Sdk.Model;
-using Doordeck.Headless.Sdk.Utils;
+using Doordeck.Headless.Sdk.Utilities;
 
 namespace Doordeck.Headless.Sdk.Wrapper;
 
@@ -16,7 +16,7 @@ public unsafe class ContextManager(
         try
         {
             result = contextManager.getApiEnvironment_(context);
-            return Enum.Parse<ApiEnvironment>(Utils.Utils.ConvertSByteToString(result));
+            return Enum.Parse<ApiEnvironment>(Utils.SByteToString(result));
         }
         finally
         {
@@ -26,7 +26,7 @@ public unsafe class ContextManager(
 
     public void SetCloudAuthToken(string token)
     {
-        var data = token.ToSByte();
+        var data = token.StringToSByte();
         try
         {
             contextManager.setCloudAuthToken_(context, data);
@@ -43,7 +43,7 @@ public unsafe class ContextManager(
         try
         {
             result = contextManager.getCloudAuthToken_(context);
-            return Utils.Utils.ConvertSByteToString(result);
+            return Utils.SByteToString(result);
         }
         finally
         {
@@ -56,7 +56,7 @@ public unsafe class ContextManager(
 
     public void SetCloudRefreshToken(string token)
     {
-        var data = token.ToSByte();
+        var data = token.StringToSByte();
         try
         {
             contextManager.setCloudRefreshToken_(context, data);
@@ -73,7 +73,7 @@ public unsafe class ContextManager(
         try
         {
             result = contextManager.getCloudRefreshToken_(context);
-            return Utils.Utils.ConvertSByteToString(result);
+            return Utils.SByteToString(result);
         }
         finally
         {
@@ -83,7 +83,7 @@ public unsafe class ContextManager(
 
     public void SetFusionHost(string host)
     {
-        var data = host.ToSByte();
+        var data = host.StringToSByte();
         try
         {
             contextManager.setFusionHost_(context, data);
@@ -100,7 +100,7 @@ public unsafe class ContextManager(
         try
         {
             result = contextManager.getFusionHost_(context);
-            return Utils.Utils.ConvertSByteToString(result);
+            return Utils.SByteToString(result);
         }
         finally
         {
@@ -110,7 +110,7 @@ public unsafe class ContextManager(
 
     public void SetFusionAuthToken(string token)
     {
-        var data = token.ToSByte();
+        var data = token.StringToSByte();
         try
         {
             contextManager.setFusionAuthToken_(context, data);
@@ -127,7 +127,7 @@ public unsafe class ContextManager(
         try
         {
             result = contextManager.getFusionAuthToken_(context);
-            return Utils.Utils.ConvertSByteToString(result);
+            return Utils.SByteToString(result);
         }
         finally
         {
@@ -137,7 +137,7 @@ public unsafe class ContextManager(
 
     public void SetUserId(string userId)
     {
-        var data = userId.ToSByte();
+        var data = userId.StringToSByte();
         try
         {
             contextManager.setUserId_(context, data);
@@ -154,7 +154,7 @@ public unsafe class ContextManager(
         try
         {
             result = contextManager.getUserId_(context);
-            return Utils.Utils.ConvertSByteToString(result);
+            return Utils.SByteToString(result);
         }
         finally
         {
@@ -164,7 +164,7 @@ public unsafe class ContextManager(
 
     public void SetUserEmail(string email)
     {
-        var data = email.ToSByte();
+        var data = email.StringToSByte();
         try
         {
             contextManager.setUserEmail_(context, data);
@@ -181,7 +181,7 @@ public unsafe class ContextManager(
         try
         {
             result = contextManager.getUserEmail_(context);
-            return Utils.Utils.ConvertSByteToString(result);
+            return Utils.SByteToString(result);
         }
         finally
         {
@@ -195,7 +195,7 @@ public unsafe class ContextManager(
 
     public bool IsCertificateChainInvalidOrExpired()
     {
-        return contextManager.isCertificateChainInvalidOrExpired_(context).ToBoolean();
+        return contextManager.isCertificateChainInvalidOrExpired_(context).ByteToBoolean();
     }
 
     // SetKeyPair
@@ -206,17 +206,17 @@ public unsafe class ContextManager(
 
     public bool IsKeyPairVerified()
     {
-        return contextManager.isKeyPairVerified_(context).ToBoolean();
+        return contextManager.isKeyPairVerified_(context).ByteToBoolean();
     }
 
     public bool IsKeyPairValid()
     {
-        return contextManager.isKeyPairValid_(context).ToBoolean();
+        return contextManager.isKeyPairValid_(context).ByteToBoolean();
     }
 
-    public void SetOperationContext(string userId, string userCertificateChain, string userPublicKey, string userPrivateKey, bool isKeyPairVerified)
+    public void SetOperationContext(string userId, string certificateChain, string publicKey, string privateKey, bool isKeyPairVerified)
     {
-        var sData = new { userId, userCertificateChain, userPublicKey, userPrivateKey, isKeyPairVerified }.ToData();
+        var sData = new { userId, certificateChain, publicKey, privateKey, isKeyPairVerified }.ToJsonSByte();
         try
         {
             contextManager.setOperationContext_(context, sData);

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/CryptoManager.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/CryptoManager.cs
@@ -9,13 +9,13 @@ public unsafe class CryptoManager(
         _multiplatform_e__Struct._sdk_e__Struct._crypto_e__Struct._CryptoManager_e__Struct cryptoManager,
     Doordeck_Headless_Sdk_ExportedSymbols* symbols)
 {
-    public EncodedKeyPair GenerateEncodedKeyPair()
+    public KeyPair GenerateKeyPair()
     {
         sbyte* result = null;
         try
         {
             result = cryptoManager.generateEncodedKeyPair_(crypto);
-            return Utils.FromJsonSByte<EncodedKeyPair>(result);
+            return Utils.FromJsonSByte<KeyPair>(result);
         }
         finally
         {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/CryptoManager.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/CryptoManager.cs
@@ -1,6 +1,5 @@
-﻿using System.Runtime.InteropServices;
-using Doordeck.Headless.Sdk.Model;
-using Doordeck.Headless.Sdk.Utils;
+﻿using Doordeck.Headless.Sdk.Model;
+using Doordeck.Headless.Sdk.Utilities;
 
 namespace Doordeck.Headless.Sdk.Wrapper;
 
@@ -16,7 +15,7 @@ public unsafe class CryptoManager(
         try
         {
             result = cryptoManager.generateEncodedKeyPair_(crypto);
-            return Utils.Utils.FromData<EncodedKeyPair>(result);
+            return Utils.FromJsonSByte<EncodedKeyPair>(result);
         }
         finally
         {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Fusion.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Fusion.cs
@@ -3,44 +3,34 @@ using Doordeck.Headless.Sdk.Model.Responses;
 
 namespace Doordeck.Headless.Sdk.Wrapper;
 
+using FusionApi = Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_FusionApi;
+
 public class Fusion(
     Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_FusionApi fusion,
     Doordeck_Headless_Sdk_ExportedSymbols._kotlin_e__Struct._root_e__Struct._com_e__Struct._doordeck_e__Struct.
         _multiplatform_e__Struct._sdk_e__Struct._api_e__Struct._FusionApi_e__Struct fusionApi) : AbstractWrapper
 {
     public unsafe Task<FusionLoginResponse> Login(string email, string password) =>
-        Process<FusionLoginResponse>(fusionApi.login, null, new { email, password });
+        Process<FusionApi, FusionLoginResponse>(fusion, fusionApi.login, new { email, password });
 
     public unsafe Task<IntegrationTypeResponse> GetIntegrationType() =>
-        Process<IntegrationTypeResponse>(null, fusionApi.getIntegrationType_, null);
+        Process<FusionApi, IntegrationTypeResponse>(fusion, fusionApi.getIntegrationType_);
 
     public unsafe Task<List<IntegrationConfigurationResponse>> GetIntegrationConfiguration(string type) =>
-        Process<List<IntegrationConfigurationResponse>>(fusionApi.getIntegrationConfiguration_, null, new { type });
+        Process<FusionApi, List<IntegrationConfigurationResponse>>(fusion, fusionApi.getIntegrationConfiguration_, new { type });
 
     public unsafe Task<object> EnableDoor(string name, string siteId, LockController controller) =>
-        Process<object>(fusionApi.enableDoor_, null, new { name, siteId, controller });
+        Process<FusionApi, object>(fusion, fusionApi.enableDoor_, new { name, siteId, controller });
 
     public unsafe Task<object> DeleteDoor(string deviceId) =>
-        Process<object>(fusionApi.deleteDoor_, null, new { deviceId });
+        Process<FusionApi, object>(fusion, fusionApi.deleteDoor_, new { deviceId });
 
     public unsafe Task<DoorStateResponse> GetDoorStatus(string deviceId) =>
-        Process<DoorStateResponse>(fusionApi.getDoorStatus_, null, new { deviceId });
+        Process<FusionApi, DoorStateResponse>(fusion, fusionApi.getDoorStatus_, new { deviceId });
 
     public unsafe Task<object> StartDoor(string deviceId) =>
-        Process<object>(fusionApi.startDoor_, null, new { deviceId });
+        Process<FusionApi, object>(fusion, fusionApi.startDoor_, new { deviceId });
 
     public unsafe Task<object> StopDoor(string deviceId) =>
-        Process<object>(fusionApi.stopDoor_, null, new { deviceId });
-
-    private unsafe Task<TResponse> Process<TResponse>(
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_FusionApi,
-            sbyte*, void*, void> processWithData,
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_FusionApi,
-            void*, void> processWithoutData,
-        object? data) => 
-        ProcessCommon<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_FusionApi, TResponse>(
-            fusion,
-            data,
-            processWithData,
-            processWithoutData);
+        Process<FusionApi, object>(fusion, fusionApi.stopDoor_, new { deviceId });
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Fusion.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Fusion.cs
@@ -19,18 +19,18 @@ public class Fusion(
     public unsafe Task<List<IntegrationConfigurationResponse>> GetIntegrationConfiguration(string type) =>
         Process<FusionApi, List<IntegrationConfigurationResponse>>(fusion, fusionApi.getIntegrationConfiguration_, new { type });
 
-    public unsafe Task<object> EnableDoor(string name, string siteId, LockController controller) =>
+    public unsafe Task<object> EnableDoor(string name, Guid siteId, LockController controller) =>
         Process<FusionApi, object>(fusion, fusionApi.enableDoor_, new { name, siteId, controller });
 
-    public unsafe Task<object> DeleteDoor(string deviceId) =>
+    public unsafe Task<object> DeleteDoor(Guid deviceId) =>
         Process<FusionApi, object>(fusion, fusionApi.deleteDoor_, new { deviceId });
 
-    public unsafe Task<DoorStateResponse> GetDoorStatus(string deviceId) =>
+    public unsafe Task<DoorStateResponse> GetDoorStatus(Guid deviceId) =>
         Process<FusionApi, DoorStateResponse>(fusion, fusionApi.getDoorStatus_, new { deviceId });
 
-    public unsafe Task<object> StartDoor(string deviceId) =>
+    public unsafe Task<object> StartDoor(Guid deviceId) =>
         Process<FusionApi, object>(fusion, fusionApi.startDoor_, new { deviceId });
 
-    public unsafe Task<object> StopDoor(string deviceId) =>
+    public unsafe Task<object> StopDoor(Guid deviceId) =>
         Process<FusionApi, object>(fusion, fusionApi.stopDoor_, new { deviceId });
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Helper.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Helper.cs
@@ -15,7 +15,7 @@ public class Helper(
     public unsafe Task<AssistedLoginResponse> AssistedLogin(string email, string password) =>
         Process<HelperApi, AssistedLoginResponse>(helper, helperApi.assistedLogin_, new { email, password });
 
-    public unsafe Task<AssistedRegisterEphemeralKeyResponse> AssistedRegisterEphemeralKey(string? publicKey = null, string? privateKey = null) =>
+    public unsafe Task<AssistedRegisterEphemeralKeyResponse> AssistedRegisterEphemeralKey(byte[]? publicKey = null, byte[]? privateKey = null) =>
         Process<HelperApi, AssistedRegisterEphemeralKeyResponse>(helper, helperApi.assistedRegisterEphemeralKey_, new { publicKey, privateKey });
 
     public unsafe Task<object> AssistedRegister(string email, string password, string? displayName = null, bool force = false) =>

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Helper.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Helper.cs
@@ -2,32 +2,22 @@
 
 namespace Doordeck.Headless.Sdk.Wrapper;
 
+using HelperApi = Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_HelperApi;
+
 public class Helper(
     Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_HelperApi helper,
     Doordeck_Headless_Sdk_ExportedSymbols._kotlin_e__Struct._root_e__Struct._com_e__Struct._doordeck_e__Struct.
         _multiplatform_e__Struct._sdk_e__Struct._api_e__Struct._HelperApi_e__Struct helperApi) : AbstractWrapper
 {
     public unsafe Task<object> UploadPlatformLogo(string applicationId, string contentType, string image) =>
-        Process<object>(helperApi.uploadPlatformLogo_, null, new { applicationId, contentType, image });
+        Process<HelperApi, object>(helper, helperApi.uploadPlatformLogo_, new { applicationId, contentType, image });
 
     public unsafe Task<AssistedLoginResponse> AssistedLogin(string email, string password) =>
-        Process<AssistedLoginResponse>(helperApi.assistedLogin_, null, new { email, password });
+        Process<HelperApi, AssistedLoginResponse>(helper, helperApi.assistedLogin_, new { email, password });
 
     public unsafe Task<AssistedRegisterEphemeralKeyResponse> AssistedRegisterEphemeralKey(string? publicKey = null, string? privateKey = null) =>
-        Process<AssistedRegisterEphemeralKeyResponse>(helperApi.assistedRegisterEphemeralKey_, null, new { publicKey, privateKey });
+        Process<HelperApi, AssistedRegisterEphemeralKeyResponse>(helper, helperApi.assistedRegisterEphemeralKey_, new { publicKey, privateKey });
 
     public unsafe Task<object> AssistedRegister(string email, string password, string? displayName = null, bool force = false) =>
-        Process<object>(helperApi.assistedRegister_, null, new { email, password, displayName, force });
-
-    private unsafe Task<TResponse> Process<TResponse>(
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_HelperApi,
-            sbyte*, void*, void> processWithData,
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_HelperApi,
-            void*, void> processWithoutData,
-        object? data) => 
-        ProcessCommon<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_HelperApi, TResponse>(
-            helper,
-            data,
-            processWithData,
-            processWithoutData);
+        Process<HelperApi, object>(helper, helperApi.assistedRegister_, new { email, password, displayName, force });
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Helper.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Helper.cs
@@ -9,7 +9,7 @@ public class Helper(
     Doordeck_Headless_Sdk_ExportedSymbols._kotlin_e__Struct._root_e__Struct._com_e__Struct._doordeck_e__Struct.
         _multiplatform_e__Struct._sdk_e__Struct._api_e__Struct._HelperApi_e__Struct helperApi) : AbstractWrapper
 {
-    public unsafe Task<object> UploadPlatformLogo(string applicationId, string contentType, string image) =>
+    public unsafe Task<object> UploadPlatformLogo(Guid applicationId, string contentType, string image) =>
         Process<HelperApi, object>(helper, helperApi.uploadPlatformLogo_, new { applicationId, contentType, image });
 
     public unsafe Task<AssistedLoginResponse> AssistedLogin(string email, string password) =>

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ISecureStorage.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/ISecureStorage.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography.X509Certificates;
 using Doordeck.Headless.Sdk.Model;
 
 namespace Doordeck.Headless.Sdk.Wrapper;
@@ -36,17 +37,17 @@ public interface ISecureStorage
 
     public byte[]? GetKeyPairVerified();
 
-    public void AddUserId(string userId);
+    public void AddUserId(Guid userId);
 
-    public string? GetUserId();
+    public Guid? GetUserId();
 
     public void AddUserEmail(string email);
 
     public string? GetUserEmail();
 
-    public void AddCertificateChain(List<string> certificateChain);
+    public void AddCertificateChain(List<X509Certificate> certificateChain);
 
-    public List<string>? GetCertificateChain();
+    public List<X509Certificate>? GetCertificateChain();
 
     public void Clear();
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/LockOperations.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/LockOperations.cs
@@ -1,4 +1,5 @@
-﻿using Doordeck.Headless.Sdk.Model;
+﻿using System.Net;
+using Doordeck.Headless.Sdk.Model;
 using Doordeck.Headless.Sdk.Model.Responses;
 
 namespace Doordeck.Headless.Sdk.Wrapper;
@@ -10,40 +11,40 @@ public class LockOperations(
     Doordeck_Headless_Sdk_ExportedSymbols._kotlin_e__Struct._root_e__Struct._com_e__Struct._doordeck_e__Struct.
         _multiplatform_e__Struct._sdk_e__Struct._api_e__Struct._LockOperationsApi_e__Struct lockOperationsApi) : AbstractWrapper
 {
-    public unsafe Task<LockResponse> GetSingleLock(string lockId) =>
+    public unsafe Task<LockResponse> GetSingleLock(Guid lockId) =>
         Process<LockOperationsApi, LockResponse>(lockOperations, lockOperationsApi.getSingleLock_, new { lockId });
 
-    public unsafe Task<List<AuditResponse>> GetLockAuditTrail(string lockId, long? start = null, long? end = null) =>
+    public unsafe Task<List<AuditResponse>> GetLockAuditTrail(Guid lockId, DateTime? start = null, DateTime? end = null) =>
         Process<LockOperationsApi, List<AuditResponse>>(lockOperations, lockOperationsApi.getLockAuditTrail_, new { lockId, start, end });
 
-    public unsafe Task<List<AuditResponse>> GetAuditForUser(string userId, long? start = null, long? end = null) =>
+    public unsafe Task<List<AuditResponse>> GetAuditForUser(Guid userId, DateTime? start = null, DateTime? end = null) =>
         Process<LockOperationsApi, List<AuditResponse>>(lockOperations, lockOperationsApi.getAuditForUser_, new { userId, start, end });
 
-    public unsafe Task<List<UserLockResponse>> GetUsersForLock(string lockId) =>
+    public unsafe Task<List<UserLockResponse>> GetUsersForLock(Guid lockId) =>
         Process<LockOperationsApi, List<UserLockResponse>>(lockOperations, lockOperationsApi.getUsersForLock_, new { lockId });
 
-    public unsafe Task<LockUserResponse> GetLocksForUser(string userId) =>
+    public unsafe Task<LockUserResponse> GetLocksForUser(Guid userId) =>
         Process<LockOperationsApi, LockUserResponse>(lockOperations, lockOperationsApi.getLocksForUser_, new { userId });
 
-    public unsafe Task<object> UpdateLockName(string lockId, string? name = null) =>
+    public unsafe Task<object> UpdateLockName(Guid lockId, string? name = null) =>
         Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.updateLockName_, new { lockId, name });
 
-    public unsafe Task<object> UpdateLockFavourite(string lockId, bool favourite) =>
+    public unsafe Task<object> UpdateLockFavourite(Guid lockId, bool favourite) =>
         Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.updateLockFavourite_, new { lockId, favourite });
 
-    public unsafe Task<object> UpdateLockSettingDefaultName(string lockId, string name) =>
+    public unsafe Task<object> UpdateLockSettingDefaultName(Guid lockId, string name) =>
         Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.updateLockSettingDefaultName_, new { lockId, name });
 
-    public unsafe Task<object> SetLockSettingPermittedAddresses(string lockId, List<string> permittedAddresses) =>
+    public unsafe Task<object> SetLockSettingPermittedAddresses(Guid lockId, List<IPAddress> permittedAddresses) =>
         Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.setLockSettingPermittedAddresses_, new { lockId,  permittedAddresses });
 
-    public unsafe Task<object> UpdateLockSettingHidden(string lockId, bool hidden) =>
+    public unsafe Task<object> UpdateLockSettingHidden(Guid lockId, bool hidden) =>
         Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.updateLockSettingHidden_, new { lockId, hidden });
 
-    public unsafe Task<object> SetLockSettingTimeRestrictions(string lockId, List<TimeRequirement> times) =>
+    public unsafe Task<object> SetLockSettingTimeRestrictions(Guid lockId, List<TimeRequirement> times) =>
         Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.setLockSettingTimeRestrictions_, new { lockId, times });
 
-    public unsafe Task<object> UpdateLockSettingLocationRestrictions(string lockId, LocationRequirement? location = null) =>
+    public unsafe Task<object> UpdateLockSettingLocationRestrictions(Guid lockId, LocationRequirement? location = null) =>
         Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.updateLockSettingLocationRestrictions_, new { lockId, location });
 
     public unsafe Task<UserPublicKeyResponse> GetUserPublicKey(string userEmail, bool visitor = false) =>

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/LockOperations.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/LockOperations.cs
@@ -3,110 +3,100 @@ using Doordeck.Headless.Sdk.Model.Responses;
 
 namespace Doordeck.Headless.Sdk.Wrapper;
 
+using LockOperationsApi = Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_LockOperationsApi;
+
 public class LockOperations(
     Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_LockOperationsApi lockOperations,
     Doordeck_Headless_Sdk_ExportedSymbols._kotlin_e__Struct._root_e__Struct._com_e__Struct._doordeck_e__Struct.
         _multiplatform_e__Struct._sdk_e__Struct._api_e__Struct._LockOperationsApi_e__Struct lockOperationsApi) : AbstractWrapper
 {
     public unsafe Task<LockResponse> GetSingleLock(string lockId) =>
-        Process<LockResponse>(lockOperationsApi.getSingleLock_, null, new { lockId });
+        Process<LockOperationsApi, LockResponse>(lockOperations, lockOperationsApi.getSingleLock_, new { lockId });
 
     public unsafe Task<List<AuditResponse>> GetLockAuditTrail(string lockId, long? start = null, long? end = null) =>
-        Process<List<AuditResponse>>(lockOperationsApi.getLockAuditTrail_, null, new { lockId, start, end });
+        Process<LockOperationsApi, List<AuditResponse>>(lockOperations, lockOperationsApi.getLockAuditTrail_, new { lockId, start, end });
 
     public unsafe Task<List<AuditResponse>> GetAuditForUser(string userId, long? start = null, long? end = null) =>
-        Process<List<AuditResponse>>(lockOperationsApi.getAuditForUser_, null, new { userId, start, end });
+        Process<LockOperationsApi, List<AuditResponse>>(lockOperations, lockOperationsApi.getAuditForUser_, new { userId, start, end });
 
     public unsafe Task<List<UserLockResponse>> GetUsersForLock(string lockId) =>
-        Process<List<UserLockResponse>>(lockOperationsApi.getUsersForLock_, null, new { lockId });
+        Process<LockOperationsApi, List<UserLockResponse>>(lockOperations, lockOperationsApi.getUsersForLock_, new { lockId });
 
     public unsafe Task<LockUserResponse> GetLocksForUser(string userId) =>
-        Process<LockUserResponse>(lockOperationsApi.getLocksForUser_, null, new { userId });
+        Process<LockOperationsApi, LockUserResponse>(lockOperations, lockOperationsApi.getLocksForUser_, new { userId });
 
     public unsafe Task<object> UpdateLockName(string lockId, string? name = null) =>
-        Process<object>(lockOperationsApi.updateLockName_, null, new { lockId, name });
+        Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.updateLockName_, new { lockId, name });
 
     public unsafe Task<object> UpdateLockFavourite(string lockId, bool favourite) =>
-        Process<object>(lockOperationsApi.updateLockFavourite_, null, new { lockId, favourite });
+        Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.updateLockFavourite_, new { lockId, favourite });
 
     public unsafe Task<object> UpdateLockSettingDefaultName(string lockId, string name) =>
-        Process<object>(lockOperationsApi.updateLockSettingDefaultName_, null, new { lockId, name });
+        Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.updateLockSettingDefaultName_, new { lockId, name });
 
     public unsafe Task<object> SetLockSettingPermittedAddresses(string lockId, List<string> permittedAddresses) =>
-        Process<object>(lockOperationsApi.setLockSettingPermittedAddresses_, null, new { lockId,  permittedAddresses });
+        Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.setLockSettingPermittedAddresses_, new { lockId,  permittedAddresses });
 
     public unsafe Task<object> UpdateLockSettingHidden(string lockId, bool hidden) =>
-        Process<object>(lockOperationsApi.updateLockSettingHidden_, null, new { lockId, hidden });
+        Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.updateLockSettingHidden_, new { lockId, hidden });
 
     public unsafe Task<object> SetLockSettingTimeRestrictions(string lockId, List<TimeRequirement> times) =>
-        Process<object>(lockOperationsApi.setLockSettingTimeRestrictions_, null, new { lockId, times });
+        Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.setLockSettingTimeRestrictions_, new { lockId, times });
 
     public unsafe Task<object> UpdateLockSettingLocationRestrictions(string lockId, LocationRequirement? location = null) =>
-        Process<object>(lockOperationsApi.updateLockSettingLocationRestrictions_, null, new { lockId, location });
+        Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.updateLockSettingLocationRestrictions_, new { lockId, location });
 
     public unsafe Task<UserPublicKeyResponse> GetUserPublicKey(string userEmail, bool visitor = false) =>
-        Process<UserPublicKeyResponse>(lockOperationsApi.getUserPublicKey_, null, new { userEmail, visitor });
+        Process<LockOperationsApi, UserPublicKeyResponse>(lockOperations, lockOperationsApi.getUserPublicKey_, new { userEmail, visitor });
 
     public unsafe Task<UserPublicKeyResponse> GetUserPublicKeyByEmail(string email) =>
-        Process<UserPublicKeyResponse>(lockOperationsApi.getUserPublicKeyByEmail_, null, new { email });
+        Process<LockOperationsApi, UserPublicKeyResponse>(lockOperations, lockOperationsApi.getUserPublicKeyByEmail_, new { email });
 
     public unsafe Task<UserPublicKeyResponse> GetUserPublicKeyByTelephone(string telephone) =>
-        Process<UserPublicKeyResponse>(lockOperationsApi.getUserPublicKeyByTelephone_, null, new { telephone });
+        Process<LockOperationsApi, UserPublicKeyResponse>(lockOperations, lockOperationsApi.getUserPublicKeyByTelephone_, new { telephone });
 
     public unsafe Task<UserPublicKeyResponse> GetUserPublicKeyByLocalKey(string localKey) =>
-        Process<UserPublicKeyResponse>(lockOperationsApi.getUserPublicKeyByLocalKey_, null, new { localKey });
+        Process<LockOperationsApi, UserPublicKeyResponse>(lockOperations, lockOperationsApi.getUserPublicKeyByLocalKey_, new { localKey });
 
     public unsafe Task<UserPublicKeyResponse> GetUserPublicKeyByForeignKey(string foreignKey) =>
-        Process<UserPublicKeyResponse>(lockOperationsApi.getUserPublicKeyByForeignKey_, null, new { foreignKey });
+        Process<LockOperationsApi, UserPublicKeyResponse>(lockOperations, lockOperationsApi.getUserPublicKeyByForeignKey_, new { foreignKey });
 
     public unsafe Task<UserPublicKeyResponse> GetUserPublicKeyByIdentity(string identity) =>
-        Process<UserPublicKeyResponse>(lockOperationsApi.getUserPublicKeyByIdentity_, null, new { identity });
+        Process<LockOperationsApi, UserPublicKeyResponse>(lockOperations, lockOperationsApi.getUserPublicKeyByIdentity_, new { identity });
 
     public unsafe Task<List<BatchUserPublicKeyResponse>> GetUserPublicKeyByEmails(List<string> emails) =>
-        Process<List<BatchUserPublicKeyResponse>>(lockOperationsApi.getUserPublicKeyByEmails_, null, new { emails });
+        Process<LockOperationsApi, List<BatchUserPublicKeyResponse>>(lockOperations, lockOperationsApi.getUserPublicKeyByEmails_, new { emails });
 
     public unsafe Task<List<BatchUserPublicKeyResponse>> GetUserPublicKeyByTelephones(List<string> telephones) =>
-        Process<List<BatchUserPublicKeyResponse>>(lockOperationsApi.getUserPublicKeyByTelephones_, null, new { telephones });
+        Process<LockOperationsApi, List<BatchUserPublicKeyResponse>>(lockOperations, lockOperationsApi.getUserPublicKeyByTelephones_, new { telephones });
 
     public unsafe Task<List<BatchUserPublicKeyResponse>> GetUserPublicKeyByLocalKeys(List<string> localKeys) =>
-        Process<List<BatchUserPublicKeyResponse>>(lockOperationsApi.getUserPublicKeyByLocalKeys_, null, new { localKeys });
+        Process<LockOperationsApi, List<BatchUserPublicKeyResponse>>(lockOperations, lockOperationsApi.getUserPublicKeyByLocalKeys_, new { localKeys });
 
     public unsafe Task<List<BatchUserPublicKeyResponse>> GetUserPublicKeyByForeignKeys(List<string> foreignKeys) =>
-        Process<List<BatchUserPublicKeyResponse>>(lockOperationsApi.getUserPublicKeyByForeignKeys_, null, new { foreignKeys });
+        Process<LockOperationsApi, List<BatchUserPublicKeyResponse>>(lockOperations, lockOperationsApi.getUserPublicKeyByForeignKeys_, new { foreignKeys });
     
     public unsafe Task<object> Unlock(UnlockOperation data) =>
-        Process<object>(lockOperationsApi.unlock_, null, data);
+        Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.unlock_, data);
 
     public unsafe Task<object> ShareLock(ShareLockOperation data) =>
-        Process<object>(lockOperationsApi.shareLock_, null, data);
+        Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.shareLock_, data);
 
     public unsafe Task<object> BatchShareLock(BatchShareLockOperation data) =>
-        Process<object>(lockOperationsApi.batchShareLock_, null, data);
+        Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.batchShareLock_, data);
 
     public unsafe Task<object> RevokeAccessToLock(RevokeAccessToLockOperation data) =>
-        Process<object>(lockOperationsApi.revokeAccessToLock_, null, data);
+        Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.revokeAccessToLock_, data);
 
     public unsafe Task<object> UpdateSecureSettingUnlockDuration(UpdateSecureSettingUnlockDuration data) =>
-        Process<object>(lockOperationsApi.updateSecureSettingUnlockDuration_, null, data);
+        Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.updateSecureSettingUnlockDuration_, data);
 
     public unsafe Task<object> UpdateSecureSettingUnlockBetween(UpdateSecureSettingUnlockBetween data) =>
-        Process<object>(lockOperationsApi.updateSecureSettingUnlockBetween_, null, data);
+        Process<LockOperationsApi, object>(lockOperations, lockOperationsApi.updateSecureSettingUnlockBetween_, data);
 
     public unsafe Task<List<LockResponse>> GetPinnedLocks() =>
-        Process<List<LockResponse>>(null, lockOperationsApi.getPinnedLocks_, null);
+        Process<LockOperationsApi, List<LockResponse>>(lockOperations, lockOperationsApi.getPinnedLocks_);
 
     public unsafe Task<List<ShareableLockResponse>> GetShareableLocks() =>
-        Process<List<ShareableLockResponse>>(null, lockOperationsApi.getShareableLocks_, null);
-
-    private unsafe Task<TResponse> Process<TResponse>(
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_LockOperationsApi,
-            sbyte*, void*, void> processWithData,
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_LockOperationsApi,
-            void*, void> processWithoutData,
-        object? data) =>
-        ProcessCommon<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_LockOperationsApi, TResponse>(
-            lockOperations,
-            data,
-            processWithData,
-            processWithoutData);
+        Process<LockOperationsApi, List<ShareableLockResponse>>(lockOperations, lockOperationsApi.getShareableLocks_);
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Platform.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Platform.cs
@@ -16,60 +16,60 @@ public class Platform(
     public unsafe Task<List<ApplicationResponse>> ListApplications() =>
         Process<PlatformApi, List<ApplicationResponse>>(platform, platformApi.listApplications_);
 
-    public unsafe Task<ApplicationResponse> GetApplication(string applicationId) =>
+    public unsafe Task<ApplicationResponse> GetApplication(Guid applicationId) =>
         Process<PlatformApi, ApplicationResponse>(platform, platformApi.getApplication_, new { applicationId });
 
-    public unsafe Task<object> UpdateApplicationName(string applicationId, string name) =>
+    public unsafe Task<object> UpdateApplicationName(Guid applicationId, string name) =>
         Process<PlatformApi, object>(platform, platformApi.updateApplicationName_, new { applicationId, name });
-    
-    public unsafe Task<object> UpdateApplicationCompanyName(string applicationId, string companyName) =>
+
+    public unsafe Task<object> UpdateApplicationCompanyName(Guid applicationId, string companyName) =>
         Process<PlatformApi, object>(platform, platformApi.updateApplicationCompanyName_, new { applicationId, companyName });
 
-    public unsafe Task<object> UpdateApplicationMailingAddress(string applicationId, string mailingAddress) =>
+    public unsafe Task<object> UpdateApplicationMailingAddress(Guid applicationId, string mailingAddress) =>
         Process<PlatformApi, object>(platform, platformApi.updateApplicationMailingAddress_, new { applicationId, mailingAddress });
 
-    public unsafe Task<object> UpdateApplicationPrivacyPolicy(string applicationId, string privacyPolicy) =>
+    public unsafe Task<object> UpdateApplicationPrivacyPolicy(Guid applicationId, Uri privacyPolicy) =>
         Process<PlatformApi, object>(platform, platformApi.updateApplicationPrivacyPolicy_, new { applicationId, privacyPolicy });
 
-    public unsafe Task<object> UpdateApplicationSupportContact(string applicationId, string supportContact) =>
+    public unsafe Task<object> UpdateApplicationSupportContact(Guid applicationId, Uri supportContact) =>
         Process<PlatformApi, object>(platform, platformApi.updateApplicationSupportContact_, new { applicationId, supportContact });
 
-    public unsafe Task<object> UpdateApplicationAppLink(string applicationId, string appLink) =>
+    public unsafe Task<object> UpdateApplicationAppLink(Guid applicationId, Uri appLink) =>
         Process<PlatformApi, object>(platform, platformApi.updateApplicationAppLink_, new { applicationId, appLink });
 
-    public unsafe Task<object> UpdateApplicationEmailPreferences(string applicationId, EmailPreferences emailPreferences) =>
+    public unsafe Task<object> UpdateApplicationEmailPreferences(Guid applicationId, EmailPreferences emailPreferences) =>
         Process<PlatformApi, object>(platform, platformApi.updateApplicationEmailPreferences_, new { applicationId, emailPreferences });
 
-    public unsafe Task<object> UpdateApplicationLogoUrl(string applicationId, string logoUrl) =>
+    public unsafe Task<object> UpdateApplicationLogoUrl(Guid applicationId, Uri logoUrl) =>
         Process<PlatformApi, object>(platform, platformApi.updateApplicationLogoUrl_, new { applicationId, logoUrl });
 
-    public unsafe Task<object> DeleteApplication(string applicationId) =>
+    public unsafe Task<object> DeleteApplication(Guid applicationId) =>
         Process<PlatformApi, object>(platform, platformApi.deleteApplication_, new { applicationId });
 
-    public unsafe Task<GetLogoUploadUrlResponse> GetLogoUploadUrl(string applicationId, string contentType) =>
+    public unsafe Task<GetLogoUploadUrlResponse> GetLogoUploadUrl(Guid applicationId, string contentType) =>
         Process<PlatformApi, GetLogoUploadUrlResponse>(platform, platformApi.getLogoUploadUrl_, new { applicationId, contentType });
 
-    public unsafe Task<object> AddAuthKey(string applicationId, IAuthKey key) =>
+    public unsafe Task<object> AddAuthKey(Guid applicationId, IAuthKey key) =>
         Process<PlatformApi, object>(platform, platformApi.addAuthKey_, new { applicationId, key });
 
-    public unsafe Task<object> AddAuthIssuer(string applicationId, string url) =>
+    public unsafe Task<object> AddAuthIssuer(Guid applicationId, Uri url) =>
         Process<PlatformApi, object>(platform, platformApi.addAuthIssuer_, new { applicationId, url });
 
-    public unsafe Task<object> DeleteAuthIssuer(string applicationId, string url) =>
+    public unsafe Task<object> DeleteAuthIssuer(Guid applicationId, Uri url) =>
         Process<PlatformApi, object>(platform, platformApi.deleteAuthIssuer_, new { applicationId, url });
 
-    public unsafe Task<object> AddCorsDomain(string applicationId, string url) =>
+    public unsafe Task<object> AddCorsDomain(Guid applicationId, Uri url) =>
         Process<PlatformApi, object>(platform, platformApi.addCorsDomain_, new { applicationId, url });
 
-    public unsafe Task<object> RemoveCorsDomain(string applicationId, string url) =>
+    public unsafe Task<object> RemoveCorsDomain(Guid applicationId, Uri url) =>
         Process<PlatformApi, object>(platform, platformApi.removeCorsDomain_, new { applicationId, url });
 
-    public unsafe Task<object> AddApplicationOwner(string applicationId, string userId) =>
+    public unsafe Task<object> AddApplicationOwner(Guid applicationId, Guid userId) =>
         Process<PlatformApi, object>(platform, platformApi.addApplicationOwner_, new { applicationId, userId });
 
-    public unsafe Task<object> RemoveApplicationOwner(string applicationId, string userId) =>
+    public unsafe Task<object> RemoveApplicationOwner(Guid applicationId, Guid userId) =>
         Process<PlatformApi, object>(platform, platformApi.removeApplicationOwner_, new { applicationId, userId });
 
-    public unsafe Task<List<ApplicationOwnerDetailsResponse>> GetApplicationOwnersDetails(string applicationId, string userId) =>
+    public unsafe Task<List<ApplicationOwnerDetailsResponse>> GetApplicationOwnersDetails(Guid applicationId, Guid userId) =>
         Process<PlatformApi, List<ApplicationOwnerDetailsResponse>>(platform, platformApi.getApplicationOwnersDetails_, new { applicationId, userId });
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Platform.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Platform.cs
@@ -3,83 +3,73 @@ using Doordeck.Headless.Sdk.Model.Responses;
 
 namespace Doordeck.Headless.Sdk.Wrapper;
 
+using PlatformApi = Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_PlatformApi;
+
 public class Platform(
     Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_PlatformApi platform,
     Doordeck_Headless_Sdk_ExportedSymbols._kotlin_e__Struct._root_e__Struct._com_e__Struct._doordeck_e__Struct.
         _multiplatform_e__Struct._sdk_e__Struct._api_e__Struct._PlatformApi_e__Struct platformApi) : AbstractWrapper
 {
     public unsafe Task<string> CreateApplication(CreateApplication data) =>
-        Process<string>(platformApi.createApplication_, null, data);
+        Process<PlatformApi, string>(platform, platformApi.createApplication_, data);
 
     public unsafe Task<List<ApplicationResponse>> ListApplications() =>
-        Process<List<ApplicationResponse>>(null, platformApi.listApplications_, null);
+        Process<PlatformApi, List<ApplicationResponse>>(platform, platformApi.listApplications_);
 
     public unsafe Task<ApplicationResponse> GetApplication(string applicationId) =>
-        Process<ApplicationResponse>(platformApi.getApplication_, null, new { applicationId });
+        Process<PlatformApi, ApplicationResponse>(platform, platformApi.getApplication_, new { applicationId });
 
     public unsafe Task<object> UpdateApplicationName(string applicationId, string name) =>
-        Process<object>(platformApi.updateApplicationName_, null, new { applicationId, name });
+        Process<PlatformApi, object>(platform, platformApi.updateApplicationName_, new { applicationId, name });
     
     public unsafe Task<object> UpdateApplicationCompanyName(string applicationId, string companyName) =>
-        Process<object>(platformApi.updateApplicationCompanyName_, null, new { applicationId, companyName });
+        Process<PlatformApi, object>(platform, platformApi.updateApplicationCompanyName_, new { applicationId, companyName });
 
     public unsafe Task<object> UpdateApplicationMailingAddress(string applicationId, string mailingAddress) =>
-        Process<object>(platformApi.updateApplicationMailingAddress_, null, new { applicationId, mailingAddress });
+        Process<PlatformApi, object>(platform, platformApi.updateApplicationMailingAddress_, new { applicationId, mailingAddress });
 
     public unsafe Task<object> UpdateApplicationPrivacyPolicy(string applicationId, string privacyPolicy) =>
-        Process<object>(platformApi.updateApplicationPrivacyPolicy_, null, new { applicationId, privacyPolicy });
+        Process<PlatformApi, object>(platform, platformApi.updateApplicationPrivacyPolicy_, new { applicationId, privacyPolicy });
 
     public unsafe Task<object> UpdateApplicationSupportContact(string applicationId, string supportContact) =>
-        Process<object>(platformApi.updateApplicationSupportContact_, null, new { applicationId, supportContact });
+        Process<PlatformApi, object>(platform, platformApi.updateApplicationSupportContact_, new { applicationId, supportContact });
 
     public unsafe Task<object> UpdateApplicationAppLink(string applicationId, string appLink) =>
-        Process<object>(platformApi.updateApplicationAppLink_, null, new { applicationId, appLink });
+        Process<PlatformApi, object>(platform, platformApi.updateApplicationAppLink_, new { applicationId, appLink });
 
     public unsafe Task<object> UpdateApplicationEmailPreferences(string applicationId, EmailPreferences emailPreferences) =>
-        Process<object>(platformApi.updateApplicationEmailPreferences_, null, new { applicationId, emailPreferences });
+        Process<PlatformApi, object>(platform, platformApi.updateApplicationEmailPreferences_, new { applicationId, emailPreferences });
 
     public unsafe Task<object> UpdateApplicationLogoUrl(string applicationId, string logoUrl) =>
-        Process<object>(platformApi.updateApplicationLogoUrl_, null, new { applicationId, logoUrl });
+        Process<PlatformApi, object>(platform, platformApi.updateApplicationLogoUrl_, new { applicationId, logoUrl });
 
     public unsafe Task<object> DeleteApplication(string applicationId) =>
-        Process<object>(platformApi.deleteApplication_, null, new { applicationId });
+        Process<PlatformApi, object>(platform, platformApi.deleteApplication_, new { applicationId });
 
     public unsafe Task<GetLogoUploadUrlResponse> GetLogoUploadUrl(string applicationId, string contentType) =>
-        Process<GetLogoUploadUrlResponse>(platformApi.getLogoUploadUrl_, null, new { applicationId, contentType });
+        Process<PlatformApi, GetLogoUploadUrlResponse>(platform, platformApi.getLogoUploadUrl_, new { applicationId, contentType });
 
     public unsafe Task<object> AddAuthKey(string applicationId, IAuthKey key) =>
-        Process<object>(platformApi.addAuthKey_, null, new { applicationId, key });
+        Process<PlatformApi, object>(platform, platformApi.addAuthKey_, new { applicationId, key });
 
     public unsafe Task<object> AddAuthIssuer(string applicationId, string url) =>
-        Process<object>(platformApi.addAuthIssuer_, null, new { applicationId, url });
+        Process<PlatformApi, object>(platform, platformApi.addAuthIssuer_, new { applicationId, url });
 
     public unsafe Task<object> DeleteAuthIssuer(string applicationId, string url) =>
-        Process<object>(platformApi.deleteAuthIssuer_, null, new { applicationId, url });
+        Process<PlatformApi, object>(platform, platformApi.deleteAuthIssuer_, new { applicationId, url });
 
     public unsafe Task<object> AddCorsDomain(string applicationId, string url) =>
-        Process<object>(platformApi.addCorsDomain_, null, new { applicationId, url });
+        Process<PlatformApi, object>(platform, platformApi.addCorsDomain_, new { applicationId, url });
 
     public unsafe Task<object> RemoveCorsDomain(string applicationId, string url) =>
-        Process<object>(platformApi.removeCorsDomain_, null, new { applicationId, url });
+        Process<PlatformApi, object>(platform, platformApi.removeCorsDomain_, new { applicationId, url });
 
     public unsafe Task<object> AddApplicationOwner(string applicationId, string userId) =>
-        Process<object>(platformApi.addApplicationOwner_, null, new { applicationId, userId });
+        Process<PlatformApi, object>(platform, platformApi.addApplicationOwner_, new { applicationId, userId });
 
     public unsafe Task<object> RemoveApplicationOwner(string applicationId, string userId) =>
-        Process<object>(platformApi.removeApplicationOwner_, null, new { applicationId, userId });
+        Process<PlatformApi, object>(platform, platformApi.removeApplicationOwner_, new { applicationId, userId });
 
     public unsafe Task<List<ApplicationOwnerDetailsResponse>> GetApplicationOwnersDetails(string applicationId, string userId) =>
-        Process<List<ApplicationOwnerDetailsResponse>>(platformApi.getApplicationOwnersDetails_, null, new { applicationId, userId });
-
-    private unsafe Task<TResponse> Process<TResponse>(
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_PlatformApi,
-            sbyte*, void*, void> processWithData,
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_PlatformApi,
-            void*, void> processWithoutData,
-        object? data) => 
-        ProcessCommon<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_PlatformApi, TResponse>(
-            platform,
-            data,
-            processWithData,
-            processWithoutData);
+        Process<PlatformApi, List<ApplicationOwnerDetailsResponse>>(platform, platformApi.getApplicationOwnersDetails_, new { applicationId, userId });
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Platform.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Platform.cs
@@ -10,8 +10,8 @@ public class Platform(
     Doordeck_Headless_Sdk_ExportedSymbols._kotlin_e__Struct._root_e__Struct._com_e__Struct._doordeck_e__Struct.
         _multiplatform_e__Struct._sdk_e__Struct._api_e__Struct._PlatformApi_e__Struct platformApi) : AbstractWrapper
 {
-    public unsafe Task<string> CreateApplication(CreateApplication data) =>
-        Process<PlatformApi, string>(platform, platformApi.createApplication_, data);
+    public unsafe Task<Guid> CreateApplication(CreateApplication data) =>
+        Process<PlatformApi, Guid>(platform, platformApi.createApplication_, data);
 
     public unsafe Task<List<ApplicationResponse>> ListApplications() =>
         Process<PlatformApi, List<ApplicationResponse>>(platform, platformApi.listApplications_);

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/SecureStorage.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/SecureStorage.cs
@@ -170,12 +170,12 @@ internal static class SecureStorage
     {
         if (GetStringFromPtr(c) is {} result)
         {
-            Implementation?.AddUserId(result);
+            Implementation?.AddUserId(new Guid(result));
         }
     }
-    
+
     public static IntPtr GetUserId() =>
-        GetPtrFromString(Implementation?.GetUserId());
+        GetPtrFromString(Implementation?.GetUserId().ToString());
     
     public static void AddUserEmail(IntPtr c)
     {

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/SecureStorage.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/SecureStorage.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 using Doordeck.Headless.Sdk.Model;
-using Doordeck.Headless.Sdk.Utils;
+using Doordeck.Headless.Sdk.Utilities;
 
 namespace Doordeck.Headless.Sdk.Wrapper;
 

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Sites.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Sites.cs
@@ -12,9 +12,9 @@ public class Sites(
     public unsafe Task<List<SiteResponse>> ListSites() =>
         Process<SitesApi, List<SiteResponse>>(sites, sitesApi.listSites_);
 
-    public unsafe Task<List<LockResponse>> GetLocksForSite(string siteId) =>
+    public unsafe Task<List<LockResponse>> GetLocksForSite(Guid siteId) =>
         Process<SitesApi, List<LockResponse>>(sites, sitesApi.getLocksForSite_, new { siteId });
 
-    public unsafe Task<List<UserForSiteResponse>> GetUsersForSite(string siteId) =>
+    public unsafe Task<List<UserForSiteResponse>> GetUsersForSite(Guid siteId) =>
         Process<SitesApi, List<UserForSiteResponse>>(sites, sitesApi.getUsersForSite_, new { siteId });
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Sites.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Sites.cs
@@ -2,29 +2,19 @@
 
 namespace Doordeck.Headless.Sdk.Wrapper;
 
+using SitesApi = Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_SitesApi;
+
 public class Sites(
     Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_SitesApi sites,
     Doordeck_Headless_Sdk_ExportedSymbols._kotlin_e__Struct._root_e__Struct._com_e__Struct._doordeck_e__Struct.
         _multiplatform_e__Struct._sdk_e__Struct._api_e__Struct._SitesApi_e__Struct sitesApi) : AbstractWrapper
 {
     public unsafe Task<List<SiteResponse>> ListSites() =>
-        Process<List<SiteResponse>>(null, sitesApi.listSites_, null);
+        Process<SitesApi, List<SiteResponse>>(sites, sitesApi.listSites_);
 
     public unsafe Task<List<LockResponse>> GetLocksForSite(string siteId) =>
-        Process<List<LockResponse>>(sitesApi.getLocksForSite_, null, new { siteId });
+        Process<SitesApi, List<LockResponse>>(sites, sitesApi.getLocksForSite_, new { siteId });
 
     public unsafe Task<List<UserForSiteResponse>> GetUsersForSite(string siteId) =>
-        Process<List<UserForSiteResponse>>(sitesApi.getUsersForSite_, null, new { siteId });
-
-    private unsafe Task<TResponse> Process<TResponse>(
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_SitesApi,
-            sbyte*, void*, void> processWithData,
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_SitesApi,
-            void*, void> processWithoutData,
-        object? data) =>
-        ProcessCommon<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_SitesApi, TResponse>(
-            sites,
-            data,
-            processWithData,
-            processWithoutData);
+        Process<SitesApi, List<UserForSiteResponse>>(sites, sitesApi.getUsersForSite_, new { siteId });
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Tiles.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Tiles.cs
@@ -2,26 +2,16 @@
 
 namespace Doordeck.Headless.Sdk.Wrapper;
 
+using TilesApi = Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_TilesApi;
+
 public class Tiles(
     Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_TilesApi tiles,
     Doordeck_Headless_Sdk_ExportedSymbols._kotlin_e__Struct._root_e__Struct._com_e__Struct._doordeck_e__Struct.
         _multiplatform_e__Struct._sdk_e__Struct._api_e__Struct._TilesApi_e__Struct tilesApi): AbstractWrapper
 {
     public unsafe Task<TileLocksResponse> GetLocksBelongingToTile(string tileId) =>
-        Process<TileLocksResponse>(tilesApi.getLocksBelongingToTile_, null, new { tileId });
+        Process<TilesApi, TileLocksResponse>(tiles, tilesApi.getLocksBelongingToTile_, new { tileId });
 
     public unsafe Task<object> AssociateMultipleLocks(string tileId, string siteId, List<string> lockIds) =>
-        Process<object>(tilesApi.associateMultipleLocks_, null, new { tileId, siteId, lockIds });
-
-    private unsafe Task<TResponse> Process<TResponse>(
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_TilesApi,
-            sbyte*, void*, void> processWithData,
-        delegate* unmanaged[Cdecl]<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_TilesApi,
-            void*, void> processWithoutData,
-        object? data) =>
-        ProcessCommon<Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_api_TilesApi, TResponse>(
-            tiles,
-            data,
-            processWithData,
-            processWithoutData);
+        Process<TilesApi, object>(tiles, tilesApi.associateMultipleLocks_, new { tileId, siteId, lockIds });
 }

--- a/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Tiles.cs
+++ b/doordeck-sdk/src/mingwMain/resources/csharp/Wrapper/Tiles.cs
@@ -9,9 +9,9 @@ public class Tiles(
     Doordeck_Headless_Sdk_ExportedSymbols._kotlin_e__Struct._root_e__Struct._com_e__Struct._doordeck_e__Struct.
         _multiplatform_e__Struct._sdk_e__Struct._api_e__Struct._TilesApi_e__Struct tilesApi): AbstractWrapper
 {
-    public unsafe Task<TileLocksResponse> GetLocksBelongingToTile(string tileId) =>
+    public unsafe Task<TileLocksResponse> GetLocksBelongingToTile(Guid tileId) =>
         Process<TilesApi, TileLocksResponse>(tiles, tilesApi.getLocksBelongingToTile_, new { tileId });
 
-    public unsafe Task<object> AssociateMultipleLocks(string tileId, string siteId, List<string> lockIds) =>
+    public unsafe Task<object> AssociateMultipleLocks(Guid tileId, Guid siteId, List<Guid> lockIds) =>
         Process<TilesApi, object>(tiles, tilesApi.associateMultipleLocks_, new { tileId, siteId, lockIds });
 }

--- a/doordeck-sdk/src/mingwMain/resources/python/doordeck_headless_sdk.i
+++ b/doordeck-sdk/src/mingwMain/resources/python/doordeck_headless_sdk.i
@@ -74,9 +74,8 @@ class InitializeSdk(object):
                 clearCp
             )
 
-        self.sdkApiEnvironment = _doordeck_headless_sdk.getApiEnvironmentByName(Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_model_data_ApiEnvironment(), api_environment)
         self.debugLogging = 'False' if debug_logging is None else str(debug_logging)
-        self.sdkConfig = _doordeck_headless_sdk.buildSdkConfig(self.sdkApiEnvironment, cloud_auth_token, cloud_refresh_token, fusion_host, self.secureStorage, self.debugLogging)
+        self.sdkConfig = _doordeck_headless_sdk.buildSdkConfig(api_environment, cloud_auth_token, cloud_refresh_token, fusion_host, self.secureStorage, self.debugLogging)
         self.sdk = initialize(Doordeck_Headless_Sdk_kref_com_doordeck_multiplatform_sdk_KDoordeckFactory(), self.sdkConfig)
         self.accountless = Accountless(accountless(self.sdk))
         self.account = Account(account(self.sdk))

--- a/doordeck-sdk/src/mingwMain/resources/python/wrapper/context_manager.i
+++ b/doordeck-sdk/src/mingwMain/resources/python/wrapper/context_manager.i
@@ -5,9 +5,7 @@ class ContextManager(object):
         self.resource = resource
 
     def get_api_environment(self):
-        env = _doordeck_headless_sdk.getApiEnvironment(self.resource)
-        name = _doordeck_headless_sdk.getApiEnvironmentName(env)
-        return name
+        return _doordeck_headless_sdk.getApiEnvironment(self.resource)
 
     def set_cloud_auth_token(self, token: str):
         _doordeck_headless_sdk.setCloudAuthToken(self.resource, token)
@@ -60,9 +58,9 @@ class ContextManager(object):
     def set_operation_context(self, userId: str, userCertificateChain: str, userPublicKey: str, userPrivateKey: str):
         data = {
             "userId": userId,
-            "userCertificateChain": userCertificateChain,
-            "userPublicKey": userPublicKey,
-            "userPrivateKey": userPrivateKey
+            "certificateChain": userCertificateChain,
+            "publicKey": userPublicKey,
+            "privateKey": userPrivateKey
         }
         _doordeck_headless_sdk.setOperationContextJson(self.resource, json.dumps(data))
 

--- a/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/CallbackTest.kt
+++ b/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/CallbackTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import kotlin.test.BeforeTest
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 private var capturedCallback: String = ""
@@ -30,7 +31,7 @@ open class CallbackTest : IntegrationTest() {
             apiCall()
             withTimeout(60.seconds) {
                 while (capturedCallback.isEmpty()) {
-                    delay(1.seconds)
+                    delay(10.milliseconds)
                 }
             }
             return@runBlocking capturedCallback.fromJson<T>().also {

--- a/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/KDoordeckFactoryTest.kt
+++ b/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/KDoordeckFactoryTest.kt
@@ -14,7 +14,7 @@ class KDoordeckFactoryTest {
     fun shouldInitialize() = runTest {
         // Given
         val sdkConfig = SdkConfig.Builder()
-            .setApiEnvironment(TEST_ENVIRONMENT)
+            .setApiEnvironment(TEST_ENVIRONMENT.name)
             .setCloudAuthToken(randomString())
             .setCloudRefreshToken(randomString())
             .setSecureStorageOverride(DefaultSecureStorage(MemorySettings()))

--- a/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.mingw.kt
+++ b/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/api/AccountApiTest.mingw.kt
@@ -8,6 +8,7 @@ import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_EMAIL
 import com.doordeck.multiplatform.sdk.TestConstants.TEST_MAIN_USER_PASSWORD
 import com.doordeck.multiplatform.sdk.context.ContextManager
 import com.doordeck.multiplatform.sdk.model.data.ChangePasswordData
+import com.doordeck.multiplatform.sdk.model.data.EncodedKeyPair
 import com.doordeck.multiplatform.sdk.model.data.LoginData
 import com.doordeck.multiplatform.sdk.model.data.RefreshTokenData
 import com.doordeck.multiplatform.sdk.model.data.RegisterEphemeralKeyData
@@ -16,7 +17,8 @@ import com.doordeck.multiplatform.sdk.model.responses.BasicRegisterEphemeralKeyR
 import com.doordeck.multiplatform.sdk.model.responses.BasicTokenResponse
 import com.doordeck.multiplatform.sdk.model.responses.BasicUserDetailsResponse
 import com.doordeck.multiplatform.sdk.testCallback
-import com.doordeck.multiplatform.sdk.util.Utils.encodeByteArrayToBase64
+import com.doordeck.multiplatform.sdk.util.Utils.certificateChainToString
+import com.doordeck.multiplatform.sdk.util.fromJson
 import com.doordeck.multiplatform.sdk.util.toJson
 import kotlinx.cinterop.staticCFunction
 import kotlinx.coroutines.runBlocking
@@ -82,9 +84,10 @@ class AccountApiTest : CallbackTest() {
             assertTrue { result.success.result.certificateChain.isNotEmpty() }
             assertEquals(PLATFORM_TEST_MAIN_USER_ID, result.success.result.userId)
             assertEquals(PLATFORM_TEST_MAIN_USER_ID, ContextManager.getUserId())
-            assertEquals(result.success.result.certificateChain, ContextManager.getCertificateChain())
-            assertEquals(publicKey, ContextManager.getKeyPair()?.public?.encodeByteArrayToBase64())
-            assertEquals(privateKey, ContextManager.getKeyPair()?.private?.encodeByteArrayToBase64())
+            assertEquals(result.success.result.certificateChain.certificateChainToString(), ContextManager.getCertificateChain())
+            val contextKeyPair = ContextManager.getKeyPair()?.fromJson<EncodedKeyPair>()
+            assertEquals(publicKey, contextKeyPair?.publicKey)
+            assertEquals(privateKey, contextKeyPair?.privateKey)
             assertFalse { ContextManager.isCertificateChainInvalidOrExpired() }
             assertTrue { ContextManager.isKeyPairVerified() }
         }

--- a/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsApiTest.mingw.kt
+++ b/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsApiTest.mingw.kt
@@ -33,6 +33,7 @@ import com.doordeck.multiplatform.sdk.model.data.GetUserPublicKeyData
 import com.doordeck.multiplatform.sdk.model.data.GetUsersForLockData
 import com.doordeck.multiplatform.sdk.model.data.LocationRequirementData
 import com.doordeck.multiplatform.sdk.model.data.LoginData
+import com.doordeck.multiplatform.sdk.model.data.OperationContextData
 import com.doordeck.multiplatform.sdk.model.data.RegisterEphemeralKeyData
 import com.doordeck.multiplatform.sdk.model.data.ResultData
 import com.doordeck.multiplatform.sdk.model.data.RevokeAccessToLockOperationData
@@ -63,7 +64,7 @@ import com.doordeck.multiplatform.sdk.randomDouble
 import com.doordeck.multiplatform.sdk.randomInt
 import com.doordeck.multiplatform.sdk.randomUuidString
 import com.doordeck.multiplatform.sdk.testCallback
-import com.doordeck.multiplatform.sdk.util.Utils.decodeBase64ToByteArray
+import com.doordeck.multiplatform.sdk.util.Utils.certificateChainToString
 import com.doordeck.multiplatform.sdk.util.Utils.encodeByteArrayToBase64
 import com.doordeck.multiplatform.sdk.util.toJson
 import kotlinx.cinterop.staticCFunction
@@ -722,11 +723,13 @@ class LockOperationsApiTest : CallbackTest() {
         assertNotNull(registerKeyResponse.success.result)
         val TEST_MAIN_USER_CERTIFICATE_CHAIN = registerKeyResponse.success.result.certificateChain
         ContextManager.setOperationContext(
-            userId = PLATFORM_TEST_MAIN_USER_ID,
-            certificateChain = TEST_MAIN_USER_CERTIFICATE_CHAIN,
-            publicKey = PLATFORM_TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
-            privateKey = PLATFORM_TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray(),
-            isKeyPairVerified = true
+            OperationContextData(
+                userId = PLATFORM_TEST_MAIN_USER_ID,
+                certificateChain = TEST_MAIN_USER_CERTIFICATE_CHAIN.certificateChainToString(),
+                publicKey = PLATFORM_TEST_MAIN_USER_PUBLIC_KEY,
+                privateKey = PLATFORM_TEST_MAIN_USER_PRIVATE_KEY,
+                isKeyPairVerified = true
+            ).toJson()
         )
 
         // When
@@ -971,11 +974,13 @@ class LockOperationsApiTest : CallbackTest() {
         assertNotNull(registerKeyResponse.success.result)
         val TEST_MAIN_USER_CERTIFICATE_CHAIN = registerKeyResponse.success.result.certificateChain
         ContextManager.setOperationContext(
-            userId = PLATFORM_TEST_MAIN_USER_ID,
-            certificateChain = TEST_MAIN_USER_CERTIFICATE_CHAIN,
-            publicKey = PLATFORM_TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
-            privateKey = PLATFORM_TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray(),
-            isKeyPairVerified = true
+            OperationContextData(
+                userId = PLATFORM_TEST_MAIN_USER_ID,
+                certificateChain = TEST_MAIN_USER_CERTIFICATE_CHAIN.certificateChainToString(),
+                publicKey = PLATFORM_TEST_MAIN_USER_PUBLIC_KEY,
+                privateKey = PLATFORM_TEST_MAIN_USER_PRIVATE_KEY,
+                isKeyPairVerified = true
+            ).toJson()
         )
         val shareLock = ShareLockData(
             targetUserId = PLATFORM_TEST_SUPPLEMENTARY_USER_ID,
@@ -1050,11 +1055,13 @@ class LockOperationsApiTest : CallbackTest() {
         assertNotNull(registerKeyResponse.success.result)
         val TEST_MAIN_USER_CERTIFICATE_CHAIN = registerKeyResponse.success.result.certificateChain
         ContextManager.setOperationContext(
-            userId = PLATFORM_TEST_MAIN_USER_ID,
-            certificateChain = TEST_MAIN_USER_CERTIFICATE_CHAIN,
-            publicKey = PLATFORM_TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
-            privateKey = PLATFORM_TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray(),
-            isKeyPairVerified = true
+            OperationContextData(
+                userId = PLATFORM_TEST_MAIN_USER_ID,
+                certificateChain = TEST_MAIN_USER_CERTIFICATE_CHAIN.certificateChainToString(),
+                publicKey = PLATFORM_TEST_MAIN_USER_PUBLIC_KEY,
+                privateKey = PLATFORM_TEST_MAIN_USER_PRIVATE_KEY,
+                isKeyPairVerified = true
+            ).toJson()
         )
         val batchShareLock = listOf(
             ShareLockData(
@@ -1218,11 +1225,13 @@ class LockOperationsApiTest : CallbackTest() {
         val TEST_MAIN_USER_CERTIFICATE_CHAIN = registerKeyResponse.success.result.certificateChain
         val updatedUnlockDuration = 1
         ContextManager.setOperationContext(
-            userId = PLATFORM_TEST_MAIN_USER_ID,
-            certificateChain = TEST_MAIN_USER_CERTIFICATE_CHAIN,
-            publicKey = PLATFORM_TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
-            privateKey = PLATFORM_TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray(),
-            isKeyPairVerified = true
+            OperationContextData(
+                userId = PLATFORM_TEST_MAIN_USER_ID,
+                certificateChain = TEST_MAIN_USER_CERTIFICATE_CHAIN.certificateChainToString(),
+                publicKey = PLATFORM_TEST_MAIN_USER_PUBLIC_KEY,
+                privateKey = PLATFORM_TEST_MAIN_USER_PRIVATE_KEY,
+                isKeyPairVerified = true
+            ).toJson()
         )
 
         // When
@@ -1369,11 +1378,13 @@ class LockOperationsApiTest : CallbackTest() {
             exceptions = emptyList()
         )
         ContextManager.setOperationContext(
-            userId = PLATFORM_TEST_MAIN_USER_ID,
-            certificateChain = TEST_MAIN_USER_CERTIFICATE_CHAIN,
-            publicKey = PLATFORM_TEST_MAIN_USER_PUBLIC_KEY.decodeBase64ToByteArray(),
-            privateKey = PLATFORM_TEST_MAIN_USER_PRIVATE_KEY.decodeBase64ToByteArray(),
-            isKeyPairVerified = true
+            OperationContextData(
+                userId = PLATFORM_TEST_MAIN_USER_ID,
+                certificateChain = TEST_MAIN_USER_CERTIFICATE_CHAIN.certificateChainToString(),
+                publicKey = PLATFORM_TEST_MAIN_USER_PUBLIC_KEY,
+                privateKey = PLATFORM_TEST_MAIN_USER_PRIVATE_KEY,
+                isKeyPairVerified = true
+            ).toJson()
         )
 
         // When

--- a/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.mingw.kt
+++ b/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.mingw.kt
@@ -17,7 +17,7 @@ class SdkConfigTest {
     fun shouldBuildSdkConfig () = runTest {
         // Given
         val sdkConfig = SdkConfig(
-            apiEnvironment = randomNullable { ApiEnvironment.entries.random() },
+            apiEnvironment = randomNullable { ApiEnvironment.entries.random().name },
             cloudAuthToken = randomNullable { randomString() },
             cloudRefreshToken = randomNullable { randomString() },
             fusionHost = randomNullable { randomUrlString() },

--- a/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.mingw.kt
+++ b/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.mingw.kt
@@ -22,7 +22,7 @@ class SdkConfigTest {
             cloudRefreshToken = randomNullable { randomString() },
             fusionHost = randomNullable { randomUrlString() },
             secureStorage = DefaultSecureStorage(MemorySettings()),
-            debugLogging = randomNullable { randomBoolean() }
+            debugLogging = randomNullable { randomBoolean().toString() }
         )
 
         // When

--- a/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerTest.mingw.kt
+++ b/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerTest.mingw.kt
@@ -9,6 +9,7 @@ import com.doordeck.multiplatform.sdk.TestConstants.TEST_VALID_JWT
 import com.doordeck.multiplatform.sdk.crypto.CryptoManager
 import com.doordeck.multiplatform.sdk.model.common.ContextState
 import com.doordeck.multiplatform.sdk.model.data.ApiEnvironment
+import com.doordeck.multiplatform.sdk.model.data.EncodedKeyPair
 import com.doordeck.multiplatform.sdk.model.data.OperationContextData
 import com.doordeck.multiplatform.sdk.model.data.ResultData
 import com.doordeck.multiplatform.sdk.model.responses.BasicUserDetailsResponse
@@ -25,6 +26,7 @@ import com.doordeck.multiplatform.sdk.storage.MemorySettings
 import com.doordeck.multiplatform.sdk.testCallback
 import com.doordeck.multiplatform.sdk.util.Utils.certificateChainToString
 import com.doordeck.multiplatform.sdk.util.Utils.encodeByteArrayToBase64
+import com.doordeck.multiplatform.sdk.util.fromJson
 import com.doordeck.multiplatform.sdk.util.toJson
 import kotlinx.cinterop.staticCFunction
 import kotlinx.coroutines.runBlocking
@@ -49,9 +51,11 @@ class ContextManagerTest : CallbackTest() {
         val fusionAuthToken = randomString()
         val userId = randomUuidString()
         val email = randomEmail()
-        val certificateChain = listOf(PLATFORM_TEST_VALID_CERTIFICATE)
+        val certificateChain = PLATFORM_TEST_VALID_CERTIFICATE
         val keyPair = CryptoManager.generateRawKeyPair()
-        val keyPairVerified = keyPair.public
+        val publicKey = keyPair.public.encodeByteArrayToBase64()
+        val privateKey = keyPair.private.encodeByteArrayToBase64()
+        val keyPairVerified = publicKey
         val settings = DefaultSecureStorage(MemorySettings())
         Context.setSecureStorageImpl(settings)
         ContextManager.apply {
@@ -62,7 +66,7 @@ class ContextManagerTest : CallbackTest() {
             setFusionAuthToken(fusionAuthToken)
             setUserId(userId)
             setCertificateChain(certificateChain)
-            setKeyPair(keyPair.public, keyPair.private)
+            setKeyPair(publicKey, privateKey)
             setKeyPairVerified(keyPairVerified)
             setUserEmail(email)
         }
@@ -76,9 +80,10 @@ class ContextManagerTest : CallbackTest() {
         assertEquals(apiEnvironment, ContextManager.getApiEnvironment())
         assertEquals(userId, ContextManager.getUserId())
         assertEquals(email, ContextManager.getUserEmail())
-        assertContentEquals(certificateChain, ContextManager.getCertificateChain())
-        assertContentEquals(keyPair.public, ContextManager.getKeyPair()?.public)
-        assertContentEquals(keyPair.private, ContextManager.getKeyPair()?.private)
+        assertEquals(certificateChain, ContextManager.getCertificateChain())
+        val contextKeyPair = ContextManager.getKeyPair()?.fromJson<EncodedKeyPair>()
+        assertEquals(publicKey, contextKeyPair?.publicKey)
+        assertEquals(privateKey, contextKeyPair?.privateKey)
         assertTrue { ContextManager.isKeyPairVerified() }
         assertEquals(cloudAuthToken, ContextManager.getCloudAuthToken())
         assertEquals(cloudRefreshToken, ContextManager.getCloudRefreshToken())
@@ -96,9 +101,11 @@ class ContextManagerTest : CallbackTest() {
         val fusionAuthToken = randomString()
         val userId = randomUuidString()
         val email = randomEmail()
-        val certificateChain = listOf(PLATFORM_TEST_VALID_CERTIFICATE)
+        val certificateChain = PLATFORM_TEST_VALID_CERTIFICATE
         val keyPair = CryptoManager.generateRawKeyPair()
-        val keyPairVerified = keyPair.public
+        val publicKeyEncoded = keyPair.public.encodeByteArrayToBase64()
+        val privateKeyEncoded = keyPair.private.encodeByteArrayToBase64()
+        val keyPairVerified = publicKeyEncoded
         ContextManager.apply {
             setApiEnvironment(apiEnvironment)
             setCloudAuthToken(cloudAuthToken)
@@ -107,7 +114,7 @@ class ContextManagerTest : CallbackTest() {
             setFusionAuthToken(fusionAuthToken)
             setUserId(userId)
             setCertificateChain(certificateChain)
-            setKeyPair(keyPair.public, keyPair.private)
+            setKeyPair(publicKeyEncoded, privateKeyEncoded)
             setKeyPairVerified(keyPairVerified)
             setUserEmail(email)
         }
@@ -129,7 +136,7 @@ class ContextManagerTest : CallbackTest() {
     }
 
     @Test
-    fun shouldStoreJsonOperationContext() = runTest {
+    fun shouldStoreOperationContext() = runTest {
         // Given
         val userId = randomUuidString()
         val certificateChain = (1..3).map { randomPublicKey().encodeByteArrayToBase64() }
@@ -137,13 +144,13 @@ class ContextManagerTest : CallbackTest() {
         val privateKey = randomPrivateKey()
         val operationContextData = OperationContextData(
             userId = userId,
-            userCertificateChain = certificateChain.certificateChainToString(),
-            userPublicKey = publicKey.encodeByteArrayToBase64(),
-            userPrivateKey = privateKey.encodeByteArrayToBase64()
+            certificateChain = certificateChain.certificateChainToString(),
+            publicKey = publicKey.encodeByteArrayToBase64(),
+            privateKey = privateKey.encodeByteArrayToBase64()
         )
         val settings = DefaultSecureStorage(MemorySettings())
         Context.setSecureStorageImpl(settings)
-        ContextManager.setOperationContextJson(operationContextData.toJson())
+        ContextManager.setOperationContext(operationContextData.toJson())
 
         // When
         Context.setSecureStorageImpl(DefaultSecureStorage(MemorySettings())) // Override the storage so that it is not deleted upon a reset call
@@ -243,8 +250,8 @@ class ContextManagerTest : CallbackTest() {
     @Test
     fun shouldCheckKeyPairValidityWithNonMatchingKeys() = runTest {
         // Given
-        val publicKey = CryptoManager.generateRawKeyPair().public
-        val privateKey = CryptoManager.generateRawKeyPair().private
+        val publicKey = CryptoManager.generateRawKeyPair().public.encodeByteArrayToBase64()
+        val privateKey = CryptoManager.generateRawKeyPair().private.encodeByteArrayToBase64()
         ContextManager.setKeyPair(publicKey, privateKey)
 
         // When
@@ -258,7 +265,9 @@ class ContextManagerTest : CallbackTest() {
     fun shouldCheckKeyPairValidity() = runTest {
         // Given
         val keyPair = CryptoManager.generateRawKeyPair()
-        ContextManager.setKeyPair(keyPair.public, keyPair.private)
+        val publicKey = keyPair.public.encodeByteArrayToBase64()
+        val privateKey = keyPair.private.encodeByteArrayToBase64()
+        ContextManager.setKeyPair(publicKey, privateKey)
 
         // When
         val result = ContextManager.isKeyPairValid()
@@ -338,8 +347,10 @@ class ContextManagerTest : CallbackTest() {
             ))
 
             val keyPair = CryptoManager.generateRawKeyPair()
+            val publicKey = keyPair.public.encodeByteArrayToBase64()
+            val privateKey = keyPair.private.encodeByteArrayToBase64()
             ContextManager.setCloudAuthToken(TEST_VALID_JWT)
-            ContextManager.setKeyPair(keyPair.public, keyPair.private)
+            ContextManager.setKeyPair(publicKey, privateKey)
 
             // When
             val result = callbackApiCall<ResultData<ContextState>> {
@@ -367,10 +378,12 @@ class ContextManagerTest : CallbackTest() {
             ))
 
             val keyPair = CryptoManager.generateRawKeyPair()
+            val publicKey = keyPair.public.encodeByteArrayToBase64()
+            val privateKey = keyPair.private.encodeByteArrayToBase64()
             ContextManager.setCloudAuthToken(TEST_VALID_JWT)
-            ContextManager.setKeyPair(keyPair.public, keyPair.private)
-            ContextManager.setKeyPairVerified(keyPair.public)
-            ContextManager.setCertificateChain(listOf(PLATFORM_TEST_EXPIRED_CERTIFICATE))
+            ContextManager.setKeyPair(publicKey, privateKey)
+            ContextManager.setKeyPairVerified(publicKey)
+            ContextManager.setCertificateChain(PLATFORM_TEST_EXPIRED_CERTIFICATE)
 
             // When
             val result = callbackApiCall<ResultData<ContextState>> {
@@ -398,10 +411,12 @@ class ContextManagerTest : CallbackTest() {
             ))
 
             val keyPair = CryptoManager.generateRawKeyPair()
+            val publicKey = keyPair.public.encodeByteArrayToBase64()
+            val privateKey = keyPair.private.encodeByteArrayToBase64()
             ContextManager.setCloudAuthToken(TEST_VALID_JWT)
-            ContextManager.setKeyPair(keyPair.public, keyPair.private)
-            ContextManager.setKeyPairVerified(keyPair.public)
-            ContextManager.setCertificateChain(listOf(PLATFORM_TEST_VALID_CERTIFICATE))
+            ContextManager.setKeyPair(publicKey, privateKey)
+            ContextManager.setKeyPairVerified(publicKey)
+            ContextManager.setCertificateChain(PLATFORM_TEST_VALID_CERTIFICATE)
 
             // When
             val result = callbackApiCall<ResultData<ContextState>> {

--- a/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerTest.mingw.kt
+++ b/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/context/ContextManagerTest.mingw.kt
@@ -42,7 +42,7 @@ class ContextManagerTest : CallbackTest() {
     @Test
     fun shouldStoreAndLoadContext() = runTest {
         // Given
-        val apiEnvironment = ApiEnvironment.entries.random()
+        val apiEnvironment = ApiEnvironment.entries.random().name
         val fusionHost = randomUrlString()
         val cloudAuthToken = randomString()
         val cloudRefreshToken = randomString()
@@ -89,7 +89,7 @@ class ContextManagerTest : CallbackTest() {
     @Test
     fun shouldClearContext() = runTest {
         // Given
-        val apiEnvironment = ApiEnvironment.entries.random()
+        val apiEnvironment = ApiEnvironment.entries.random().name
         val fusionHost = randomUrlString()
         val cloudAuthToken = randomString()
         val cloudRefreshToken = randomString()
@@ -116,7 +116,7 @@ class ContextManagerTest : CallbackTest() {
         ContextManager.clearContext()
 
         // Then
-        assertEquals(ApiEnvironment.PROD, ContextManager.getApiEnvironment())
+        assertEquals(ApiEnvironment.PROD.name, ContextManager.getApiEnvironment())
         assertNull(ContextManager.getUserId())
         assertNull(ContextManager.getUserEmail())
         assertNull(ContextManager.getCertificateChain())
@@ -270,7 +270,7 @@ class ContextManagerTest : CallbackTest() {
     @Test
     fun shouldUpdateApiEnvironment() = runTest {
         // Given
-        val apiEnvironment = ApiEnvironment.STAGING
+        val apiEnvironment = ApiEnvironment.STAGING.name
 
         // When
         ContextManager.setApiEnvironment(apiEnvironment)


### PR DESCRIPTION
This PR contains:
* Slightly simplified both sides, Kotlin/CSharp, and adjusted the code format a bit
* [Guid](https://learn.microsoft.com/en-us/dotnet/api/system.guid?view=net-9.0) replaces `string` UUIDs
* [TimeZoneInfo](https://learn.microsoft.com/en-us/dotnet/api/system.timezoneinfo?view=net-9.0) replace `string` timezones
* [IPAddress](https://learn.microsoft.com/en-us/dotnet/api/system.net.ipaddress?view=net-8.0) replaces `string` IP address
* [Uri](https://learn.microsoft.com/en-us/dotnet/api/system.uri?view=net-8.0) replaces `string` urls
* [DateTime](https://learn.microsoft.com/en-us/dotnet/api/system.datetime?view=net-8.0) replaces `string` / `double` instant representations
* [TimeOnly](https://learn.microsoft.com/en-us/dotnet/api/system.timeonly?view=net-8.0) replaces `string` time representations (HH:mm)
* [DateOnly](https://learn.microsoft.com/en-us/dotnet/api/system.dateonly?view=net-8.0) replaces `string` date representations (yyyy-MM-dd)
* [TimeSpan](https://learn.microsoft.com/en-us/dotnet/api/system.timespan?view=net-8.0) replaces `int` / `double` duration representations
* [X509Certificates](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate?view=net-8.0) replaces `string` certificates

It looks like NET does not have a native class to represent Ed25519 public/private keys. Although this [could be added soon](https://github.com/dotnet/runtime/issues/63174), the alternative would be to use a third-party library.