### PR TITLE
Do not require auth at the password related endpoints

### DIFF
--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/network/Paths.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/network/Paths.kt
@@ -76,7 +76,7 @@ internal object Paths {
      */
     @JvmSynthetic
     internal fun requiresAuth(path: String) = path != getLoginPath() && path != getRegistrationPath() &&
-            path != getVerifyEmailPath()
+            path != getVerifyEmailPath() && path != getPasswordResetPath() && path != getPasswordResetVerifyPath()
 }
 
 /**


### PR DESCRIPTION
Password-related endpoints shouldn't require auth.