### PR TITLE
Revert "Bump at.asitplus.signum:indispensable-asn1 from 3.20.1 to 3.21.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kgp = "9.1.1"
 bouncy-castle = "1.84"
-indispensable-asn1 = "3.21.0"
+indispensable-asn1 = "3.20.1"
 kotlin = "2.3.20"
 multiplatform-settings = "1.3.0"
 android-min-sdk = "26"


### PR DESCRIPTION
Reverts doordeck/doordeck-headless-sdk#412, they dropped support for Apple X64 targets, and it broke the build.