### PR TITLE
fusionHost is incorrectly being stored as the string "null"

### DIFF
--- a/doordeck-sdk/src/androidHostTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.android.kt
+++ b/doordeck-sdk/src/androidHostTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.android.kt
@@ -7,6 +7,7 @@ import com.doordeck.multiplatform.sdk.randomString
 import com.doordeck.multiplatform.sdk.randomUri
 import com.doordeck.multiplatform.sdk.storage.DefaultSecureStorage
 import com.doordeck.multiplatform.sdk.storage.MemorySettings
+import com.doordeck.multiplatform.sdk.util.toUri
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -37,5 +38,28 @@ class SdkConfigTest {
 
         // Then
         assertEquals(sdkConfig, result)
+    }
+
+    @Test
+    fun shouldMapToBasicConfig () = runTest {
+        // Given
+        val sdkConfig = SdkConfig(
+            apiEnvironment = randomNullable { ApiEnvironment.entries.random() },
+            cloudAuthToken = randomNullable { randomString() },
+            cloudRefreshToken = randomNullable { randomString() },
+            fusionHost = randomNullable { randomUri() },
+            secureStorage = DefaultSecureStorage(MemorySettings()),
+            debugLogging = randomNullable { randomBoolean() }
+        )
+
+        // When
+        val result = sdkConfig.toBasicSdkConfig()
+
+        // Then
+        assertEquals(sdkConfig.apiEnvironment, result.apiEnvironment)
+        assertEquals(sdkConfig.cloudAuthToken, result.cloudAuthToken)
+        assertEquals(sdkConfig.cloudRefreshToken, result.cloudRefreshToken)
+        assertEquals(sdkConfig.fusionHost, result.fusionHost?.toUri())
+        assertEquals(sdkConfig.debugLogging, result.debugLogging)
     }
 }

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.android.kt
@@ -87,7 +87,7 @@ internal fun SdkConfig.toBasicSdkConfig(): BasicSdkConfig = BasicSdkConfig(
     apiEnvironment = apiEnvironment,
     cloudAuthToken = cloudAuthToken,
     cloudRefreshToken = cloudRefreshToken,
-    fusionHost = fusionHost.toString(),
+    fusionHost = fusionHost?.toString(),
     secureStorage = secureStorage,
     debugLogging = debugLogging
 )

--- a/doordeck-sdk/src/appleTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.apple.kt
+++ b/doordeck-sdk/src/appleTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.apple.kt
@@ -7,6 +7,7 @@ import com.doordeck.multiplatform.sdk.randomString
 import com.doordeck.multiplatform.sdk.randomUri
 import com.doordeck.multiplatform.sdk.storage.DefaultSecureStorage
 import com.doordeck.multiplatform.sdk.storage.MemorySettings
+import com.doordeck.multiplatform.sdk.util.toNsUrlComponents
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -14,7 +15,7 @@ import kotlin.test.assertEquals
 class SdkConfigTest {
 
     @Test
-    fun shouldBuildSdkConfig () = runTest {
+    fun shouldBuildSdkConfig() = runTest {
         // Given
         val sdkConfig = SdkConfig(
             apiEnvironment = randomNullable { ApiEnvironment.entries.random() },
@@ -37,5 +38,28 @@ class SdkConfigTest {
 
         // Then
         assertEquals(sdkConfig, result)
+    }
+
+    @Test
+    fun shouldMapToBasicConfig() = runTest {
+        // Given
+        val sdkConfig = SdkConfig(
+            apiEnvironment = randomNullable { ApiEnvironment.entries.random() },
+            cloudAuthToken = randomNullable { randomString() },
+            cloudRefreshToken = randomNullable { randomString() },
+            fusionHost = randomNullable { randomUri() },
+            secureStorage = DefaultSecureStorage(MemorySettings()),
+            debugLogging = randomNullable { randomBoolean() }
+        )
+
+        // When
+        val result = sdkConfig.toBasicSdkConfig()
+
+        // Then
+        assertEquals(sdkConfig.apiEnvironment, result.apiEnvironment)
+        assertEquals(sdkConfig.cloudAuthToken, result.cloudAuthToken)
+        assertEquals(sdkConfig.cloudRefreshToken, result.cloudRefreshToken)
+        assertEquals(sdkConfig.fusionHost, result.fusionHost?.toNsUrlComponents())
+        assertEquals(sdkConfig.debugLogging, result.debugLogging)
     }
 }

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/migrations/Migrate2To3.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/migrations/Migrate2To3.kt
@@ -1,0 +1,21 @@
+package com.doordeck.multiplatform.sdk.storage.migrations
+
+import com.russhwolf.settings.Settings
+
+/**
+ * Removes the stored value from FUSION_HOST_KEY when it's set to 'null'
+ */
+internal object Migrate2To3 : StorageMigration {
+
+    override val fromVersion: Int = 2
+    override val toVersion: Int = 3
+
+    private const val FUSION_HOST_KEY = "FUSION_HOST_KEY"
+
+    override fun migrate(settings: Settings) {
+        val fusionHostKey = settings.getStringOrNull(FUSION_HOST_KEY)
+        if (fusionHostKey != null && fusionHostKey == "null") {
+            settings.remove(FUSION_HOST_KEY)
+        }
+    }
+}

--- a/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/migrations/Migrations.kt
+++ b/doordeck-sdk/src/commonMain/kotlin/com/doordeck/multiplatform/sdk/storage/migrations/Migrations.kt
@@ -14,7 +14,8 @@ internal const val CURRENT_STORAGE_VERSION = 2
 internal object Migrations {
     private var _migrations: List<StorageMigration> = listOf(
         Migrate0To1,
-        Migrate1To2
+        Migrate1To2,
+        Migrate2To3
     )
 
     @get:JvmSynthetic

--- a/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/storage/MigrationTest.kt
+++ b/doordeck-sdk/src/commonTest/kotlin/com/doordeck/multiplatform/sdk/storage/MigrationTest.kt
@@ -4,6 +4,7 @@ import com.doordeck.multiplatform.sdk.randomBoolean
 import com.doordeck.multiplatform.sdk.randomByteArray
 import com.doordeck.multiplatform.sdk.storage.migrations.Migrate0To1
 import com.doordeck.multiplatform.sdk.storage.migrations.Migrate1To2
+import com.doordeck.multiplatform.sdk.storage.migrations.Migrate2To3
 import com.doordeck.multiplatform.sdk.storage.migrations.Migrations
 import com.doordeck.multiplatform.sdk.util.Utils.encodeByteArrayToBase64
 import com.russhwolf.settings.contains
@@ -11,6 +12,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class MigrationTest {
@@ -56,6 +58,22 @@ class MigrationTest {
         assertFalse { settings.contains(deprecatedKey) }
         assertTrue { settings.contains(newKey) }
         assertEquals(key, settings.getStringOrNull(newKey))
+    }
+
+    @Test
+    fun shouldMigrate2To3Test() = runTest {
+        // Given
+        Migrations.overrideMigrations(listOf(Migrate2To3))
+        val fusionHostKey = "FUSION_HOST_KEY"
+        val settings = MemorySettings().apply {
+            putString(fusionHostKey, "null")
+        }
+
+        // When
+        val storage = DefaultSecureStorage(settings)
+
+        // Then
+        assertNull(storage.getFusionHost())
     }
 
     @Test

--- a/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.js.kt
+++ b/doordeck-sdk/src/jsMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.js.kt
@@ -86,7 +86,7 @@ internal fun SdkConfig.toBasicSdkConfig(): BasicSdkConfig = BasicSdkConfig(
     apiEnvironment = apiEnvironment?.let { ApiEnvironment.valueOf(it) },
     cloudAuthToken = cloudAuthToken,
     cloudRefreshToken = cloudRefreshToken,
-    fusionHost = fusionHost.toString(),
+    fusionHost = fusionHost,
     secureStorage = secureStorage,
     debugLogging = debugLogging
 )

--- a/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.js.kt
+++ b/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.js.kt
@@ -38,4 +38,27 @@ class SdkConfigTest {
         // Then
         assertEquals(sdkConfig, result)
     }
+
+    @Test
+    fun shouldMapToBasicConfig () = runTest {
+        // Given
+        val sdkConfig = SdkConfig(
+            apiEnvironment = randomNullable { ApiEnvironment.entries.random().name },
+            cloudAuthToken = randomNullable { randomString() },
+            cloudRefreshToken = randomNullable { randomString() },
+            fusionHost = randomNullable { randomUrlString() },
+            secureStorage = DefaultSecureStorage(MemorySettings()),
+            debugLogging = randomNullable { randomBoolean() }
+        )
+
+        // When
+        val result = sdkConfig.toBasicSdkConfig()
+
+        // Then
+        assertEquals(sdkConfig.apiEnvironment, result.apiEnvironment?.name)
+        assertEquals(sdkConfig.cloudAuthToken, result.cloudAuthToken)
+        assertEquals(sdkConfig.cloudRefreshToken, result.cloudRefreshToken)
+        assertEquals(sdkConfig.fusionHost, result.fusionHost)
+        assertEquals(sdkConfig.debugLogging, result.debugLogging)
+    }
 }

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.jvm.kt
@@ -87,7 +87,7 @@ internal fun SdkConfig.toBasicSdkConfig(): BasicSdkConfig = BasicSdkConfig(
     apiEnvironment = apiEnvironment,
     cloudAuthToken = cloudAuthToken,
     cloudRefreshToken = cloudRefreshToken,
-    fusionHost = fusionHost.toString(),
+    fusionHost = fusionHost?.toString(),
     secureStorage = secureStorage,
     debugLogging = debugLogging
 )

--- a/doordeck-sdk/src/jvmTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.jvm.kt
+++ b/doordeck-sdk/src/jvmTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.jvm.kt
@@ -7,6 +7,7 @@ import com.doordeck.multiplatform.sdk.randomString
 import com.doordeck.multiplatform.sdk.randomUri
 import com.doordeck.multiplatform.sdk.storage.DefaultSecureStorage
 import com.doordeck.multiplatform.sdk.storage.MemorySettings
+import com.doordeck.multiplatform.sdk.util.toUri
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -37,5 +38,28 @@ class SdkConfigTest {
 
         // Then
         assertEquals(sdkConfig, result)
+    }
+
+    @Test
+    fun shouldMapToBasicConfig () = runTest {
+        // Given
+        val sdkConfig = SdkConfig(
+            apiEnvironment = randomNullable { ApiEnvironment.entries.random() },
+            cloudAuthToken = randomNullable { randomString() },
+            cloudRefreshToken = randomNullable { randomString() },
+            fusionHost = randomNullable { randomUri() },
+            secureStorage = DefaultSecureStorage(MemorySettings()),
+            debugLogging = randomNullable { randomBoolean() }
+        )
+
+        // When
+        val result = sdkConfig.toBasicSdkConfig()
+
+        // Then
+        assertEquals(sdkConfig.apiEnvironment, result.apiEnvironment)
+        assertEquals(sdkConfig.cloudAuthToken, result.cloudAuthToken)
+        assertEquals(sdkConfig.cloudRefreshToken, result.cloudRefreshToken)
+        assertEquals(sdkConfig.fusionHost, result.fusionHost?.toUri())
+        assertEquals(sdkConfig.debugLogging, result.debugLogging)
     }
 }

--- a/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.mingw.kt
+++ b/doordeck-sdk/src/mingwMain/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfig.mingw.kt
@@ -85,7 +85,7 @@ internal fun SdkConfig.toBasicSdkConfig(): BasicSdkConfig = BasicSdkConfig(
     apiEnvironment = apiEnvironment?.let { ApiEnvironment.valueOf(it) },
     cloudAuthToken = cloudAuthToken,
     cloudRefreshToken = cloudRefreshToken,
-    fusionHost = fusionHost.toString(),
+    fusionHost = fusionHost,
     secureStorage = secureStorage,
     debugLogging = debugLogging?.toBoolean()
 )

--- a/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.mingw.kt
+++ b/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/config/SdkConfigTest.mingw.kt
@@ -38,4 +38,27 @@ class SdkConfigTest {
         // Then
         assertEquals(sdkConfig, result)
     }
+
+    @Test
+    fun shouldMapToBasicConfig () = runTest {
+        // Given
+        val sdkConfig = SdkConfig(
+            apiEnvironment = randomNullable { ApiEnvironment.entries.random().name },
+            cloudAuthToken = randomNullable { randomString() },
+            cloudRefreshToken = randomNullable { randomString() },
+            fusionHost = randomNullable { randomUrlString() },
+            secureStorage = DefaultSecureStorage(MemorySettings()),
+            debugLogging = randomNullable { randomBoolean().toString() }
+        )
+
+        // When
+        val result = sdkConfig.toBasicSdkConfig()
+
+        // Then
+        assertEquals(sdkConfig.apiEnvironment, result.apiEnvironment?.name)
+        assertEquals(sdkConfig.cloudAuthToken, result.cloudAuthToken)
+        assertEquals(sdkConfig.cloudRefreshToken, result.cloudRefreshToken)
+        assertEquals(sdkConfig.fusionHost, result.fusionHost)
+        assertEquals(sdkConfig.debugLogging, result.debugLogging?.toString())
+    }
 }


### PR DESCRIPTION
* Fixed so it's not stored anymore as the string `"null"` (Android/JVM/JS/MingW).
* Added a migration to remove the `fusionHost` value when it's stored as the string `"null"`.
* Added tests for the `toBasicSdkConfig` function and the new migration.