### PR TITLE
getUserPublicKeyAsync shouldn't be a suspended function

### DIFF
--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsApi.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsApi.android.kt
@@ -306,7 +306,7 @@ actual object LockOperationsApi {
      * Async variant of [LockOperationsApi.getUserPublicKey] returning [CompletableFuture].
      */
     @DoordeckOnly
-    suspend fun getUserPublicKeyAsync(
+    fun getUserPublicKeyAsync(
         userEmail: String,
         visitor: Boolean = false
     ): CompletableFuture<UserPublicKeyResponse> = completableFuture {

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsApi.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/api/LockOperationsApi.jvm.kt
@@ -306,7 +306,7 @@ actual object LockOperationsApi {
      * Async variant of [LockOperationsApi.getUserPublicKey] returning [CompletableFuture].
      */
     @DoordeckOnly
-    suspend fun getUserPublicKeyAsync(
+    fun getUserPublicKeyAsync(
         userEmail: String,
         visitor: Boolean = false
     ): CompletableFuture<UserPublicKeyResponse> = completableFuture {


### PR DESCRIPTION
* `getUserPublicKeyAsync`  function shouldn't be a suspended function on Android/JVM, since that makes it inaccessible.