### PR TITLE
Operation header typ typo

### DIFF
--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/requests/LockOperationRequests.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/model/requests/LockOperationRequests.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.Serializable
 internal data class OperationHeaderRequest(
     val alg: String = "EdDSA",
     val x5c: List<String>,
+    @SerialName("typ")
     val type: String = "JWT"
 )
 


### PR DESCRIPTION
This is apparently correctly handled at the backend since it's working with the field wrongly serialized as `type`, but anyway, according to [RFC7515](https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.9), it should be serialized as `typ`