### PR TITLE
Fixing String.toInstant() for cases when the string does not contain a dot

### DIFF
--- a/doordeck-sdk/src/androidHostTest/kotlin/com/doordeck/multiplatform/sdk/util/AndroidExtensionsTest.kt
+++ b/doordeck-sdk/src/androidHostTest/kotlin/com/doordeck/multiplatform/sdk/util/AndroidExtensionsTest.kt
@@ -1,9 +1,25 @@
 package com.doordeck.multiplatform.sdk.util
 
+import com.doordeck.multiplatform.sdk.exceptions.SdkException
+import com.doordeck.multiplatform.sdk.model.data.ApiEnvironment
+import kotlinx.coroutines.future.await
 import kotlinx.coroutines.test.runTest
+import java.net.InetAddress
+import java.net.URI
+import java.net.UnknownHostException
 import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeParseException
+import java.time.zone.ZoneRulesException
+import java.util.EnumSet
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertIs
 
 class AndroidExtensionsTest {
 
@@ -17,5 +33,376 @@ class AndroidExtensionsTest {
 
         // Then
         assertEquals(183840, seconds)
+    }
+
+    @Test
+    fun shouldMapStringToLocalTime12() = runTest {
+        // Given
+        val localTime = "07:34"
+
+        // When
+        val result = localTime.toLocalTime()
+
+        // Then
+        assertEquals(LocalTime.of(7, 34), result)
+    }
+
+    @Test
+    fun shouldMapStringToLocalTime24() = runTest {
+        // Given
+        val localTime = "16:34"
+
+        // When
+        val result = localTime.toLocalTime()
+
+        // Then
+        assertEquals(LocalTime.of(16, 34), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToLocalTime() = runTest {
+        // Given
+        val wrong = "localtime"
+
+        // When
+        val exception = assertFails {
+            wrong.toLocalTime()
+        }
+
+        // Then
+        assertIs<DateTimeParseException>(exception)
+    }
+
+    @Test
+    fun shouldMapLocalTimeToLocalTimeString12() = runTest {
+        // Given
+        val localTime = LocalTime.of(7, 34)
+
+        // When
+        val result = localTime.toLocalTimeString()
+
+        // Then
+        assertEquals("07:34", result)
+    }
+
+    @Test
+    fun shouldMapLocalTimeToLocalTimeString24() = runTest {
+        // Given
+        val localTime = LocalTime.of(16, 34)
+
+        // When
+        val result = localTime.toLocalTimeString()
+
+        // Then
+        assertEquals("16:34", result)
+    }
+
+    @Test
+    fun shouldMapStringToLocalDate() = runTest {
+        // Given
+        val localDate = "2023-10-27"
+
+        // When
+        val result = localDate.toLocalDate()
+
+        // Then
+        assertEquals(LocalDate.of(2023, 10, 27), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToLocalDate() = runTest {
+        // Given
+        val wrong = "localdate"
+
+        // When
+        val exception = assertFails {
+            wrong.toLocalDate()
+        }
+
+        // Then
+        assertIs<DateTimeParseException>(exception)
+    }
+
+    @Test
+    fun shouldMapLocalDateToLocalDateString() = runTest {
+        // Given
+        val localDate = LocalDate.of(2023, 10, 27)
+
+        // When
+        val result = localDate.toLocalDateString()
+
+        // Then
+        assertEquals("2023-10-27", result)
+    }
+
+    @Test
+    fun shouldMapSecondsToDuration() = runTest {
+        // Given
+        val duration = 120
+
+        // When
+        val result = duration.secondsToDuration()
+
+        // Then
+        assertEquals(Duration.ofMinutes(2), result)
+    }
+
+    @Test
+    fun shouldMapStringToUri() = runTest {
+        // Given
+        val uri = "https://google.com"
+
+        // When
+        val result = uri.toUri()
+
+        // Then
+        assertEquals(URI.create(uri), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToUri() = runTest {
+        // Given
+        val wrong = "`"
+
+        // When
+        val exception = assertFails {
+            wrong.toUri()
+        }
+
+        // Then
+        assertIs<IllegalArgumentException>(exception)
+    }
+
+    @Test
+    fun shouldMapStringToUrl() = runTest {
+        // Given
+        val url = "https://google.com"
+
+        // When
+        val result = url.toUrl()
+
+        // Then
+        assertEquals(URI.create(url).toURL(), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToUrl() = runTest {
+        // Given
+        val wrong = "wrong"
+
+        // When
+        val exception = assertFails {
+            wrong.toUrl()
+        }
+
+        // Then
+        assertIs<IllegalArgumentException>(exception)
+    }
+
+    @Test
+    fun shouldMapStringToZoneId() = runTest {
+        // Given
+        val zoneId = "UTC"
+
+        // When
+        val result = zoneId.toZoneId()
+
+        // Then
+        assertEquals(ZoneId.of("UTC"), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToZoneId() = runTest {
+        // Given
+        val wrong = "wrong"
+
+        // When
+        val exception = assertFails {
+            wrong.toZoneId()
+        }
+
+        // Then
+        assertIs<ZoneRulesException>(exception)
+    }
+
+    @Test
+    fun shouldMapStringToUuid() = runTest {
+        // Given
+        val uuid = "8abede37-298a-4c70-bbcc-19bddecc53c7"
+
+        // When
+        val result = uuid.toUuid()
+
+        // Then
+        assertEquals(UUID.fromString(uuid), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToUuid() = runTest {
+        // Given
+        val wrong = "wrong"
+
+        // When
+        val exception = assertFails {
+            wrong.toUuid()
+        }
+
+        // Then
+        assertIs<IllegalArgumentException>(exception)
+    }
+
+    @Test
+    fun shouldMapStringToInstantWithDot() = runTest {
+        // Given
+        val instantString = "1672531200.0"
+
+        // When
+        val result = instantString.toInstant()
+
+        // Then
+        assertEquals(Instant.ofEpochSecond(1672531200L, 0L), result)
+    }
+
+    @Test
+    fun shouldMapStringToInstantWithoutDot() = runTest {
+        // Given
+        val instantString = "1672531200"
+
+        // When
+        val result = instantString.toInstant()
+
+        // Then
+        assertEquals(Instant.ofEpochSecond(1672531200L, 0L), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToInstant() = runTest {
+        // Given
+        val wrong = "wrong"
+
+        // When
+        val exception = assertFails {
+            wrong.toInstant()
+        }
+
+        // Then
+        assertIs<NumberFormatException>(exception)
+    }
+
+    @Test
+    fun shouldMapIsoStringToInstant() = runTest {
+        // Given
+        val isoString = "2023-01-01T00:00:00Z"
+
+        // When
+        val result = isoString.isoToInstant()
+
+        // Then
+        assertEquals(Instant.parse(isoString), result)
+    }
+
+    @Test
+    fun shouldFailToMapIsoStringToInstant() = runTest {
+        // Given
+        val wrong = "wrong"
+
+        // When
+        val exception = assertFails {
+            wrong.isoToInstant()
+        }
+
+        // Then
+        assertIs<DateTimeParseException>(exception)
+    }
+
+    @Test
+    fun shouldMapDoubleToInstant() = runTest {
+        // Given
+        val seconds = 1672531200.0
+
+        // When
+        val instant = seconds.toInstant()
+
+        // Then
+        assertEquals(Instant.ofEpochSecond(1672531200L), instant)
+    }
+
+    @Test
+    fun shouldMapStringToInetAddress() = runTest {
+        // Given
+        val host = "127.0.0.1"
+
+        // When
+        val result = host.toInetAddress()
+
+        // Then
+        assertEquals(InetAddress.getByName("127.0.0.1"), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToInetAddress() = runTest {
+        // Given
+        val host = "host"
+
+        // When
+        val exception = assertFails {
+            host.toInetAddress()
+        }
+
+        // Then
+        assertIs<UnknownHostException>(exception)
+    }
+
+    @Test
+    fun shouldMapListToEnumSet() = runTest {
+        // Given
+        val enums = EnumSet.of(ApiEnvironment.DEV, ApiEnvironment.STAGING,
+            ApiEnvironment.PROD)
+
+        // When
+        val result = enums.toList().toEnumSet()
+
+        // Then
+        assertEquals(enums, result)
+    }
+
+    @Test
+    fun shouldMapEmptyListToEnumSet() = runTest {
+        // Given
+        val enums = EnumSet.noneOf(ApiEnvironment::class.java)
+
+        // When
+        val result = enums.toList().toEnumSet()
+
+        // Then
+        assertEquals(enums, result)
+    }
+
+    @Test
+    fun shouldCreateCompletableFuture() = runTest {
+        // Given
+        val toReturn = "result"
+
+        // When
+        val result = completableFuture {
+            toReturn
+        }.await()
+
+        // Then
+        assertEquals(toReturn, result)
+    }
+
+    @Test
+    fun shouldFailToProcessCompletableFuture() = runTest {
+        // Given
+        val exception = SdkException("Error")
+
+        // When
+        val result = completableFuture {
+            exception
+        }.await()
+
+        // Then
+        assertIs<SdkException>(result)
     }
 }

--- a/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.android.kt
+++ b/doordeck-sdk/src/androidMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.android.kt
@@ -78,8 +78,8 @@ internal fun String.toUuid(): UUID = UUID.fromString(this)
 internal fun String.toInstant(): Instant {
     val split = split(".")
     return Instant.ofEpochSecond(
-        split.first().toLong(),
-        split.lastOrNull()?.toLong() ?: 0
+        split[0].toLong(),
+        split.getOrNull(1)?.toLong() ?: 0
     )
 }
 

--- a/doordeck-sdk/src/appleTest/kotlin/com/doordeck/multiplatform/sdk/util/AppleExtensionsTest.kt
+++ b/doordeck-sdk/src/appleTest/kotlin/com/doordeck/multiplatform/sdk/util/AppleExtensionsTest.kt
@@ -5,14 +5,23 @@ import com.doordeck.multiplatform.sdk.randomUuid
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toNSTimeZone
+import platform.Foundation.NSCalendar
+import platform.Foundation.NSDate
+import platform.Foundation.NSDateComponents
+import platform.Foundation.NSTimeInterval
+import platform.Foundation.NSTimeZone
+import platform.Foundation.date
+import platform.Foundation.timeZoneWithName
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertIs
 import kotlin.time.Clock.System.now
 
 class AppleExtensionsTest {
 
     @Test
-    fun shouldConvertStringToNsUuid() = runTest {
+    fun shouldMapStringToNsUuid() = runTest {
         // Given
         val uuid = randomUuid()
 
@@ -24,7 +33,33 @@ class AppleExtensionsTest {
     }
 
     @Test
-    fun shouldConvertStringToNsUrlComponentes() = runTest {
+    fun shouldFailToMapStringToNsUuid() = runTest {
+        // Given
+        val wrong = "wrong"
+
+        // When
+        val exception = assertFails {
+            wrong.toNsUuid()
+        }
+
+        // Then
+        assertIs<NullPointerException>(exception)
+    }
+
+    @Test
+    fun shouldMapNsUrlComponentsToUrlString() = runTest {
+        // Given
+        val url = randomUri().toString()
+
+        // When
+        val result = url.toNsUrlComponents().toUrlString()
+
+        // Then
+        assertEquals(url, result)
+    }
+
+    @Test
+    fun shouldMapStringToNsUrlComponents() = runTest {
         // Given
         val url = randomUri()
 
@@ -72,7 +107,31 @@ class AppleExtensionsTest {
     }
 
     @Test
-    fun shouldConvertStringToNsDate() = runTest {
+    fun shouldMapNsTimeIntervalToWholeSeconds() = runTest {
+        // Given
+        val interval: NSTimeInterval = 90.75
+
+        // When
+        val result = interval.toWholeSeconds()
+
+        // Then
+        assertEquals(90, result)
+    }
+
+    @Test
+    fun shouldMapDoubleToNsDate() = runTest {
+        // Given
+        val date = now().epochSeconds
+
+        // When
+        val result = date.toDouble().toNsDate()
+
+        // Then
+        assertEquals(date, result.toEpochSeconds())
+    }
+
+    @Test
+    fun shouldMapStringToNsDate() = runTest {
         // Given
         val date = now().epochSeconds
 
@@ -84,14 +143,40 @@ class AppleExtensionsTest {
     }
 
     @Test
-    fun shouldConvertDoubleToNsDate() = runTest {
+    fun shouldMapIsoStringToNsDate() = runTest {
         // Given
-        val date = now().epochSeconds
+        val isoString = "2023-01-01T00:00:00Z"
+        val calendar = NSCalendar.currentCalendar.apply {
+            timeZone = NSTimeZone.timeZoneWithName("UTC")!!
+        }
+        val components = NSDateComponents().apply {
+            year = 2023
+            month = 1
+            day = 1
+            hour = 0
+            minute = 0
+            second = 0
+        }
+        val date = calendar.dateFromComponents(components)
 
         // When
-        val result = date.toDouble().toNsDate()
+        val result = isoString.isoToNsDate()
 
         // Then
-        assertEquals(date, result.toEpochSeconds())
+        assertEquals(date, result)
+    }
+
+    @Test
+    fun shouldFailToMapIsoStringToNsDate() = runTest {
+        // Given
+        val isoString = "wrong"
+
+        // When
+        val exception = assertFails {
+            isoString.isoToNsDate()
+        }
+
+        // Then
+        assertIs<Exception>(exception) // InstantFormatException
     }
 }

--- a/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/util/JsExtensionsTest.kt
+++ b/doordeck-sdk/src/jsTest/kotlin/com/doordeck/multiplatform/sdk/util/JsExtensionsTest.kt
@@ -1,0 +1,109 @@
+package com.doordeck.multiplatform.sdk.util
+
+import com.doordeck.multiplatform.sdk.exceptions.SdkException
+import com.doordeck.multiplatform.sdk.size
+import kotlinx.coroutines.await
+import kotlinx.coroutines.test.runTest
+import kotlin.js.collections.JsArray
+import kotlin.js.collections.JsMap
+import kotlin.js.collections.JsSet
+import kotlin.js.collections.toList
+import kotlin.js.collections.toMap
+import kotlin.js.collections.toMutableMap
+import kotlin.js.collections.toSet
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class JsExtensionsTest {
+
+    @Test
+    fun shouldCreateEmptyJsArray() = runTest {
+        // When
+        val empty = emptyJsArray<Int>()
+
+        // Then
+        assertEquals(0, empty.size())
+        assertIs<JsArray<Int>>(empty)
+    }
+
+    @Test
+    fun shouldCreateEmptyJsMap() = runTest {
+        // When
+        val empty = emptyJsMap<Int, Int>()
+
+        // Then
+        assertEquals(0, empty.toMutableMap().size)
+        assertIs<JsMap<Int, Int>>(empty)
+    }
+
+    @Test
+    fun shouldMapListToJsArray() = runTest {
+        // Given
+        val list = listOf(1, 2, 3)
+
+        // When
+        val result = list.toJsArray()
+
+        // Then
+        assertIs<JsArray<Int>>(result)
+        assertEquals(list.size, result.size())
+        assertEquals(list, result.toList())
+    }
+
+    @Test
+    fun shouldMapSetToJsSet() = runTest {
+        // Given
+        val set = setOf(1, 2, 3)
+
+        // When
+        val result = set.toJsSet()
+
+        // Then
+        assertIs<JsSet<Int>>(result)
+        assertEquals(set.size, result.toSet().size)
+        assertEquals(set, result.toSet())
+    }
+
+    @Test
+    fun shouldMapPairToJsMap() = runTest {
+        // Given
+        val pairs = listOf(1 to "one", 2 to "two", 3 to "three")
+
+        // When
+        val result = pairs.toJsMap()
+
+        // Then
+        assertIs<JsMap<Int, String>>(result)
+        assertEquals(pairs.size, result.toMutableMap().size)
+        assertEquals(pairs, result.toMap().map { it.key to it.value }.toList())
+    }
+
+    @Test
+    fun shouldCreatePromise() = runTest {
+        // Given
+        val toReturn = "result"
+
+        // When
+        val result = promise {
+            toReturn
+        }.await()
+
+        // Then
+        assertEquals(toReturn, result)
+    }
+
+    @Test
+    fun shouldFailToProcessPromise() = runTest {
+        // Given
+        val exception = SdkException("Error")
+
+        // When
+        val result = promise {
+            exception
+        }.await()
+
+        // Then
+        assertIs<SdkException>(result)
+    }
+}

--- a/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.jvm.kt
+++ b/doordeck-sdk/src/jvmMain/kotlin/com/doordeck/multiplatform/sdk/util/Extensions.jvm.kt
@@ -78,8 +78,8 @@ internal fun String.toUuid(): UUID = UUID.fromString(this)
 internal fun String.toInstant(): Instant {
     val split = split(".")
     return Instant.ofEpochSecond(
-        split.first().toLong(),
-        split.lastOrNull()?.toLong() ?: 0
+        split[0].toLong(),
+        split.getOrNull(1)?.toLong() ?: 0
     )
 }
 

--- a/doordeck-sdk/src/jvmTest/kotlin/com/doordeck/multiplatform/sdk/util/JvmExtensionsTest.kt
+++ b/doordeck-sdk/src/jvmTest/kotlin/com/doordeck/multiplatform/sdk/util/JvmExtensionsTest.kt
@@ -1,9 +1,25 @@
 package com.doordeck.multiplatform.sdk.util
 
+import com.doordeck.multiplatform.sdk.exceptions.SdkException
+import com.doordeck.multiplatform.sdk.model.data.ApiEnvironment
+import kotlinx.coroutines.future.await
 import kotlinx.coroutines.test.runTest
+import java.net.InetAddress
+import java.net.URI
+import java.net.UnknownHostException
 import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeParseException
+import java.time.zone.ZoneRulesException
+import java.util.EnumSet
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertIs
 
 class JvmExtensionsTest {
 
@@ -17,5 +33,376 @@ class JvmExtensionsTest {
 
         // Then
         assertEquals(183840, seconds)
+    }
+
+    @Test
+    fun shouldMapStringToLocalTime12() = runTest {
+        // Given
+        val localTime = "07:34"
+
+        // When
+        val result = localTime.toLocalTime()
+
+        // Then
+        assertEquals(LocalTime.of(7, 34), result)
+    }
+
+    @Test
+    fun shouldMapStringToLocalTime24() = runTest {
+        // Given
+        val localTime = "16:34"
+
+        // When
+        val result = localTime.toLocalTime()
+
+        // Then
+        assertEquals(LocalTime.of(16, 34), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToLocalTime() = runTest {
+        // Given
+        val wrong = "localtime"
+
+        // When
+        val exception = assertFails {
+            wrong.toLocalTime()
+        }
+
+        // Then
+        assertIs<DateTimeParseException>(exception)
+    }
+
+    @Test
+    fun shouldMapLocalTimeToLocalTimeString12() = runTest {
+        // Given
+        val localTime = LocalTime.of(7, 34)
+
+        // When
+        val result = localTime.toLocalTimeString()
+
+        // Then
+        assertEquals("07:34", result)
+    }
+
+    @Test
+    fun shouldMapLocalTimeToLocalTimeString24() = runTest {
+        // Given
+        val localTime = LocalTime.of(16, 34)
+
+        // When
+        val result = localTime.toLocalTimeString()
+
+        // Then
+        assertEquals("16:34", result)
+    }
+
+    @Test
+    fun shouldMapStringToLocalDate() = runTest {
+        // Given
+        val localDate = "2023-10-27"
+
+        // When
+        val result = localDate.toLocalDate()
+
+        // Then
+        assertEquals(LocalDate.of(2023, 10, 27), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToLocalDate() = runTest {
+        // Given
+        val wrong = "localdate"
+
+        // When
+        val exception = assertFails {
+            wrong.toLocalDate()
+        }
+
+        // Then
+        assertIs<DateTimeParseException>(exception)
+    }
+
+    @Test
+    fun shouldMapLocalDateToLocalDateString() = runTest {
+        // Given
+        val localDate = LocalDate.of(2023, 10, 27)
+
+        // When
+        val result = localDate.toLocalDateString()
+
+        // Then
+        assertEquals("2023-10-27", result)
+    }
+
+    @Test
+    fun shouldMapSecondsToDuration() = runTest {
+        // Given
+        val duration = 120
+
+        // When
+        val result = duration.secondsToDuration()
+
+        // Then
+        assertEquals(Duration.ofMinutes(2), result)
+    }
+
+    @Test
+    fun shouldMapStringToUri() = runTest {
+        // Given
+        val uri = "https://google.com"
+
+        // When
+        val result = uri.toUri()
+
+        // Then
+        assertEquals(URI.create(uri), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToUri() = runTest {
+        // Given
+        val wrong = "`"
+
+        // When
+        val exception = assertFails {
+            wrong.toUri()
+        }
+
+        // Then
+        assertIs<IllegalArgumentException>(exception)
+    }
+
+    @Test
+    fun shouldMapStringToUrl() = runTest {
+        // Given
+        val url = "https://google.com"
+
+        // When
+        val result = url.toUrl()
+
+        // Then
+        assertEquals(URI.create(url).toURL(), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToUrl() = runTest {
+        // Given
+        val wrong = "wrong"
+
+        // When
+        val exception = assertFails {
+            wrong.toUrl()
+        }
+
+        // Then
+        assertIs<IllegalArgumentException>(exception)
+    }
+
+    @Test
+    fun shouldMapStringToZoneId() = runTest {
+        // Given
+        val zoneId = "UTC"
+
+        // When
+        val result = zoneId.toZoneId()
+
+        // Then
+        assertEquals(ZoneId.of("UTC"), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToZoneId() = runTest {
+        // Given
+        val wrong = "wrong"
+
+        // When
+        val exception = assertFails {
+            wrong.toZoneId()
+        }
+
+        // Then
+        assertIs<ZoneRulesException>(exception)
+    }
+
+    @Test
+    fun shouldMapStringToUuid() = runTest {
+        // Given
+        val uuid = "8abede37-298a-4c70-bbcc-19bddecc53c7"
+
+        // When
+        val result = uuid.toUuid()
+
+        // Then
+        assertEquals(UUID.fromString(uuid), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToUuid() = runTest {
+        // Given
+        val wrong = "wrong"
+
+        // When
+        val exception = assertFails {
+            wrong.toUuid()
+        }
+
+        // Then
+        assertIs<IllegalArgumentException>(exception)
+    }
+
+    @Test
+    fun shouldMapStringToInstantWithDot() = runTest {
+        // Given
+        val instantString = "1672531200.0"
+
+        // When
+        val result = instantString.toInstant()
+
+        // Then
+        assertEquals(Instant.ofEpochSecond(1672531200L, 0L), result)
+    }
+
+    @Test
+    fun shouldMapStringToInstantWithoutDot() = runTest {
+        // Given
+        val instantString = "1672531200"
+
+        // When
+        val result = instantString.toInstant()
+
+        // Then
+        assertEquals(Instant.ofEpochSecond(1672531200L, 0L), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToInstant() = runTest {
+        // Given
+        val wrong = "wrong"
+
+        // When
+        val exception = assertFails {
+            wrong.toInstant()
+        }
+
+        // Then
+        assertIs<NumberFormatException>(exception)
+    }
+
+    @Test
+    fun shouldMapIsoStringToInstant() = runTest {
+        // Given
+        val isoString = "2023-01-01T00:00:00Z"
+
+        // When
+        val result = isoString.isoToInstant()
+
+        // Then
+        assertEquals(Instant.parse(isoString), result)
+    }
+
+    @Test
+    fun shouldFailToMapIsoStringToInstant() = runTest {
+        // Given
+        val wrong = "wrong"
+
+        // When
+        val exception = assertFails {
+            wrong.isoToInstant()
+        }
+
+        // Then
+        assertIs<DateTimeParseException>(exception)
+    }
+
+    @Test
+    fun shouldMapDoubleToInstant() = runTest {
+        // Given
+        val seconds = 1672531200.0
+
+        // When
+        val instant = seconds.toInstant()
+
+        // Then
+        assertEquals(Instant.ofEpochSecond(1672531200L), instant)
+    }
+
+    @Test
+    fun shouldMapStringToInetAddress() = runTest {
+        // Given
+        val host = "127.0.0.1"
+
+        // When
+        val result = host.toInetAddress()
+
+        // Then
+        assertEquals(InetAddress.getByName("127.0.0.1"), result)
+    }
+
+    @Test
+    fun shouldFailToMapStringToInetAddress() = runTest {
+        // Given
+        val host = "host"
+
+        // When
+        val exception = assertFails {
+            host.toInetAddress()
+        }
+
+        // Then
+        assertIs<UnknownHostException>(exception)
+    }
+
+    @Test
+    fun shouldMapListToEnumSet() = runTest {
+        // Given
+        val enums = EnumSet.of(ApiEnvironment.DEV, ApiEnvironment.STAGING,
+            ApiEnvironment.PROD)
+
+        // When
+        val result = enums.toList().toEnumSet()
+
+        // Then
+        assertEquals(enums, result)
+    }
+
+    @Test
+    fun shouldMapEmptyListToEnumSet() = runTest {
+        // Given
+        val enums = EnumSet.noneOf(ApiEnvironment::class.java)
+
+        // When
+        val result = enums.toList().toEnumSet()
+
+        // Then
+        assertEquals(enums, result)
+    }
+
+    @Test
+    fun shouldCreateCompletableFuture() = runTest {
+        // Given
+        val toReturn = "result"
+
+        // When
+        val result = completableFuture {
+            toReturn
+        }.await()
+
+        // Then
+        assertEquals(toReturn, result)
+    }
+
+    @Test
+    fun shouldFailToProcessCompletableFuture() = runTest {
+        // Given
+        val exception = SdkException("Error")
+
+        // When
+        val result = completableFuture {
+            exception
+        }.await()
+
+        // Then
+        assertIs<SdkException>(result)
     }
 }

--- a/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/util/MingwExtensionsTest.kt
+++ b/doordeck-sdk/src/mingwTest/kotlin/com/doordeck/multiplatform/sdk/util/MingwExtensionsTest.kt
@@ -1,0 +1,94 @@
+package com.doordeck.multiplatform.sdk.util
+
+import com.doordeck.multiplatform.sdk.CallbackTest
+import com.doordeck.multiplatform.sdk.TestCallback
+import com.doordeck.multiplatform.sdk.callbackApiCall
+import com.doordeck.multiplatform.sdk.model.data.ResultData
+import com.doordeck.multiplatform.sdk.randomBoolean
+import com.doordeck.multiplatform.sdk.randomNullable
+import com.doordeck.multiplatform.sdk.storage.DefaultSecureStorage
+import com.doordeck.multiplatform.sdk.storage.MemorySettings
+import com.doordeck.multiplatform.sdk.unwrap
+import com.doordeck.multiplatform.sdk.unwrapFailure
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MingwExtensionsTest : CallbackTest() {
+
+    @Test
+    fun shouldMapSdkConfig() = runTest {
+        // Given
+        val apiEnvironment = "DEV"
+        val cloudAuthToken = randomNullable { "cloudAuthToken" }
+        val cloudRefreshToken = randomNullable { "cloudRefreshToken" }
+        val fusionHost = randomNullable { "fusionHost" }
+        val secureStorage = randomNullable { DefaultSecureStorage(MemorySettings()) }
+        val debugLogging = randomNullable { randomBoolean().toString() }
+
+        // When
+        val result = buildSdkConfig(
+            apiEnvironment = apiEnvironment,
+            cloudAuthToken = cloudAuthToken,
+            cloudRefreshToken = cloudRefreshToken,
+            fusionHost = fusionHost,
+            secureStorage = secureStorage,
+            debugLogging = debugLogging
+        )
+
+        // Then
+        assertEquals(apiEnvironment, result.apiEnvironment)
+        assertEquals(cloudAuthToken, result.cloudAuthToken)
+        assertEquals(cloudRefreshToken, result.cloudRefreshToken)
+        assertEquals(fusionHost, result.fusionHost)
+        assertEquals(debugLogging, result.debugLogging)
+    }
+
+    @Test
+    fun shouldHandleCallbackSuccess() {
+        // Given
+        val expectedResult = "success"
+
+        // When
+        val result = callbackApiCall<ResultData<String>> {
+            TestCallback.handleCallback {
+                expectedResult
+            }
+        }
+
+        // Then
+        assertEquals(expectedResult, result.unwrap())
+    }
+
+    @Test
+    fun shouldHandleCallbackSuccessUnit() {
+        // Given
+        val unit = Unit
+
+        val result = callbackApiCall<ResultData<Unit>> {
+            TestCallback.handleCallback {
+                unit
+            }
+        }
+
+        // Then
+        assertEquals(unit, result.unwrap())
+    }
+
+    @Test
+    fun shouldHandleCallbackFailure() {
+        // Given
+        val errorMessage = "test error"
+
+        // When
+        val result = callbackApiCall<ResultData<String>> {
+            TestCallback.handleCallback<String> {
+                throw Exception(errorMessage)
+            }
+        }
+
+        // Then
+        val failure = result.unwrapFailure()
+        assertEquals(errorMessage, failure.exceptionMessage)
+    }
+}


### PR DESCRIPTION
* Fixing `String.toInstant()` for cases when the string does not contain a dot (JVM/Android)
* Added missing extensions tests (All platforms)